### PR TITLE
README: Minor stylistic changes, add documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sdformat #
+# sdformat
 
 SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications. SDFormat is capable of representing
@@ -7,37 +7,44 @@ or dynamic objects, and articulated robots with various sensors, and acutators.
 The format of SDFormat is also described by XML, which facilitates updates and
 allows conversion from previous versions.
 
-* SDFormat - The specification.
-    * SDF - Synonym for SDFormat, though SDFormat should be preferred, as "SDF"
-      is an acronym with other meanings.
-* libsdformat - The C++ parsing code contained within this repository,
+## Terminology
+
+* **SDFormat** - The specification.
+    * **SDF** - Synonym for SDFormat, though SDFormat should be preferred, as
+      "SDF" is an acronym with other meanings.
+* `libsdformat` - The C++ parsing code contained within this repository,
   which can be used to read SDFormat files and return a C++ interface.
 
-Test coverage:
+## Test coverage
 
 [![codecov](https://codecov.io/bb/osrf/sdformat/branch/default/graph/badge.svg)](https://codecov.io/bb/osrf/sdformat)
 
-
-## Installation ##
+## Installation
 
 Standard installation can be performed in UNIX systems using the following
 steps:
 
- - mkdir build/
- - cd build/
- - cmake ..
- - sudo make install
+```sh
+mkdir build/
+cd build/
+cmake ..  # Consider specifying -DCMAKE_INSTALL_PREFIX=...
+make install
+```
 
 sdformat supported cmake parameters at configuring time:
- - USE_INTERNAL_URDF (bool) [default False]
-   Use an internal copy of urdfdom 1.0.0 instead of look for one
-   installed in the system
- - USE_UPSTREAM_CFLAGS (bool) [default True]
-   Use the sdformat team compilation flags instead of the common set defined
-   by cmake.
 
-## Uninstallation ##
+* `USE_INTERNAL_URDF (bool) [default False]` <br/>
+  Use an internal copy of urdfdom 1.0.0 instead of look for one
+  installed in the system
+* `USE_UPSTREAM_CFLAGS (bool) [default True]` <br/>
+  Use the sdformat team compilation flags instead of the common set defined
+  by cmake.
+
+## Uninstallation
 
 To uninstall the software installed with the previous steps:
- - cd build/
- - sudo make uninstall
+
+```sh
+cd build/
+make uninstall
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@ or dynamic objects, and articulated robots with various sensors, and acutators.
 The format of SDFormat is also described by XML, which facilitates updates and
 allows conversion from previous versions.
 
+## Documentation
+
+See the [SDFormat Website](http://sdformat.org/) for a more comprehensive
+description of the specification, proposals for modifications, developer
+information, etc.
+This website is published using some information from the
+[`sdf_tutorials`](https://github.com/osrf/sdf_tutorials) repository.
+
+<!--
+TODO(eric.cousineau): Move installation instructions to sdf_tutorials, and link
+there?
+TODO(eric.cousineau): Move terminology section to sdf_tutorials?
+-->
+
 ## Terminology
 
 * **SDFormat** - The specification.


### PR DESCRIPTION
* Discourages (or rather does not encourage) use of `sudo make [un]install` - it's a Bad Idea™
* Updates Markdown formatting
* Add explicit links to sdf_tutorials and sdformat.org