### PR TITLE
[master] Update BitBucket links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 build
 build_*
 *.*.sw?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set (CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 # to choose the flag -std=gnu++14 instead of -std=c++14 when the C++14
 # features are requested. Explicitly turning this flag off will force cmake to
 # choose -std=c++14.
-# See https://bitbucket.org/ignitionrobotics/ign-cmake/issues/13 for more info.
+# See https://github.com/ignitionrobotics/ign-cmake/issues/13 for more info.
 set(CMAKE_CXX_EXTENSIONS off)
 
 # Include GNUInstallDirs to get canonical paths

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,562 +5,562 @@
 ### libsdformat 10.0.0 (202X-XX-XX)
 
 1. Changed the default radius of a Cylinder from 1.0 to 0.5 meters.
-    * [Pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)
+    * [BitBucket pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)
 
 1. Initial version of SDFormat 1.8 specification.
-    * [Pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
+    * [BitBucket pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
 
 1. SDFormat 1.8: Deprecate //joint/axis/initial_position.
-    * [Pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
+    * [BitBucket pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
 
 ## libsdformat 9.X
 
 ### libsdformat 9.X.X (202X-XX-XX)
 
 1. Fix homebrew build with external urdfdom.
-    * [Pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
-    * [Pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
+    * [BitBucket pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
+    * [BitBucket pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
 
 ### libsdformat 9.2.0 (2020-04-02)
 
 1. Remove URI scheme, if present, when finding files.
-    * [Pull request 650](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/650)
-    * [Pull request 652](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/652)
+    * [BitBucket pull request 650](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/650)
+    * [BitBucket pull request 652](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/652)
 
 1. Build `Utils_TEST` with Utils.cc explicitly passed since its symbols are not visible.
-    * [Pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
+    * [BitBucket pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
 
 1. Keep the URDF style of specifying kinematics when converting URDF to SDF by using frame semantics.
-    * [Pull request 676](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/676)
+    * [BitBucket pull request 676](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/676)
 
 1. Increase output precision of URDF to SDF conversion, output -0 as 0.
-    * [Pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
+    * [BitBucket pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
 
 1. Add test of URDF frame semantics.
-    * [Pull request 680](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/680)
+    * [BitBucket pull request 680](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/680)
 
 1. Support frame semantics for models nested with <include>
-    * [Pull request 668](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/668)
+    * [BitBucket pull request 668](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/668)
 
 1. Add surface DOM
-    * [pull request 660](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/660)
+    * [BitBucket pull request 660](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/660)
 
 1. Add Transparency to visual DOM
-    * [Pull request 671](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/671)
+    * [BitBucket pull request 671](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/671)
 
 1. Add camera visibility mask and visual visibility flags
-    * [Pull request 673](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/673)
+    * [BitBucket pull request 673](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/673)
 
 1. Include overrides for actor and light
-    * [Pull request 669](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/669)
+    * [BitBucket pull request 669](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/669)
 
 1. Add functionality to generate aggregated SDFormat descriptions via CMake.
-    * [Pull request 667](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/667)
-    * [Pull request 665](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/665)
+    * [BitBucket pull request 667](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/667)
+    * [BitBucket pull request 665](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/665)
 
 1. parser addNestedModel: check `//axis/xyz/@expressed_in` before rotating joint axis.
-    * [Pull request 657](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/657)
+    * [BitBucket pull request 657](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/657)
     * [Issue 219](https://github.com/osrf/sdformat/issues/219)
 
 1. Remove TinyXML symbols from public API: Deprecate URDF2SDF
-    * [Pull request 658](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/658)
+    * [BitBucket pull request 658](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/658)
 
 1. Remove TinyXML symbols from public API: Move uninstalled headers
-    * [Pull request 662](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/662)
+    * [BitBucket pull request 662](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/662)
 
 1. Install the Windows `.dll` shared libraries to bin folder.
-    * [Pull request 659](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/659)
-    * [Pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
+    * [BitBucket pull request 659](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/659)
+    * [BitBucket pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
 
 1. Fix cmake type for `tinyxml_INCLUDE_DIRS`.
-    * [Pull request 661](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/661)
-    * [Pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
+    * [BitBucket pull request 661](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/661)
+    * [BitBucket pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
 
 1. Rename SDF to SDFormat / libsdformat on documentation
-    * [Pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
+    * [BitBucket pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
 
 ### libsdformat 9.1.0 (2020-01-29)
 
 1. Remove URI scheme, if present, when finding files.
-    * [Pull request 653](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/653)
+    * [BitBucket pull request 653](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/653)
 
 1. Fix parsing of pose elements under `<include>`
-    * [Pull request 649](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/649)
+    * [BitBucket pull request 649](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/649)
 
 1. Parser: add readFileWithoutConversion and readStringWithoutConversion.
-    * [Pull request 647](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/647)
+    * [BitBucket pull request 647](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/647)
 
 1. Added accessors to `ignition::math::[Boxd, Cylinderd, Planed, Sphered]`
    in the matching `sdf::[Box, Cylinder, Plane, Sphere]` classes.
-    * [Pull request 639](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/639)
+    * [BitBucket pull request 639](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/639)
 
 1. Forward port of adjustments for memory leaks:
-   [Pull Request 641](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/641) and
-   [Pull Request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
-    * [Pull Request 645](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/645)
+    * [BitBucket pull request 641](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/641) and
+    * [BitBucket pull request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
+    * [BitBucket pull request 645](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/645)
 
 1. SDFormat 1.7: remove `//world/joint` element since it has never been used.
-    * [Pull request 637](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/637)
+    * [BitBucket pull request 637](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/637)
 
 1. Add clipping for depth camera on rgbd camera sensor
-    * [Pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
+    * [BitBucket pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
 
 1. Add tests to confirm that world is not allowed as child link of a joint.
-    * [Pull request 634](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/634)
+    * [BitBucket pull request 634](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/634)
 
 1. Fix link pose multiplication for URDF.
-    * [Pull request 630](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/630)
+    * [BitBucket pull request 630](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/630)
 
 1. Enable linter for URDF parser and fix style.
-    * [Pull request 631](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/631)
+    * [BitBucket pull request 631](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/631)
 
 1. Converter: fix memory leak pointed out by ASan.
-    * [Pull request 638](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/638)
+    * [BitBucket pull request 638](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/638)
 
 1. Access the original parsed version of an SDF document with `Element::OriginalVersion`.
-    * [Pull request 640](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/640)
+    * [BitBucket pull request 640](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/640)
 
 1. Model::Load: fail fast if an SDFormat 1.7 file has name collisions.
-    * [Pull request 648](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/648)
+    * [BitBucket pull request 648](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/648)
 
 1. Keep DOM objects even if they were loaded with errors.
-    * [Pull request 655](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/655)
+    * [BitBucket pull request 655](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/655)
 
 ### libsdformat 9.0.0 (2019-12-10)
 
 1. Move recursiveSameTypeUniqueNames from ign.cc to parser.cc and make public.
-    * [Pull request 606](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/606)
+    * [BitBucket pull request 606](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/606)
 
 1. Check that joints have valid parent and child names in `ign sdf --check`.
-    * [Pull request 609](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/609)
+    * [BitBucket pull request 609](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/609)
 
 1. Model DOM: error when trying to load nested models, which aren't yet supported.
-    * [Pull request 610](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/610)
+    * [BitBucket pull request 610](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/610)
 
 1. Use consistent namespaces in Filesystem.
-    * [Pull request 567](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/567)
+    * [BitBucket pull request 567](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/567)
 
 1. Enforce rules about reserved names and unique names among sibling elements.
-    * [Pull request 600](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/600)
+    * [BitBucket pull request 600](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/600)
 
 1. Relax name checking, so name collisions generate warnings and names are automatically changed.
-    * [Pull request 621](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/621)
+    * [BitBucket pull request 621](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/621)
 
 1. Unversioned library name for ign tool commands.
-    * [Pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
+    * [BitBucket pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
 
 1. Initial version of SDFormat 1.7 specification.
-    * [Pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
+    * [BitBucket pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
 
 1. Converter: add `<map>` element for converting fixed values.
-    * [Pull request 580](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/580)
+    * [BitBucket pull request 580](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/580)
 
 1. Converter: add `descendant_name` attribute to recursively search for elements to convert.
-    * [Pull request 596](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/596)
+    * [BitBucket pull request 596](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/596)
 
 1. SDFormat 1.7: replace `use_parent_model_frame` element with `//axis/xyz/@expressed_in` attribute.
-    * [Pull request 589](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/589)
+    * [BitBucket pull request 589](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/589)
 
 1. SDFormat 1.7: replace `//pose/@frame` attribute with `//pose/@relative_to` attribute.
-    * [Pull request 597](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/597)
+    * [BitBucket pull request 597](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/597)
 
 1. SDFormat 1.7: add `//model/@canonical_link` attribute and require models to have at least one link.
-    * [Pull request 601](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/601)
+    * [BitBucket pull request 601](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/601)
 
 1. Static models: allow them to have no links and skip building FrameAttachedToGraph.
-    * [Pull request 626](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/626)
+    * [BitBucket pull request 626](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/626)
 
 1. SDFormat 1.7: add `//frame/attached_to`, only allow frames in model and world, add Frame DOM.
-    * [pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
+    * [BitBucket pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
 
 1. FrameSemantics API: add FrameAttachedToGraph and functions for building graph and resolving attached-to body.
-    * [Pull request 613](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/613)
+    * [BitBucket pull request 613](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/613)
 
 1. FrameSemantics API: add PoseRelativeToGraph and functions for building graph and resolving poses.
-    * [Pull request 614](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/614)
+    * [BitBucket pull request 614](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/614)
 
 1. Build and validate graphs during Model::Load and World::Load.
-    * [Pull request 615](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/615)
+    * [BitBucket pull request 615](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/615)
 
 1. Add SemanticPose class with implementation for Link.
-    * [Pull request 616](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/616)
+    * [BitBucket pull request 616](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/616)
 
 1. Add JointAxis::ResolveXyz and Joint::SemanticPose.
-    * [Pull request 617](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/617)
+    * [BitBucket pull request 617](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/617)
 
 1. Implement SemanticPose() for Collision, Frame, Light, Model, Sensor, Visual.
-    * [Pull request 618](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/618)
+    * [BitBucket pull request 618](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/618)
 
 1. Add Frame::ResolveAttachedToBody API for resolving the attached-to body of a frame.
-    * [Pull request 619](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/619)
+    * [BitBucket pull request 619](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/619)
 
 1. DOM API: deprecate `(Set)?PoseFrame` API and replace with `(Set)?PoseRelativeTo`
-    * [Pull request 598](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/598)
+    * [BitBucket pull request 598](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/598)
 
 1. DOM API: deprecate `(Set)?Pose` API and replace with `(Set)?RawPose`
-    * [Pull request 599](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/599)
+    * [BitBucket pull request 599](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/599)
 
 1. Hide FrameSemantics implementation.
-    * [Pull request 622](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/622)
-    * [Pull request 623](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/623)
+    * [BitBucket pull request 622](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/622)
+    * [BitBucket pull request 623](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/623)
 
 ## libsdformat 8.0
 
 ### libsdformat 8.X.X (202X-XX-XX)
 
 1. Increase output precision of URDF to SDF conversion, output -0 as 0.
-    * [Pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
+    * [BitBucket pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
 
 1. Fix homebrew build with external urdfdom.
-    * [Pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
-    * [Pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
+    * [BitBucket pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
+    * [BitBucket pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
 
 ### libsdformat 8.8.0 (2020-03-18)
 
 1. Add Transparency to visual DOM
-    * [Pull request 671](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/671)
+    * [BitBucket pull request 671](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/671)
 
 1. Install the Windows `.dll` shared libraries to bin folder.
-    * [Pull request 659](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/659)
-    * [Pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
+    * [BitBucket pull request 659](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/659)
+    * [BitBucket pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
 
 1. Fix cmake type for `tinyxml_INCLUDE_DIRS`.
-    * [Pull request 661](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/661)
-    * [Pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
+    * [BitBucket pull request 661](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/661)
+    * [BitBucket pull request 663](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/663)
 
 1. Add functionality to generate aggregated SDFormat descriptions via CMake.
-    * [Pull request 665](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/665)
+    * [BitBucket pull request 665](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/665)
 
 1. Remove URI scheme, if present, when finding files.
-    * [Pull request 650](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/650)
-    * [Pull request 652](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/652)
+    * [BitBucket pull request 650](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/650)
+    * [BitBucket pull request 652](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/652)
 
 1. Rename SDF to SDFormat / libsdformat on documentation
-    * [Pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
+    * [BitBucket pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
 
 ### libsdformat 8.7.1 (2020-01-13)
 
 1. Fix memory leaks in move assignment operator.
-    * [Pull request 641](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/641)
+    * [BitBucket pull request 641](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/641)
 
 1. Refactoring based on rule-of-five guidance to address memory leaks
-   * [Pull request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
+    * [BitBucket pull request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
 
 ### libsdformat 8.7.0 (2019-12-13)
 
 1. Remove some URDF error messages
-    * [Pull request 605](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/605)
+    * [BitBucket pull request 605](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/605)
 
 1. Fix parsing URDF without <material> inside <gazebo>
-    * [Pull request 608](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/608)
+    * [BitBucket pull request 608](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/608)
 
 1. Backport URDF multiplication and linter
-    * [Pull request 632](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/632)
+    * [BitBucket pull request 632](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/632)
 
 1. Add clipping for depth camera on rgbd camera sensor
-    * [Pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
+    * [BitBucket pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
 
 ### libsdformat 8.6.1 (2019-12-05)
 
 1. Unversioned lib name for cmds
-    * [Pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
+    * [BitBucket pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
 
 ### libsdformat 8.6.0 (2019-11-20)
 
 1. configure.bat: use ign-math6, not gz11
-    * [Pull request 595](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/595)
+    * [BitBucket pull request 595](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/595)
 
 1. Set `sdformat8_PKGCONFIG_*` variables in cmake config instead of `SDFormat_PKGCONFIG*`.
-    * [Pull request 594](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/594)
+    * [BitBucket pull request 594](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/594)
 
 1. Relax cmake check to allow compiling with gcc-7.
-    * [Pull request 592](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/592)
+    * [BitBucket pull request 592](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/592)
 
 1. Use custom callbacks when reading file (support Fuel URIs).
-    * [Pull request 591](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/591)
+    * [BitBucket pull request 591](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/591)
 
 1. Update visual DOM to parse `cast_shadows` property of a visual.
-    * [Pull request 590](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/590)
+    * [BitBucket pull request 590](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/590)
 
 1. Build `Utils_TEST` with Utils.cc explicitly passed since its symbols are not visible.
-    * [Pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
+    * [BitBucket pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
 
 ### libsdformat 8.5.0 (2019-11-06)
 
 1. Add `thermal_camera` sensor type
-    * [Pull request 586](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/586)
+    * [BitBucket pull request 586](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/586)
 
 1. Use inline namespaces in Utils.cc
-    * [Pull request 574](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/574)
+    * [BitBucket pull request 574](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/574)
 
 1. Convert `ign sdf` file inputs to absolute paths before processing them
-    * [Pull request 583](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/583)
+    * [BitBucket pull request 583](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/583)
 
 1. Add `emissive_map` to material sdf
-    * [Pull request 585](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/585)
+    * [BitBucket pull request 585](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/585)
 
 1. Converter: fix bug when converting across multiple versions.
-    * [Pull request 584](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/584)
-    * [Pull request 573](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/573)
+    * [BitBucket pull request 584](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/584)
+    * [BitBucket pull request 573](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/573)
 
 ### libsdformat 8.4.0 (2019-10-22)
 
 1. Accept relative path in `<uri>`.
-    * [Pull request 558](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/558)
+    * [BitBucket pull request 558](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/558)
 
 1. Element: don't print unset attributes.
-    * [Pull request 571](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/571)
-    * [Pull request 576](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/576)
+    * [BitBucket pull request 571](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/571)
+    * [BitBucket pull request 576](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/576)
 
 1. Lidar.hh: remove 'using namespace ignition'.
-    * [Pull request 577](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/577)
+    * [BitBucket pull request 577](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/577)
 
-1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
-    * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
+1. Parse urdf files to sdf 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
+    * [BitBucket pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
-    * [Pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
+    * [BitBucket pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
 
 1. SDF Root DOM: add ActorCount, ActorByIndex, and ActorNameExists.
-    * [Pull request 566](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/566)
+    * [BitBucket pull request 566](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/566)
 
 1. Avoid hardcoding /machine:x64 flag on 64-bit on MSVC with CMake >= 3.5.
-    * [Pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
+    * [BitBucket pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
 
 1. Move private headers from include/sdf to src folder.
-    * [Pull request 553](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/553)
+    * [BitBucket pull request 553](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/553)
 
 1. Fix ign library path on macOS.
-    * [Pull request 542](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/542)
-    * [Pull request 564](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/564)
+    * [BitBucket pull request 542](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/542)
+    * [BitBucket pull request 564](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/564)
 
 1. Use `ign sdf --check` to check sibling elements of the same type for non-unique names.
-    * [Pull request 554](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/554)
+    * [BitBucket pull request 554](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/554)
 
 1. Converter: remove all matching elements specified by `<remove>` tag.
-    * [Pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
+    * [BitBucket pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
 
 ### libsdformat 8.3.0 (2019-08-17)
 
 1. Added Actor DOM
-    * [Pull request 547](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/547)
+    * [BitBucket pull request 547](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/547)
 
 1. Print cmake build warnings and errors to std_err
-    * [Pull request 549](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/549)
+    * [BitBucket pull request 549](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/549)
 
 ### libsdformat 8.2.0 (2019-06-18)
 
 1. Added RGBD Camera Sensor type.
-    * [Pull request 540](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/540)
+    * [BitBucket pull request 540](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/540)
 
 ### libsdformat 8.1.0 (2019-05-20)
 
 1.  Change installation path of SDF description files to allow side-by-side installation.
-    * [pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
+    * [BitBucket pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
 
 1. Added Lidar Sensor DOM. Also added `lidar` and `gpu_lidar` as sensor
    types. These two types are equivalent to `ray` and `gpu_ray`.
-    * [Pull request 536](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/536)
+    * [BitBucket pull request 536](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/536)
 
 1. SDF Sensor DOM: copy update rate in copy constructor.
-    * [Pull request 534](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/534)
+    * [BitBucket pull request 534](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/534)
 
 1. Added IMU Sensor DOM.
-    * [Pull request 532](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/532)
+    * [BitBucket pull request 532](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/532)
 
 1. Added Camera Sensor DOM.
-    * [Pull request 531](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/531)
+    * [BitBucket pull request 531](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/531)
 
 1. Added wind to link dom.
-    * [Pull request 530](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/530)
+    * [BitBucket pull request 530](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/530)
 
 1. Added Sensor DOM `==` operator.
-    * [Pull request 529](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/529)
+    * [BitBucket pull request 529](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/529)
 
 1. Added AirPressure SDF DOM
-    * [Pull request 528](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/528)
+    * [BitBucket pull request 528](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/528)
 
 1. Update SDFormat noise elements
-    * [Pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
-    * [Pull request 522](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/522)
+    * [BitBucket pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
+    * [BitBucket pull request 522](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/522)
 
 1. Apply rule of five for various DOM classes
-    * [Pull request 524](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/524)
+    * [BitBucket pull request 524](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/524)
 
 1. Support setting sensor types from a string.
-    * [Pull request 523](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/523)
+    * [BitBucket pull request 523](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/523)
 
 1. Added Altimeter SDF DOM
-    * [Pull request 527](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/527)
+    * [BitBucket pull request 527](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/527)
 
 1. Added Magnetometer SDF DOM
-    * [Pull request 518](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/518)
-    * [Pull request 519](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/519)
+    * [BitBucket pull request 518](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/518)
+    * [BitBucket pull request 519](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/519)
 
 1. Add Scene SDF DOM
-    * [Pull request 517](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/517)
+    * [BitBucket pull request 517](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/517)
 
 1. Add PBR material SDF element
-    * [Pull request 512](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/512)
-    * [Pull request 520](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/520)
-    * [Pull request 535](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/535)
+    * [BitBucket pull request 512](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/512)
+    * [BitBucket pull request 520](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/520)
+    * [BitBucket pull request 535](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/535)
 
 1. Set geometry shapes
-    * [Pull request 515](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/515)
+    * [BitBucket pull request 515](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/515)
 
 1. Clarify names of libsdformat parser and SDF specification in Readme.
-    * [Pull request 514](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/514)
+    * [BitBucket pull request 514](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/514)
 
 1. Disable macOS tests failing due to issue 202.
-    * [Pull request 511](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/511)
+    * [BitBucket pull request 511](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/511)
     * [Issue 202](https://github.com/osrf/sdformat/issues/202)
 
 ### libsdformat 8.0.0 (2019-03-01)
 
 1. Rename depth camera from 'depth' to 'depth_camera'
-    * [Pull request 507](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/507)
+    * [BitBucket pull request 507](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/507)
 
 1. Rename enum Ray to Lidar
-    * [Pull request 502](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/502)
+    * [BitBucket pull request 502](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/502)
 
 1. Add support for files that have light tags in the root
-    * [Pull request 499](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/499)
+    * [BitBucket pull request 499](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/499)
 
 1. Fix locale problems of std::stringstream and of Param::ValueFromString
-    * [Pull request 492](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/492)
+    * [BitBucket pull request 492](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/492)
     * Contribution by Silvio Traversaro
 
 1. Add functions to set visual dom's geometry and material
-    * [Pull request 490](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/490)
+    * [BitBucket pull request 490](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/490)
 
 1. Change cmake project name to sdformat8, export cmake targets
-    * [Pull request 475](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/475)
-    * [Pull request 476](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/476)
+    * [BitBucket pull request 475](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/475)
+    * [BitBucket pull request 476](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/476)
 
 1. SDF DOM: Add copy constructor and assignment operator to Light. Add lights to Link
-    * [Pull request 469](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/469)
+    * [BitBucket pull request 469](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/469)
 
 1. Make `<limit>` a required element for `<axis2>`
-    * [Pull request #472](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/472)
+    * [BitBucket pull request #472](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/472)
 
 1. SDF DOM: Add DOM methods for setting axis and thread pitch in `sdf::Joint`
-    * [Pull request #471](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/471)
-    * [Pull request #474](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/474)
+    * [BitBucket pull request #471](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/471)
+    * [BitBucket pull request #474](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/474)
 
 1. SDF DOM: Add copy constructors and assignment operator to JointAxis
-    * [Pull request #470](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/470)
+    * [BitBucket pull request #470](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/470)
 
 1. Removed boost
-    * [Pull request #438](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/438)
+    * [BitBucket pull request #438](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/438)
 
 1. Versioned namespace
-    * [Pull request 464](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/464)
+    * [BitBucket pull request 464](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/464)
 
 1. Versioned library install
-    * [Pull request 463](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/463)
+    * [BitBucket pull request 463](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/463)
 
 1. Add SetGeom to Collision
-    * [Pull request 465](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/465)
+    * [BitBucket pull request 465](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/465)
 
 1. SDF DOM: Add copy/move constructors and assignment operator to Geometry
-    * [Pull request 460](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/460)
+    * [BitBucket pull request 460](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/460)
 
 1. SDF DOM: Add copy/move constructors and assignment operator to Material
-    * [Pull request 461](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/461)
+    * [BitBucket pull request 461](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/461)
 
 1. Add collision_detector to dart physics config
-    * [Pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
+    * [BitBucket pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
 
 1. Fix cpack now that project name has version number
-    * [Pull request 478](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/478)
+    * [BitBucket pull request 478](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/478)
 
 1. Animation tension
-    * [Pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
+    * [BitBucket pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
 
 1. Add "geometry" for sonar collision shape
-    * [Pull request 479](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/479)
+    * [BitBucket pull request 479](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/479)
 
 1. Fix Gui copy constructor
-    * [Pull request 486](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/486)
+    * [BitBucket pull request 486](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/486)
 
 1. Sensor DOM
-    * [Pull request 488](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/488)
-    * [Pull request 481](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/481)
+    * [BitBucket pull request 488](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/488)
+    * [BitBucket pull request 481](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/481)
 
 ## libsdformat 7.0
 
 ### libsdformat 7.0.0 (xxxx-xx-xx)
 
 1. Build Utils_TEST with Utils.cc explicitly passed since its symbols are not visible.
-    * [Pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
+    * [BitBucket pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
 
 1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
-    * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
+    * [BitBucket pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
-    * [Pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
+    * [BitBucket pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
 
 1. Avoid hardcoding /machine:x64 flag on 64-bit on MSVC with CMake >= 3.5.
-    * [Pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
+    * [BitBucket pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
 
 1. Prevent duplicate `use_parent_model_frame` tags during file conversion.
-    * [Pull request 573](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/573)
+    * [BitBucket pull request 573](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/573)
 
 1. Backport inline versioned namespace from version 8.
-    * [Pull request 557](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/557)
-    * [pull request 464](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/464)
+    * [BitBucket pull request 557](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/557)
+    * [BitBucket pull request 464](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/464)
 
 1. Backport cmake and SDFormat spec changes from version 8.
-    * [Pull request 550](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/550)
-    * [pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
-    * [Pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
-    * [Pull request 475](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/475)
-    * [Pull request 476](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/476)
-    * [Pull request 463](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/463)
+    * [BitBucket pull request 550](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/550)
+    * [BitBucket pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
+    * [BitBucket pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
+    * [BitBucket pull request 475](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/475)
+    * [BitBucket pull request 476](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/476)
+    * [BitBucket pull request 463](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/463)
 
 1. Fix ign library path on macOS.
-    * [Pull request 542](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/542)
+    * [BitBucket pull request 542](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/542)
 
 1. Preserve XML elements that are not part of the SDF specification.
-    * [Pull request 449](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/449)
+    * [BitBucket pull request 449](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/449)
 
 1. Embed SDF specification files directly in libsdformat.so.
-    * [Pull request 434](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/434)
+    * [BitBucket pull request 434](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/434)
 
 1. Removed support for SDF spec versions 1.0 and 1.2
-    * [Pull request #432](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/432)
+    * [BitBucket pull request #432](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/432)
 
 1. SDF DOM: Additions to the document object model.
-    * [Pull request 433](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/433)
-    * [Pull request 441](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/441)
-    * [Pull request 442](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/442)
-    * [Pull request 445](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/445)
-    * [Pull request 451](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/451)
-    * [Pull request 455](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/455)
-    * [Pull request 481](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/481)
+    * [BitBucket pull request 433](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/433)
+    * [BitBucket pull request 441](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/441)
+    * [BitBucket pull request 442](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/442)
+    * [BitBucket pull request 445](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/445)
+    * [BitBucket pull request 451](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/451)
+    * [BitBucket pull request 455](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/455)
+    * [BitBucket pull request 481](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/481)
 
 1. SDF DOM: Add Element() accessor to Gui, JointAxis and World classes.
-    * [Pull request 450](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/450)
+    * [BitBucket pull request 450](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/450)
 
 1. Adds the equalivent of gz sdf -d to libsdformat. The command line option
    will print the full description of the SDF spec.
-    * [Pull request 424](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/424)
+    * [BitBucket pull request 424](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/424)
 
 1. Adds the equalivent of gz sdf -p to libsdformat. The command line option
    will convert and print the specified SDFormat file.
-    * [Pull request 494](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/494)
+    * [BitBucket pull request 494](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/494)
 
 1. SDF DOM: Additions to the document object model.
-    * [Pull request 393](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/393)
-    * [Pull request 394](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/394)
-    * [Pull request 395](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/395)
-    * [Pull request 396](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/396)
-    * [Pull request 397](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/397)
-    * [Pull request 406](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/406)
-    * [Pull request 407](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/407)
-    * [Pull request 410](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/410)
-    * [Pull request 415](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/415)
-    * [Pull request 420](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/420)
+    * [BitBucket pull request 393](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/393)
+    * [BitBucket pull request 394](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/394)
+    * [BitBucket pull request 395](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/395)
+    * [BitBucket pull request 396](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/396)
+    * [BitBucket pull request 397](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/397)
+    * [BitBucket pull request 406](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/406)
+    * [BitBucket pull request 407](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/407)
+    * [BitBucket pull request 410](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/410)
+    * [BitBucket pull request 415](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/415)
+    * [BitBucket pull request 420](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/420)
 
 
 ## libsdformat 6.0
@@ -568,85 +568,85 @@
 ### libsdformat 6.X.X (20XX-XX-XX)
 
 1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
-    * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
+    * [BitBucket pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
-    * [Pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
+    * [BitBucket pull request 504](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/504)
 
 1. Avoid hardcoding /machine:x64 flag on 64-bit on MSVC with CMake >= 3.5.
-    * [Pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
+    * [BitBucket pull request 565](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/565)
 
 1. Fix ign library path on macOS.
-    * [Pull request 552](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/552)
+    * [BitBucket pull request 552](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/552)
 
 1. Use `ign sdf --check` to check sibling elements of the same type for non-unique names.
-    * [Pull request 554](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/554)
+    * [BitBucket pull request 554](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/554)
 
 1. Converter: remove all matching elements specified by `<remove>` tag.
-    * [Pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
+    * [BitBucket pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
 
 ### libsdformat 6.2.0 (2019-01-17)
 
 1. Add geometry for sonar collision shape
-    * [Pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
+    * [BitBucket pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
 
 1. Add camera intrinsics (fx, fy, cx, cy, s)
-    * [Pull request 496](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/496)
+    * [BitBucket pull request 496](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/496)
 
 1. Add actor trajectory tension parameter
-    * [Pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
+    * [BitBucket pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
 
 
 ### libsdformat 6.1.0 (2018-10-04)
 
 1. Add collision\_detector to dart physics config
-    * [Pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
+    * [BitBucket pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
 
 1. Fix Windows support for libsdformat6
-    * [Pull request 401](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/401)
+    * [BitBucket pull request 401](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/401)
 
 1. root.sdf: default SDFormat version 1.6
-    * [Pull request 425](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/425)
+    * [BitBucket pull request 425](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/425)
 
 1. parser\_urdf: print value of highstop instead of pointer address
-    * [Pull request 408](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/408)
+    * [BitBucket pull request 408](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/408)
 
 1. Tweak error output so jenkins doesn't think it's a compiler warning
-    * [Pull request 402](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/402)
+    * [BitBucket pull request 402](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/402)
 
 
 ### libsdformat 6.0.0 (2018-01-25)
 
 1. SDF DOM: Added a document object model.
-    * [Pull request 387](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/387)
-    * [Pull request 389](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/389)
+    * [BitBucket pull request 387](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/387)
+    * [BitBucket pull request 389](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/389)
 
 1. Add simplified ``readFile`` function.
-    * [Pull request 347](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/347)
+    * [BitBucket pull request 347](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/347)
 
 1. Remove boost::lexical cast instances
-    * [Pull request 342](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/342)
+    * [BitBucket pull request 342](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/342)
 
 1. Remove boost regex and iostreams as dependencies
-    * [Pull request 302](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/302)
+    * [BitBucket pull request 302](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/302)
 
 1. Change certain error checks from asserts to throwing
    sdf::AssertionInternalError, which is more appropriate for a library.
-    * [Pull request 315](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/315)
+    * [BitBucket pull request 315](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/315)
 
 1. Updated the internal copy of urdfdom to 1.0, removing more of boost.
-    * [Pull request 324](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/324)
+    * [BitBucket pull request 324](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/324)
 
 1. urdfdom 1.0 is now required on all platforms.
-    * [Pull request 324](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/324)
+    * [BitBucket pull request 324](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/324)
 
 1. Remove boost filesystem as a dependency
-    * [Pull request 335](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/335)
-    * [Pull request 338](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/338)
-    * [Pull request 339](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/339)
+    * [BitBucket pull request 335](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/335)
+    * [BitBucket pull request 338](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/338)
+    * [BitBucket pull request 339](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/339)
 
 1. Deprecated sdf::Color, and switch to use ignition::math::Color
-    * [Pull request 330](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/330)
+    * [BitBucket pull request 330](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/330)
 
 ## libsdformat 5.x
 
@@ -655,83 +655,83 @@
 ### libsdformat 5.3.0 (2017-11-13)
 
 1. Added wrapper around root SDF for an SDF element
-    * [Pull request 378](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/378)
-    * [Pull request 372](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/372)
+    * [BitBucket pull request 378](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/378)
+    * [BitBucket pull request 372](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/372)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
-    * [Pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/380)
+    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. surface.sdf: expand documentation of friction and slip coefficients
-    * [Pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/343)
+    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/343)
 
 1. Add preserveFixedJoint option to the URDF parser
-    * [Pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/352)
+    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/352)
 
 1. Add light as child of link
-    * [Pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
+    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
 ### libsdformat 5.2.0 (2017-08-03)
 
 1. Added a block for DART-specific physics properties.
-    * [Pull request 369](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/369)
+    * [BitBucket pull request 369](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/369)
 
 1. Fix parser to read plugin child elements within an `<include>`
-    * [Pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
+    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/350)
 
 1. Choosing models with more recent SDFormat version with `<include>` tag
-    * [Pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
+    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
 1. Added `<category_bitmask>` to 1.6 surface contact parameters
-    * [Pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/318)
+    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/318)
 
 1. Support light insertion in state
-    * [Pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. Case insensitive boolean strings
-    * [Pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/322)
+    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/322)
 
 1. Enable coverage testing
-    * [Pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/317)
+    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/317)
 
 1. Add `friction_model` parameter to ode solver
-    * [Pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
-    * [Gazebo pull request 1522](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/gazebo/pull-request/1522)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
+    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/1522)
 
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
-    * [Pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
+    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/292)
 
 ### libsdformat 5.1.0 (2017-02-22)
 
 1. Fixed `sdf::convertFile` and `sdf::convertString` always converting to latest version
-    * [Pull request 320](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/320)
+    * [BitBucket pull request 320](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/320)
 1. Added back the ability to set SDFormat version at runtime
-    * [Pull request 307](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/307)
+    * [BitBucket pull request 307](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/307)
 
 ### libsdformat 5.0.0 (2017-01-25)
 
 1. Removed libsdformat 4 deprecations
-    * [Pull request 295](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/295)
+    * [BitBucket pull request 295](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/295)
 
 1. Added an example
-    * [Pull request 275](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/275)
+    * [BitBucket pull request 275](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/275)
 
 1. Move functions that use TinyXML classes in private headers
    A contribution from Silvio Traversaro
-    * [Pull request 262](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/262)
+    * [BitBucket pull request 262](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/262)
 
 1. Fix issues found by the Coverity tool
    A contribution from Olivier Crave
-    * [Pull request 259](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/259)
+    * [BitBucket pull request 259](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/259)
 
 1. Add tag to allow for specification of initial joint position
-    * [Pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/279)
+    * [BitBucket pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/279)
 
 1. Require ignition-math3 as dependency
-    * [Pull request 299](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/299)
+    * [BitBucket pull request 299](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/299)
 
 1. Simplifier way of retrieving a value from SDF using Get
-    * [Pull request 285](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/285)
+    * [BitBucket pull request 285](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/285)
 
 ## libsdformat 4.0
 
@@ -740,337 +740,337 @@
 ### libsdformat 4.4.0 (2017-10-26)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
-    * [Pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/380)
+    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. surface.sdf: expand documentation of friction and slip coefficients
-    * [Pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/343)
+    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/343)
 
 1. Add preserveFixedJoint option to the URDF parser
-    * [Pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/352)
+    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/352)
 
 1. Add light as child of link
-    * [Pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
+    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
 ### libsdformat 4.3.2 (2017-07-19)
 
 1. Add documentation for `Element::GetFirstElement()` and `Element::GetNextElement()`
-    * [Pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/341)
+    * [BitBucket pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/341)
 
 1. Fix parser to read plugin child elements within an `<include>`
-    * [Pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
+    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/350)
 
 ### libsdformat 4.3.1 (2017-03-24)
 
 1. Fix segmentation Fault in `sdf::getBestSupportedModelVersion`
-    * [Pull request 327](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/327)
+    * [BitBucket pull request 327](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/327)
     * [Issue 152](https://github.com/osrf/sdformat/issues/152)
 
 ### libsdformat 4.3.0 (2017-03-20)
 
 1. Choosing models with more recent SDFormat version with `<include>` tag
-    * [Pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
+    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
 1. Added `<category_bitmask>` to 1.6 surface contact parameters
-    * [Pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/318)
+    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/318)
 
 1. Support light insertion in state
-    * [Pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. Case insensitive boolean strings
-    * [Pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/322)
+    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/322)
 
 1. Enable coverage testing
-    * [Pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/317)
+    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/317)
 
 1. Add `friction_model` parameter to ode solver
-    * [Pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
-    * [Gazebo pull request 1522](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/gazebo/pull-request/1522)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
+    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/1522)
 
 1. Added `sampling` parameter to `<heightmap>` SDF element.
-    * [Pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/293)
+    * [BitBucket pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/293)
 
 1. Added Migration guide
-    * [Pull request 290](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/290)
+    * [BitBucket pull request 290](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/290)
 
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
-    * [Pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
+    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/292)
 
 ### libsdformat 4.2.0 (2016-10-10)
 
 1. Added tag to specify ODE friction model.
-    * [Pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
 
 1. Fix URDF to SDF `self_collide` bug.
-    * [Pull request 287](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/287)
+    * [BitBucket pull request 287](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/287)
 
 1. Added IMU orientation specification to SDF.
-    * [Pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/284)
+    * [BitBucket pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/284)
 
 ### libsdformat 4.1.1 (2016-07-08)
 
 1. Added documentation and animation to `<actor>` element.
-    * [Pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/280)
+    * [BitBucket pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/280)
 
 1. Added tag to specify initial joint position
-    * [Pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/279)
+    * [BitBucket pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/279)
 
 ### libsdformat 4.1.0 (2016-04-01)
 
 1. Added SDF conversion functions to parser including sdf::convertFile and sdf::convertString.
-    * [Pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/266)
+    * [BitBucket pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/266)
 
 1. Added an upload script
-    * [Pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/256)
+    * [BitBucket pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/256)
 
 ### libsdformat 4.0.0 (2015-01-12)
 
 1. Boost pointers and boost::function in the public API have been replaced
    by their std::equivalents (C++11 standard)
 1. Move gravity and magnetic_field tags from physics to world
-    * [Pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/247)
+    * [BitBucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/247)
 1. Switch lump link prefix from lump:: to lump_
-    * [Pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/245)
+    * [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
 1. New <wind> element.
    A contribution from Olivier Crave
-    * [Pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/240)
+    * [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 1. Add scale to model state
-    * [Pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/246)
+    * [BitBucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/246)
 1. Use stof functions to parse hex strings as floating point params.
    A contribution from Rich Mattes
-    * [Pull request 250](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/250)
+    * [BitBucket pull request 250](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/250)
 1. Fix memory leaks.
    A contribution from Silvio Traversaro
-    * [Pull request 249](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/249)
+    * [BitBucket pull request 249](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/249)
 1. Update SDF to version 1.6: new style for representing the noise properties
    of an `imu`
-    * [Pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/243)
-    * [Pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
+    * [BitBucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
+    * [BitBucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
 
 ## libsdformat 3.0
 
 ### libsdformat 3.X.X (201X-XX-XX)
 
 1. Improve precision of floating point parameters
-     * [Pull request 273](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/273)
-     * [Pull request 276](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/276)
+    * [BitBucket pull request 273](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/273)
+    * [BitBucket pull request 276](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/276)
 
 ### libsdformat 3.7.0 (2015-11-20)
 
 1. Add spring pass through for sdf3
-     * [Design document](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/gazebo_design/pull-requests/23)
-     * [Pull request 242](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/242)
+    * [Design document](https://osrf-migration.github.io/osrf-others-gh-pages/#!/osrf/gazebo_design/pull-requests/23)
+    * [BitBucket pull request 242](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/242)
 
 1. Support frame specification in SDF
-     * [Pull request 237](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/237)
+    * [BitBucket pull request 237](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/237)
 
 1. Remove boost from SDFExtension
-     * [Pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/229)
+    * [BitBucket pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/229)
 
 ### libsdformat 3.6.0 (2015-10-27)
 
 1. Add light state
-    * [Pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/227)
+    * [BitBucket pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/227)
 1. redo pull request #222 for sdf3 branch
-    * [Pull request 232](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/232)
+    * [BitBucket pull request 232](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/232)
 1. Fix links in API documentation
-    * [Pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/231)
+    * [BitBucket pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/231)
 
 ### libsdformat 3.5.0 (2015-10-07)
 
 1. Camera lens description (Replaces #213)
-    * [Pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/215)
+    * [BitBucket pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/215)
 1. Fix shared pointer reference loop in Element and memory leak (#104)
-    * [Pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/230)
+    * [BitBucket pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/230)
 
 ### libsdformat 3.4.0 (2015-10-05)
 
 1. Support nested model states
-    * [Pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/223)
+    * [BitBucket pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/223)
 1. Cleaner way to set SDF_PATH for tests
-    * [Pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/226)
+    * [BitBucket pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/226)
 
 ### libsdformat 3.3.0 (2015-09-15)
 
 1. Windows Boost linking errors
-    * [Pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/206)
+    * [BitBucket pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/206)
 1. Nested SDF -> sdf3
-    * [Pull request 221](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/221)
+    * [BitBucket pull request 221](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/221)
 1. Pointer types
-    * [Pull request 218](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/218)
+    * [BitBucket pull request 218](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/218)
 1. Torsional friction default surface radius not infinity
-    * [Pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/217)
+    * [BitBucket pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/217)
 
 ### libsdformat 3.2.2 (2015-08-24)
 
 1. Added battery element (contribution from Olivier Crave)
-     * [Pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
+    * [BitBucket pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
 1. Torsional friction backport
-     * [Pull request #211](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/211)
+    * [BitBucket pull request #211](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/211)
 1. Allow Visual Studio 2015
-     * [Pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/208)
+    * [BitBucket pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/208)
 
 ### libsdformat 3.1.1 (2015-08-03)
 
 1. Fix tinyxml linking error
-     * [Pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/209)
+    * [BitBucket pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/209)
 
 ### libsdformat 3.1.0 (2015-08-02)
 
 1. Added logical camera sensor to SDF
-     * [Pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/207)
+    * [BitBucket pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/207)
 
 ### libsdformat 3.0.0 (2015-07-24)
 
 1. Added battery to SDF
-     * [Pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
+    * [BitBucket pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
 1. Added altimeter sensor to SDF
-     * [Pull request #197](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/197)
+    * [BitBucket pull request #197](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/197)
 1. Added magnetometer sensor to SDF
-     * [Pull request 198](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/198)
+    * [BitBucket pull request 198](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/198)
 1. Fix detection of XML parsing errors
-     * [Pull request 190](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/190)
+    * [BitBucket pull request 190](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/190)
 1. Support for fixed joints
-     * [Pull request 194](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/194)
+    * [BitBucket pull request 194](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/194)
 1. Adding iterations to state
-     * [Pull request 188](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/188)
+    * [BitBucket pull request 188](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/188)
 1. Convert to use ignition-math
-     * [Pull request 173](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/173)
+    * [BitBucket pull request 173](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/173)
 1. Add world origin to scene
-     * [Pull request 183](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/183)
+    * [BitBucket pull request 183](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/183)
 1. Fix collide bitmask
-     * [Pull request 182](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/182)
+    * [BitBucket pull request 182](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/182)
 1. Adding meta information to visuals
-     * [Pull request 180](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/180)
+    * [BitBucket pull request 180](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/180)
 1. Add projection type to gui camera
-     * [Pull request 178](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/178)
+    * [BitBucket pull request 178](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/178)
 1. Fix print description to include attribute description
-     * [Pull request 170](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/170)
+    * [BitBucket pull request 170](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/170)
 1. Add -std=c++11 flag to sdf_config.cmake.in and sdformat.pc.in, needed by downstream code
-     * [Pull request 172](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/172)
+    * [BitBucket pull request 172](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/172)
 1. Added boost::any accessor for Param and Element
-     * [Pull request 166](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/166)
+    * [BitBucket pull request 166](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/166)
 1. Remove tinyxml from dependency list
-     * [Pull request 152](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/152)
+    * [BitBucket pull request 152](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/152)
 1. Added self_collide element for model
-     * [Pull request 149](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/149)
+    * [BitBucket pull request 149](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/149)
 1. Added a collision bitmask field to sdf-1.5 and c++11 support
-     * [Pull request 145](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/145)
+    * [BitBucket pull request 145](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/145)
 1. Fix problems with latin locales and decimal numbers (issue #60)
-     * [Pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/147)
-     * [Issue 60](https://github.com/osrf/sdformat/issues/60)
+    * [BitBucket pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/147)
+    * [Issue 60](https://github.com/osrf/sdformat/issues/60)
 
 ## libsdformat 2.x
 
 1. rename cfm_damping --> implicit_spring_damper
-     * [Pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/59)
+    * [BitBucket pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/59)
 1. add gear_ratio and reference_body for gearbox joint.
-     * [Pull request 62](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/62)
+    * [BitBucket pull request 62](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/62)
 1. Update joint stop stiffness and dissipation
-     * [Pull request 61](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/61)
+    * [BitBucket pull request 61](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/61)
 1. Support for GNUInstallDirs
-     * [Pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/64)
+    * [BitBucket pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/64)
 1. `<use_true_size>` element used by DEM heightmaps
-     * [Pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/67)
+    * [BitBucket pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/67)
 1. Do not export urdf symbols in SDFormat 1.4
-     * [Pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/75)
+    * [BitBucket pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/75)
 1. adding deformable properties per issue #32
-     * [Pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/78)
-     * [Issue 32](https://github.com/osrf/sdformat/issues/32)
+    * [BitBucket pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/78)
+    * [Issue 32](https://github.com/osrf/sdformat/issues/32)
 1. Support to use external URDF
-     * [Pull request 77](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/77)
+    * [BitBucket pull request 77](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/77)
 1. Add lighting element to visual
-     * [Pull request 79](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/79)
+    * [BitBucket pull request 79](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/79)
 1. SDF 1.5: add flag to fix joint axis frame #43 (gazebo issue 494)
-     * [Pull request 83](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/83)
-     * [Issue 43](https://github.com/osrf/sdformat/issues/43)
-     * [Gazebo issue 494](https://bitbucket.org/osrf/gazebo/issues/494)
+    * [BitBucket pull request 83](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/83)
+    * [Issue 43](https://github.com/osrf/sdformat/issues/43)
+    * [Gazebo issue 494](https://github.com/osrf/gazebo/issues/494)
 1. Implement SDF_PROTOCOL_VERSION (issue #51)
-     * [Pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/90)
+    * [BitBucket pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/90)
 1. Port libsdformat to compile on Windows (MSVC)
-     * [Pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/101)
+    * [BitBucket pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/101)
 1. Separate material properties in material.sdf
-     * [Pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/104)
+    * [BitBucket pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/104)
 1. Add road textures (repeat pull request #104 for sdf_2.0)
-     * [Pull request 105](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/105)
+    * [BitBucket pull request 105](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/105)
 1. Add Extruded Polylines as a model
-     * [Pull request 93](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/93)
+    * [BitBucket pull request 93](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/93)
 1. Added polyline for sdf_2.0
-     * [Pull request 106](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/106)
+    * [BitBucket pull request 106](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/106)
 1. Add spring_reference and spring_stiffness tags to joint axis dynamics
-     * [Pull request 102](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/102)
+    * [BitBucket pull request 102](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/102)
 1. Fix actor static
-     * [Pull request 110](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/110)
+    * [BitBucket pull request 110](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/110)
 1. New <Population> element
-     * [Pull request 112](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/112)
+    * [BitBucket pull request 112](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/112)
 1. Add camera distortion element
-     * [Pull request 120](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/120)
+    * [BitBucket pull request 120](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/120)
 1. Inclusion of magnetic field strength sensor
-     * [Pull request 123](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/123)
+    * [BitBucket pull request 123](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/123)
 1. Properly add URDF gazebo extensions blobs to SDF joint elements
-     * [Pull request 125](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/125)
+    * [BitBucket pull request 125](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/125)
 1. Allow gui plugins to be specified in SDF
-     * [Pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/127)
+    * [BitBucket pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/127)
 1. Backport magnetometer
-     * [Pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/128)
+    * [BitBucket pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/128)
 1. Add flag for MOI rescaling to SDFormat 1.4
-     * [Pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/121)
+    * [BitBucket pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/121)
 1. Parse urdf joint friction parameters, add corresponding test
-     * [Pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/129)
+    * [BitBucket pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/129)
 1. Allow reading of boolean values from plugin elements.
-     * [Pull request 132](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/132)
+    * [BitBucket pull request 132](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/132)
 1. Implement generation of XML Schema files (issue #2)
-     * [Pull request 91](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/91)
+    * [BitBucket pull request 91](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/91)
 1. Fix build for OS X 10.10
-     * [Pull request 135](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/135)
+    * [BitBucket pull request 135](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/135)
 1. Improve performance in loading <include> SDF elements
-     * [Pull request 138](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/138)
+    * [BitBucket pull request 138](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/138)
 1. Added urdf gazebo extension option to disable fixed joint lumping
-     * [Pull request 133](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/133)
+    * [BitBucket pull request 133](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/133)
 1. Support urdfdom 0.3 (alternative to pull request #122)
-     * [Pull request 141](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/141)
+    * [BitBucket pull request 141](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/141)
 1. Update list of supported joint types
-     * [Pull request 142](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/142)
+    * [BitBucket pull request 142](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/142)
 1. Ignore unknown elements
-     * [Pull request 148](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/148)
+    * [BitBucket pull request 148](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/148)
 1. Physics preset attributes
-     * [Pull request 146](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/146)
+    * [BitBucket pull request 146](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/146)
 1. Backport fix for latin locales (pull request #147)
-     * [Pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/150)
+    * [BitBucket pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/150)
 
 ## libsdformat 1.4
 
 ### libsdformat 1.4.8 (2013-09-06)
 
 1. Fix inertia transformations when reducing fixed joints in URDF
-    * [Pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/48/fix-for-issue-22-reducing-inertia-across/diff)
+    * [BitBucket pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/48/fix-for-issue-22-reducing-inertia-across/diff)
 1. Add <use_terrain_paging> element to support terrain paging in gazebo
-    * [Pull request 47](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/47/add-element-inside-heightmap/diff)
+    * [BitBucket pull request 47](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/47/add-element-inside-heightmap/diff)
 1. Further reduce console output when using URDF models
-    * [Pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
+    * [BitBucket pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
     * [Commit](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/commits/b15d5a1ecc57abee6691618d02d59bbc3d1b84dc)
 
 ### libsdformat 1.4.7 (2013-08-22)
 
 1. Direct console messages to std_err
-    * [Pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/44/fix-19-direct-all-messages-to-std_err)
+    * [BitBucket pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/44/fix-19-direct-all-messages-to-std_err)
 
 ### libsdformat 1.4.6 (2013-08-20)
 
 1. Add tags for GPS sensor and sensor noise
-    * [Pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/36/gps-sensor-sensor-noise-and-spherical)
+    * [BitBucket pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/36/gps-sensor-sensor-noise-and-spherical)
 1. Add tags for wireless transmitter/receiver models
-    * [Pull request 34](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/34/transceiver-support)
-    * [Pull request 43](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/43/updated-description-of-the-transceiver-sdf)
+    * [BitBucket pull request 34](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/34/transceiver-support)
+    * [BitBucket pull request 43](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/43/updated-description-of-the-transceiver-sdf)
 1. Add tags for playback of audio files in Gazebo
-    * [Pull request 26](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/26/added-audio-tags)
-    * [Pull request 35](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/35/move-audio-to-link-and-playback-on-contact)
+    * [BitBucket pull request 26](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/26/added-audio-tags)
+    * [BitBucket pull request 35](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/35/move-audio-to-link-and-playback-on-contact)
 1. Add tags for simbody physics parameters
-    * [Pull request 32](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/32/merging-some-updates-from-simbody-branch)
+    * [BitBucket pull request 32](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/32/merging-some-updates-from-simbody-branch)
 1. Log messages to a file, reduce console output
-    * [Pull request 33](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/33/log-messages-to-file-8)
+    * [BitBucket pull request 33](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/33/log-messages-to-file-8)
 1. Generalize ode's <provide_feedback> element
-    * [Pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/38/add-provide_feedback-for-bullet-joint)
+    * [BitBucket pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/38/add-provide_feedback-for-bullet-joint)
 1. Various bug, style and test fixes
 
 ### libsdformat 1.4.5 (2013-07-23)

--- a/INSTALL_WIN32.md
+++ b/INSTALL_WIN32.md
@@ -22,7 +22,7 @@ Windows `cmd` for configuring and building.
 
 1. Clone sdformat
 
-        hg clone https://bitbucket.org/osrf/sdformat
+        git clone https://github.com/osrf/sdformat
 
 1. Load your compiler setup, e.g. (note that we are asking for the 64-bit toolchain here):
 

--- a/Migration.md
+++ b/Migration.md
@@ -105,7 +105,7 @@ but with improved human-readability..
 
 1.  + Change installation path of SDF description files to allow side-by-side installation.
     + `{prefix}/share/sdformat/1.*/*.sdf` -> `{prefix}/share/sdformat8/1.*/*.sdf`
-    + [pull request 538](https://bitbucket.org/osrf/sdformat/pull-requests/538)
+    + [BitBucket pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
 
 ## SDFormat 5.x to 6.x
 
@@ -170,22 +170,22 @@ but with improved human-readability..
 1. **`gravity` and `magnetic_field` elements are moved  from `physics` to `world`**
     + In physics element: gravity and `magnetic_field` tags have been moved
       from Physics to World element.
-    + [pull request 247](https://bitbucket.org/osrf/sdformat/pull-requests/247)
-    + [gazebo pull request 2090](https://bitbucket.org/osrf/gazebo/pull-requests/2090)
+    + [BitBucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/247)
+    + [BitBucket gazebo pull request 2090](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2090)
 
 1. **New noise for IMU**
     + A new style for representing the noise properties of an `imu` was implemented
-      in [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
+      in [BitBucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
       for sdf 1.5 and the old style was declared as deprecated.
       The old style has been removed from sdf 1.6 with the conversion script
       updating to the new style.
-    + [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
-    + [pull request 243](https://bitbucket.org/osrf/sdformat/pull-requests/243)
-    + [pull request 244](https://bitbucket.org/osrf/sdformat/pull-requests/244)
+    + [BitBucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
+    + [BitBucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
+    + [BitBucket pull request 244](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/244)
 
 1. **Lump:: prefix in link names**
     + Changed to `_fixed_joint_lump__` to avoid confusion with scoped names
-    + [Pull request 245](https://bitbucket.org/osrf/sdformat/pull-request/245)
+    + [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
 
 ## SDF protocol 1.7 to 1.8
 
@@ -204,7 +204,7 @@ but with improved human-readability..
     + type: string
     + default: ""
     + required: *
-    + [pull request 603](https://bitbucket.org/osrf/sdformat/pull-requests/603)
+    + [BitBucket pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
 
 1. **joint.sdf** `//axis/xyz/@expressed_in` and `//axis2/xyz/@expressed_in` attributes
     + description: The name of the frame in which the `//axis/xyz` value is
@@ -214,7 +214,7 @@ but with improved human-readability..
     + type: string
     + default: ""
     + required: 0
-    + [pull request 589](https://bitbucket.org/osrf/sdformat/pull-requests/589)
+    + [BitBucket pull request 589](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/589)
 
 1. **model.sdf** `//model/@canonical_link` attribute
     + description: The name of the canonical link in this model to which the
@@ -224,17 +224,17 @@ but with improved human-readability..
     + type: string
     + default: ""
     + required: 0
-    + [pull request 601](https://bitbucket.org/osrf/sdformat/pull-requests/601)
+    + [BitBucket pull request 601](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/601)
 
 1. **world.sdf** `//world/frame` element is now allowed.
-    + [pull request 603](https://bitbucket.org/osrf/sdformat/pull-requests/603)
+    + [BitBucket pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
 
 ### Modifications
 
 1.  A non-static model must have at least one link, as specified in the
     [proposal](http://sdformat.org/tutorials?tut=pose_frame_semantics_proposal&cat=pose_semantics_docs&#2-model-frame-and-canonical-link).
-    + [pull request 601](https://bitbucket.org/osrf/sdformat/pull-requests/601)
-    + [pull request 626](https://bitbucket.org/osrf/sdformat/pull-requests/626)
+    + [BitBucket pull request 601](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/601)
+    + [BitBucket pull request 626](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/626)
 
 1. Unique names for all sibling elements:
     + As described in the [proposal](http://sdformat.org/tutorials?tut=pose_frame_semantics_proposal&cat=pose_semantics_docs&#3-2-unique-names-for-all-sibling-elements),
@@ -244,7 +244,7 @@ but with improved human-readability..
       Some existing SDFormat models may not comply with this requirement.
       The `ign sdf --check` command can be used to identify models that violate
       this requirement.
-    + [pull request 600](https://bitbucket.org/osrf/sdformat/pull-requests/600)
+    + [BitBucket pull request 600](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/600)
 
 1. Reserved names:
     + As described in the [proposal](http://sdformat.org/tutorials?tut=pose_frame_semantics_proposal&cat=pose_semantics_docs&#3-3-reserved-names),
@@ -259,10 +259,10 @@ but with improved human-readability..
       for implicit model / world frames, respectively).
 
 1. **joint.sdf** `//joint/child` may no longer be specified as `world`.
-    + [pull request 634](https://bitbucket.org/osrf/sdformat/pull-requests/634)
+    + [BitBucket pull request 634](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/634)
 
 1. **pose.sdf** `//pose/@frame` attribute is renamed to `//pose/@relative_to`.
-    + [pull request 597](https://bitbucket.org/osrf/sdformat/pull-requests/597)
+    + [BitBucket pull request 597](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/597)
 
 ### Removals
 
@@ -284,17 +284,17 @@ but with improved human-readability..
     + projector
     + sensor
     + visual
-    + [pull request 603](https://bitbucket.org/osrf/sdformat/pull-requests/603)
+    + [BitBucket pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
 
 1. **actor.sdf** `static` element was deprecated in
-    [pull request 280](https://bitbucket.org/osrf/sdformat/pull-requests/280)
+    [BitBucket pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/280)
     and is now removed.
-    + [pull request 588](https://bitbucket.org/osrf/sdformat/pull-requests/588)
+    + [BitBucket pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
 
 1. **imu.sdf** `topic` element was deprecated in
-    [pull request 532](https://bitbucket.org/osrf/sdformat/pull-requests/532)
+    [BitBucket pull request 532](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/532)
     and is now removed.
-    + [pull request 588](https://bitbucket.org/osrf/sdformat/pull-requests/588)
+    + [BitBucket pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
 
 1. **joint.sdf** `//axis/use_parent_model_frame` and `//axis2/use_parent_model_frame` elements
     are removed in favor of the `//axis/xyz/@expressed_in` and
@@ -302,15 +302,15 @@ but with improved human-readability..
     When migrating from sdf 1.6, a `use_parent_model_frame` value
     of `true` will be mapped to a value of `__model__` for the `expressed_in`
     attribute.
-    + [pull request 589](https://bitbucket.org/osrf/sdformat/pull-requests/589)
+    + [BitBucket pull request 589](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/589)
 
 1. **joint.sdf** `//physics/ode/provide_feedback` was deprecated in
-    [pull request 38](https://bitbucket.org/osrf/sdformat/pull-requests/38)
+    [BitBucket pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/38)
     and is now removed.
-    + [pull request 588](https://bitbucket.org/osrf/sdformat/pull-requests/588)
+    + [BitBucket pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
 
 1. **world.sdf** `//world/joint` was removed as it has never been used.
-    + [pull request 637](https://bitbucket.org/osrf/sdformat/pull-requests/637)
+    + [BitBucket pull request 637](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/637)
 
 ## SDF protocol 1.5 to 1.6
 
@@ -326,27 +326,27 @@ but with improved human-readability..
     + min: 0.0
     + max: 1.0
     + required: 0
-    + [pull request 466](https://bitbucket.org/osrf/sdformat/pull-requests/466)
+    + [BitBucket pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
 
 1. **camera.sdf** `depth_camera/clip` sub-elements: `near`, `far`
     + description: Clipping parameters for depth camera on rgbd camera sensor.
-    + [pull request 628](https://bitbucket.org/osrf/sdformat/pull-requests/628)
+    + [BitBucket pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
 
 1. **camera.sdf** `intrinsics` sub-elements: `fx`, `fy`, `cx`, `cy`, `s`
     + description: Camera intrinsic parameters for setting a custom perspective projection matrix.
-    + [pull request 496](https://bitbucket.org/osrf/sdformat/pull-requests/496)
+    + [BitBucket pull request 496](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/496)
 
 1. **link.sdf** `enable_wind` element
     + description: If true, the link is affected by the wind
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **link.sdf** `light` element
     + included from `light.sdf` with `required="*"`,
       so a link can have any number of attached lights.
-    + [pull request 373](https://bitbucket.org/osrf/sdformat/pull-requests/373)
+    + [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
 1. **model.sdf** `enable_wind` element
     + description: If set to true, all links in the model will be affected by
@@ -354,14 +354,14 @@ but with improved human-readability..
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **model_state.sdf** `scale` element
     + description: Scale for the 3 dimensions of the model.
     + type: vector3
     + default: "1 1 1"
     + required: 0
-    + [pull request 246](https://bitbucket.org/osrf/sdformat/pull-requests/246)
+    + [BitBucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/246)
 
 1. **physics.sdf** `dart::collision_detector` element
     + description: The collision detector for DART to use.
@@ -369,7 +369,7 @@ but with improved human-readability..
     + type: string
     + default: fcl
     + required: 0
-    + [pull request 440](https://bitbucket.org/osrf/sdformat/pull-requests/440)
+    + [BitBucket pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
 
 1. **physics.sdf** `dart::solver::solver_type` element
     + description: The DART LCP/constraint solver to use.
@@ -377,31 +377,31 @@ but with improved human-readability..
     + type: string
     + default: dantzig
     + required: 0
-    + [pull request 369](https://bitbucket.org/osrf/sdformat/pull-requests/369)
+    + [BitBucket pull request 369](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/369)
 
 1. **physics.sdf** `island_threads` element under `ode::solver`
     + description: Number of threads to use for "islands" of disconnected models.
     + type: int
     + default: 0
     + required: 0
-    + [pull request 380](https://bitbucket.org/osrf/sdformat/pull-requests/380)
+    + [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. **physics.sdf** `thread_position_correction` element under `ode::solver`
     + description: Flag to use threading to speed up position correction computation.
     + type: bool
     + default: 0
     + required: 0
-    + [pull request 380](https://bitbucket.org/osrf/sdformat/pull-requests/380)
+    + [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. **sonar.sdf** `geometry` element
     + description: The sonar collision shape. Currently supported geometries are: "cone" and "sphere".
     + type: string
     + default: "cone"
     + required: 0
-    + [pull request 495](https://bitbucket.org/osrf/sdformat/pull-requests/495)
+    + [BitBucket pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
 
 1. **state.sdf** allow `light` tags within `insertions` element
-    * [pull request 325](https://bitbucket.org/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. **surface.sdf** `category_bitmask` element
     + description: Bitmask for category of collision filtering.
@@ -410,16 +410,16 @@ but with improved human-readability..
     + type: unsigned int
     + default: 65535
     + required: 0
-    + [pull request 318](https://bitbucket.org/osrf/sdformat/pull-requests/318)
+    + [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/318)
 
 1. **world.sdf** `wind` element
     + description: The wind tag specifies the type and properties of the wind.
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **world.sdf** `wind::linear_velocity` element
     + description: Linear velocity of the wind.
     + type: vector3
     + default: "0 0 0"
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -10,7 +10,7 @@ pipelines:
           - sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
           - wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
           - apt-get update
-          - apt -y install cmake build-essential curl git mercurial libtinyxml-dev libxml2-utils ruby-dev python-psutil cppcheck
+          - apt -y install cmake build-essential curl git libtinyxml-dev libxml2-utils ruby-dev python-psutil cppcheck
           - gcc -v
           - g++ -v
           - gcov -v

--- a/doc/header.html
+++ b/doc/header.html
@@ -41,7 +41,7 @@
         <dd><a href="http://sdf.com/wiki/Tutorials">Tutorials</a></dd>
         <dd><a href="http://sdf.com/downloads.html">Download</a></dd>
         -->
-        <dd><a href="https://bitbucket.org/osrf/sdf/issues/new">Report Documentation Issues</a></dd>
+        <dd><a href="https://github.com/osrf/sdformat/issues/new">Report Documentation Issues</a></dd>
       </dl>
     </div>
     <div>

--- a/doc/mainpage.html
+++ b/doc/mainpage.html
@@ -5,7 +5,7 @@ This documentation provides useful information about the Simulation
 Desctiption Format API. The code reference is divided into the groups below.
 Should you find problems with this documentation - typos, unclear phrases,
 or insufficient detail - please create a <a
-  href="https://bitbucket.org/osrf/sdf/issues/new">new bitbucket issue</a>.
+  href="https://github.com/osrf/sdformat/issues/new">new GitHub issue</a>.
 Include sufficient detail to quickly locate the problematic documentation,
 and set the issue's fields accordingly: Assignee - blank; Kind - bug;
 Priority - minor; Version - blank.

--- a/sdf/1.4/physics.sdf
+++ b/sdf/1.4/physics.sdf
@@ -177,7 +177,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.5/joint.sdf
+++ b/sdf/1.5/joint.sdf
@@ -55,7 +55,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">
@@ -114,7 +114,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">

--- a/sdf/1.5/physics.sdf
+++ b/sdf/1.5/physics.sdf
@@ -189,7 +189,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.6/joint.sdf
+++ b/sdf/1.6/joint.sdf
@@ -61,7 +61,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">
@@ -125,7 +125,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">

--- a/sdf/1.6/physics.sdf
+++ b/sdf/1.6/physics.sdf
@@ -200,7 +200,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
       <element name="friction_model" type="string" default="pyramid_model" required="0">
@@ -213,8 +213,8 @@
           cone_model: friction force magnitude limited in proportion to normal force.
 
           See gazebo pull request 1522 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1522
-          https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522
+          https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.7/physics.sdf
+++ b/sdf/1.7/physics.sdf
@@ -200,7 +200,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
       <element name="friction_model" type="string" default="pyramid_model" required="0">
@@ -213,8 +213,8 @@
           cone_model: friction force magnitude limited in proportion to normal force.
 
           See gazebo pull request 1522 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1522
-          https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522
+          https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.8/physics.sdf
+++ b/sdf/1.8/physics.sdf
@@ -200,7 +200,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
       <element name="friction_model" type="string" default="pyramid_model" required="0">
@@ -213,8 +213,8 @@
           cone_model: friction force magnitude limited in proportion to normal force.
 
           See gazebo pull request 1522 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1522
-          https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522
+          https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/Migration.md
+++ b/sdf/Migration.md
@@ -28,14 +28,14 @@ but with improved human-readability.
     + type: unsigned int
     + default: 2
     + required: 0
-    + [pull request 293](https://bitbucket.org/osrf/sdformat/pull-requests/293)
+    + [Bitbucket pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/293)
 
 1. **link.sdf** `enable_wind` element
     + description: If true, the link is affected by the wind
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **model.sdf** `enable_wind` element
     + description: If set to true, all links in the model
@@ -44,14 +44,14 @@ but with improved human-readability.
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **model_state.sdf** `scale` element
     + description: Scale for the 3 dimensions of the model.
     + type: vector3
     + default: "1 1 1"
     + required: 0
-    + [pull request 246](https://bitbucket.org/osrf/sdformat/pull-requests/246)
+    + [Bitbucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/246)
 
 1. **physics.sdf** `friction_model` element
     + description: Name of ODE friction model to use. Valid values include:
@@ -59,39 +59,39 @@ but with improved human-readability.
           in proportion to normal force.
         + box_model: friction forces limited to constant in two directions.
         + cone_model: friction force magnitude limited in proportion to normal force.
-          See [gazebo pull request 1522](https://bitbucket.org/osrf/gazebo/pull-request/1522)
-          (merged in [gazebo 8c05ad64967c](https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c))
+          See [gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522)
+          (merged in [gazebo 8c05ad64967c](https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f))
           for the implementation of this feature.
     + type: string
     + default: "pyramid_model"
     + required: 0
-    + [pull request 294](https://bitbucket.org/osrf/sdformat/pull-requests/294)
+    + [Bitbucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
 
 1. **world.sdf** `wind` element
     + description: The wind tag specifies the type and properties of the wind.
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **world.sdf** `wind::linear_velocity` element
     + description: Linear velocity of the wind.
     + type: vector3
     + default: "0 0 0"
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 ### Modifications
 
 1. `gravity` and `magnetic_field` elements are moved
     from `physics` to `world`
-    + [pull request 247](https://bitbucket.org/osrf/sdformat/pull-requests/247)
-    + [gazebo pull request 2090](https://bitbucket.org/osrf/gazebo/pull-requests/2090)
+    + [Bitbucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/247)
+    + [gazebo pull request 2090](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2090)
 
 1. A new style for representing the noise properties of an `imu` was implemented
-   in [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
+   in [Bitbucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
    for sdf 1.5 and the old style was declared as deprecated.
    The old style has been removed from sdf 1.6 with the conversion script
    updating to the new style.
-    + [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
-    + [pull request 243](https://bitbucket.org/osrf/sdformat/pull-requests/243)
-    + [pull request 244](https://bitbucket.org/osrf/sdformat/pull-requests/244)
+    + [Bitbucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
+    + [Bitbucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
+    + [Bitbucket pull request 244](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/244)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ if (NOT WIN32)
 endif()
 
 sdf_add_library(${sdf_target} ${sources})
+target_compile_features(${sdf_target} PUBLIC cxx_std_17)
 target_link_libraries(${sdf_target} PUBLIC ${IGNITION-MATH_LIBRARIES})
 
 target_include_directories(${sdf_target}

--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -130,8 +130,11 @@ Errors Collision::Load(ElementPtr _sdf)
   Errors geomErr = this->dataPtr->geom.Load(_sdf->GetElement("geometry"));
   errors.insert(errors.end(), geomErr.begin(), geomErr.end());
 
-  // Load the surface parameters
-  this->dataPtr->surface.Load(_sdf->GetElement("surface"));
+  // Load the surface parameters if they are given
+  if (_sdf->HasElement("surface"))
+  {
+    this->dataPtr->surface.Load(_sdf->GetElement("surface"));
+  }
 
   return errors;
 }

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -34,7 +34,7 @@ inline namespace SDF_VERSION_NAMESPACE {
 // The following two functions were originally submitted to ign-math,
 // but were not accepted as they were not generic enough.
 // For now, they will be kept here.
-// https://bitbucket.org/ignitionrobotics/ign-math/pull-requests/333
+// https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-math/pull-requests/333
 
 /// \brief Starting from a given vertex in a directed graph, traverse edges
 /// in reverse direction to find a source vertex (has only outgoing edges).

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -34,8 +34,8 @@ using namespace sdf;
 // comma. To avoid that the SDF parsing is influenced by the current
 // global C or C++ locale, we define a custom std::stringstream variant
 // that always uses the std::locale::classic() locale.
-// See issues https://bitbucket.org/osrf/sdformat/issues/60
-// and https://bitbucket.org/osrf/sdformat/issues/207 for more details.
+// See issues https://github.com/osrf/sdformat/issues/60
+// and https://github.com/osrf/sdformat/issues/207 for more details.
 namespace sdf
 {
   inline namespace SDF_VERSION_NAMESPACE {

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -157,7 +157,7 @@ TEST(Param, HexUInt)
 TEST(Param, HexFloat)
 {
 // Microsoft does not parse hex values properly.
-// https://bitbucket.org/osrf/sdformat/issues/114
+// https://github.com/osrf/sdformat/issues/114
 #ifndef _MSC_VER
   sdf::Param floatParam("key", "float", "0", false, "description");
   float value;
@@ -192,7 +192,7 @@ TEST(Param, HexDouble)
   EXPECT_DOUBLE_EQ(value, 0.0);
 
 // Microsoft does not parse hex values properly.
-// https://bitbucket.org/osrf/sdformat/issues/114
+// https://github.com/osrf/sdformat/issues/114
 #ifndef _MSC_VER
   EXPECT_TRUE(doubleParam.SetFromString("0x01"));
   EXPECT_TRUE(doubleParam.Get<double>(value));

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -133,7 +133,7 @@ TEST(SDF, UpdateElement)
     EXPECT_EQ(flagCheck, fixture.flag);
     poseParam->Get(poseCheck);
     // test fails on homebrew see issue 202
-    // https://bitbucket.org/osrf/sdformat/issues/202
+    // https://github.com/osrf/sdformat/issues/202
 #ifndef __APPLE__
     EXPECT_EQ(poseCheck, fixture.pose);
 #endif
@@ -420,7 +420,7 @@ TEST(SDF, GetAny)
     catch(std::bad_any_cast &/*_e*/)
     {
     // test fails on homebrew see issue 202
-    // https://bitbucket.org/osrf/sdformat/issues/202
+    // https://github.com/osrf/sdformat/issues/202
 #ifndef __APPLE__
       FAIL();
 #endif
@@ -438,7 +438,7 @@ TEST(SDF, GetAny)
     catch(std::bad_any_cast &/*_e*/)
     {
     // test fails on homebrew see issue 202
-    // https://bitbucket.org/osrf/sdformat/issues/202
+    // https://github.com/osrf/sdformat/issues/202
 #ifndef __APPLE__
       FAIL();
 #endif
@@ -482,7 +482,7 @@ TEST(SDF, GetAny)
     catch(std::bad_any_cast &/*_e*/)
     {
     // test fails on homebrew see issue 202
-    // https://bitbucket.org/osrf/sdformat/issues/202
+    // https://github.com/osrf/sdformat/issues/202
 #ifndef __APPLE__
       FAIL();
 #endif


### PR DESCRIPTION
Follow-up to #233, improved the script to also update files other than the changelog.

There are a couple of links to `osrf/gazebo` which won't work until that's migrated.