### PR TITLE
changelog: Use terminology from README

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,27 +1,27 @@
-## SDFormat 10.X
+## libsdformat 10.X
 
-### SDFormat 10.X.X (202X-XX-XX)
+### libsdformat 10.X.X (202X-XX-XX)
 
-### SDFormat 10.0.0 (202X-XX-XX)
+### libsdformat 10.0.0 (202X-XX-XX)
 
 1. Changed the default radius of a Cylinder from 1.0 to 0.5 meters.
     * [Pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)
 
-1. Initial version of sdformat 1.8 specification.
+1. Initial version of SDFormat 1.8 specification.
     * [Pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
 
-1. sdf 1.8: Deprecate //joint/axis/initial_position.
+1. SDFormat 1.8: Deprecate //joint/axis/initial_position.
     * [Pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
 
-## SDFormat 9.X
+## libsdformat 9.X
 
-### SDFormat 9.X.X (202X-XX-XX)
+### libsdformat 9.X.X (202X-XX-XX)
 
 1. Fix homebrew build with external urdfdom.
     * [Pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
     * [Pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
 
-### SDFormat 9.2.0 (2020-04-02)
+### libsdformat 9.2.0 (2020-04-02)
 
 1. Remove URI scheme, if present, when finding files.
     * [Pull request 650](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/650)
@@ -79,7 +79,7 @@
 1. Rename SDF to SDFormat / libsdformat on documentation
     * [Pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
 
-### SDFormat 9.1.0 (2020-01-29)
+### libsdformat 9.1.0 (2020-01-29)
 
 1. Remove URI scheme, if present, when finding files.
     * [Pull request 653](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/653)
@@ -99,7 +99,7 @@
    [Pull Request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
     * [Pull Request 645](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/645)
 
-1. sdf 1.7: remove `//world/joint` element since it has never been used.
+1. SDFormat 1.7: remove `//world/joint` element since it has never been used.
     * [Pull request 637](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/637)
 
 1. Add clipping for depth camera on rgbd camera sensor
@@ -120,13 +120,13 @@
 1. Access the original parsed version of an SDF document with `Element::OriginalVersion`.
     * [Pull request 640](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/640)
 
-1. Model::Load: fail fast if an sdf 1.7 file has name collisions.
+1. Model::Load: fail fast if an SDFormat 1.7 file has name collisions.
     * [Pull request 648](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/648)
 
 1. Keep DOM objects even if they were loaded with errors.
     * [Pull request 655](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/655)
 
-### SDFormat 9.0.0 (2019-12-10)
+### libsdformat 9.0.0 (2019-12-10)
 
 1. Move recursiveSameTypeUniqueNames from ign.cc to parser.cc and make public.
     * [Pull request 606](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/606)
@@ -149,7 +149,7 @@
 1. Unversioned library name for ign tool commands.
     * [Pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
 
-1. Initial version of sdformat 1.7 specification.
+1. Initial version of SDFormat 1.7 specification.
     * [Pull request 588](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/588)
 
 1. Converter: add `<map>` element for converting fixed values.
@@ -158,19 +158,19 @@
 1. Converter: add `descendant_name` attribute to recursively search for elements to convert.
     * [Pull request 596](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/596)
 
-1. sdf 1.7: replace `use_parent_model_frame` element with `//axis/xyz/@expressed_in` attribute.
+1. SDFormat 1.7: replace `use_parent_model_frame` element with `//axis/xyz/@expressed_in` attribute.
     * [Pull request 589](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/589)
 
-1. sdf 1.7: replace `//pose/@frame` attribute with `//pose/@relative_to` attribute.
+1. SDFormat 1.7: replace `//pose/@frame` attribute with `//pose/@relative_to` attribute.
     * [Pull request 597](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/597)
 
-1. sdf 1.7: add `//model/@canonical_link` attribute and require models to have at least one link.
+1. SDFormat 1.7: add `//model/@canonical_link` attribute and require models to have at least one link.
     * [Pull request 601](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/601)
 
 1. Static models: allow them to have no links and skip building FrameAttachedToGraph.
     * [Pull request 626](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/626)
 
-1. sdf 1.7: add `//frame/attached_to`, only allow frames in model and world, add Frame DOM.
+1. SDFormat 1.7: add `//frame/attached_to`, only allow frames in model and world, add Frame DOM.
     * [pull request 603](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/603)
 
 1. FrameSemantics API: add FrameAttachedToGraph and functions for building graph and resolving attached-to body.
@@ -204,9 +204,9 @@
     * [Pull request 622](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/622)
     * [Pull request 623](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/623)
 
-## SDFormat 8.0
+## libsdformat 8.0
 
-### SDFormat 8.X.X (202X-XX-XX)
+### libsdformat 8.X.X (202X-XX-XX)
 
 1. Increase output precision of URDF to SDF conversion, output -0 as 0.
     * [Pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
@@ -215,7 +215,7 @@
     * [Pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
     * [Pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)
 
-### SDFormat 8.8.0 (2020-03-18)
+### libsdformat 8.8.0 (2020-03-18)
 
 1. Add Transparency to visual DOM
     * [Pull request 671](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/671)
@@ -238,7 +238,7 @@
 1. Rename SDF to SDFormat / libsdformat on documentation
     * [Pull request 666](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/666)
 
-### SDFormat 8.7.1 (2020-01-13)
+### libsdformat 8.7.1 (2020-01-13)
 
 1. Fix memory leaks in move assignment operator.
     * [Pull request 641](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/641)
@@ -246,7 +246,7 @@
 1. Refactoring based on rule-of-five guidance to address memory leaks
    * [Pull request 644](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/644)
 
-### SDFormat 8.7.0 (2019-12-13)
+### libsdformat 8.7.0 (2019-12-13)
 
 1. Remove some URDF error messages
     * [Pull request 605](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/605)
@@ -260,12 +260,12 @@
 1. Add clipping for depth camera on rgbd camera sensor
     * [Pull request 628](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/628)
 
-### SDFormat 8.6.1 (2019-12-05)
+### libsdformat 8.6.1 (2019-12-05)
 
 1. Unversioned lib name for cmds
     * [Pull request 612](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/612)
 
-### SDFormat 8.6.0 (2019-11-20)
+### libsdformat 8.6.0 (2019-11-20)
 
 1. configure.bat: use ign-math6, not gz11
     * [Pull request 595](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/595)
@@ -285,7 +285,7 @@
 1. Build `Utils_TEST` with Utils.cc explicitly passed since its symbols are not visible.
     * [Pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
 
-### SDFormat 8.5.0 (2019-11-06)
+### libsdformat 8.5.0 (2019-11-06)
 
 1. Add `thermal_camera` sensor type
     * [Pull request 586](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/586)
@@ -303,7 +303,7 @@
     * [Pull request 584](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/584)
     * [Pull request 573](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/573)
 
-### SDFormat 8.4.0 (2019-10-22)
+### libsdformat 8.4.0 (2019-10-22)
 
 1. Accept relative path in `<uri>`.
     * [Pull request 558](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/558)
@@ -315,7 +315,7 @@
 1. Lidar.hh: remove 'using namespace ignition'.
     * [Pull request 577](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/577)
 
-1. Parse urdf files to sdf 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
+1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
     * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
@@ -340,7 +340,7 @@
 1. Converter: remove all matching elements specified by `<remove>` tag.
     * [Pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
 
-### SDFormat 8.3.0 (2019-08-17)
+### libsdformat 8.3.0 (2019-08-17)
 
 1. Added Actor DOM
     * [Pull request 547](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/547)
@@ -348,12 +348,12 @@
 1. Print cmake build warnings and errors to std_err
     * [Pull request 549](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/549)
 
-### SDFormat 8.2.0 (2019-06-18)
+### libsdformat 8.2.0 (2019-06-18)
 
 1. Added RGBD Camera Sensor type.
     * [Pull request 540](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/540)
 
-### SDFormat 8.1.0 (2019-05-20)
+### libsdformat 8.1.0 (2019-05-20)
 
 1.  Change installation path of SDF description files to allow side-by-side installation.
     * [pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
@@ -380,7 +380,7 @@
 1. Added AirPressure SDF DOM
     * [Pull request 528](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/528)
 
-1. Update sdf noise elements
+1. Update SDFormat noise elements
     * [Pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
     * [Pull request 522](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/522)
 
@@ -415,7 +415,7 @@
     * [Pull request 511](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/511)
     * [Issue 202](https://github.com/osrf/sdformat/issues/202)
 
-### SDFormat 8.0.0 (2019-03-01)
+### libsdformat 8.0.0 (2019-03-01)
 
 1. Rename depth camera from 'depth' to 'depth_camera'
     * [Pull request 507](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/507)
@@ -487,14 +487,14 @@
     * [Pull request 488](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/488)
     * [Pull request 481](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/481)
 
-## SDFormat 7.0
+## libsdformat 7.0
 
-### SDFormat 7.0.0 (xxxx-xx-xx)
+### libsdformat 7.0.0 (xxxx-xx-xx)
 
 1. Build Utils_TEST with Utils.cc explicitly passed since its symbols are not visible.
     * [Pull request 572](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/572)
 
-1. Parse urdf files to sdf 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
+1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
     * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
@@ -510,7 +510,7 @@
     * [Pull request 557](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/557)
     * [pull request 464](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/464)
 
-1. Backport cmake and sdf spec changes from version 8.
+1. Backport cmake and SDFormat spec changes from version 8.
     * [Pull request 550](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/550)
     * [pull request 538](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/538)
     * [Pull request 525](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/525)
@@ -542,12 +542,12 @@
 1. SDF DOM: Add Element() accessor to Gui, JointAxis and World classes.
     * [Pull request 450](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/450)
 
-1. Adds the equalivent of gz sdf -d to sdformat. The command line option
+1. Adds the equalivent of gz sdf -d to libsdformat. The command line option
    will print the full description of the SDF spec.
     * [Pull request 424](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/424)
 
-1. Adds the equalivent of gz sdf -p to sdformat. The command line option
-   will convert and print the specified sdf file.
+1. Adds the equalivent of gz sdf -p to libsdformat. The command line option
+   will convert and print the specified SDFormat file.
     * [Pull request 494](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/494)
 
 1. SDF DOM: Additions to the document object model.
@@ -563,11 +563,11 @@
     * [Pull request 420](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/420)
 
 
-## SDFormat 6.0
+## libsdformat 6.0
 
-### SDFormat 6.X.X (20XX-XX-XX)
+### libsdformat 6.X.X (20XX-XX-XX)
 
-1. Parse urdf files to sdf 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
+1. Parse urdf files to SDFormat 1.5 instead of 1.4 to avoid `use_parent_model_frame`.
     * [Pull request 575](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/575)
 
 1. Set camera intrinsics axis skew (s) default value to 0
@@ -585,7 +585,7 @@
 1. Converter: remove all matching elements specified by `<remove>` tag.
     * [Pull request 551](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/551)
 
-### SDFormat 6.2.0 (2019-01-17)
+### libsdformat 6.2.0 (2019-01-17)
 
 1. Add geometry for sonar collision shape
     * [Pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
@@ -597,15 +597,15 @@
     * [Pull request 466](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/466)
 
 
-### SDFormat 6.1.0 (2018-10-04)
+### libsdformat 6.1.0 (2018-10-04)
 
 1. Add collision\_detector to dart physics config
     * [Pull request 440](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/440)
 
-1. Fix Windows support for SDFormat6
+1. Fix Windows support for libsdformat6
     * [Pull request 401](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/401)
 
-1. root.sdf: default sdf version 1.6
+1. root.sdf: default SDFormat version 1.6
     * [Pull request 425](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/425)
 
 1. parser\_urdf: print value of highstop instead of pointer address
@@ -615,7 +615,7 @@
     * [Pull request 402](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/402)
 
 
-### SDFormat 6.0.0 (2018-01-25)
+### libsdformat 6.0.0 (2018-01-25)
 
 1. SDF DOM: Added a document object model.
     * [Pull request 387](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/387)
@@ -648,11 +648,11 @@
 1. Deprecated sdf::Color, and switch to use ignition::math::Color
     * [Pull request 330](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/330)
 
-## SDFormat 5.x
+## libsdformat 5.x
 
-### SDFormat 5.x.x (2017-xx-xx)
+### libsdformat 5.x.x (2017-xx-xx)
 
-### SDFormat 5.3.0 (2017-11-13)
+### libsdformat 5.3.0 (2017-11-13)
 
 1. Added wrapper around root SDF for an SDF element
     * [Pull request 378](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/378)
@@ -670,7 +670,7 @@
 1. Add light as child of link
     * [Pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
 
-### SDFormat 5.2.0 (2017-08-03)
+### libsdformat 5.2.0 (2017-08-03)
 
 1. Added a block for DART-specific physics properties.
     * [Pull request 369](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/369)
@@ -678,7 +678,7 @@
 1. Fix parser to read plugin child elements within an `<include>`
     * [Pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
 
-1. Choosing models with more recent sdf version with `<include>` tag
+1. Choosing models with more recent SDFormat version with `<include>` tag
     * [Pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
@@ -701,16 +701,16 @@
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
     * [Pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
 
-### SDFormat 5.1.0 (2017-02-22)
+### libsdformat 5.1.0 (2017-02-22)
 
 1. Fixed `sdf::convertFile` and `sdf::convertString` always converting to latest version
     * [Pull request 320](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/320)
-1. Added back the ability to set sdf version at runtime
+1. Added back the ability to set SDFormat version at runtime
     * [Pull request 307](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/307)
 
-### SDFormat 5.0.0 (2017-01-25)
+### libsdformat 5.0.0 (2017-01-25)
 
-1. Removed SDFormat 4 deprecations
+1. Removed libsdformat 4 deprecations
     * [Pull request 295](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/295)
 
 1. Added an example
@@ -733,11 +733,11 @@
 1. Simplifier way of retrieving a value from SDF using Get
     * [Pull request 285](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/285)
 
-## SDFormat 4.0
+## libsdformat 4.0
 
-### SDFormat 4.x.x (2017-xx-xx)
+### libsdformat 4.x.x (2017-xx-xx)
 
-### SDFormat 4.4.0 (2017-10-26)
+### libsdformat 4.4.0 (2017-10-26)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
     * [Pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/380)
@@ -751,7 +751,7 @@
 1. Add light as child of link
     * [Pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
 
-### SDFormat 4.3.2 (2017-07-19)
+### libsdformat 4.3.2 (2017-07-19)
 
 1. Add documentation for `Element::GetFirstElement()` and `Element::GetNextElement()`
     * [Pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/341)
@@ -759,15 +759,15 @@
 1. Fix parser to read plugin child elements within an `<include>`
     * [Pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
 
-### SDFormat 4.3.1 (2017-03-24)
+### libsdformat 4.3.1 (2017-03-24)
 
 1. Fix segmentation Fault in `sdf::getBestSupportedModelVersion`
     * [Pull request 327](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/327)
     * [Issue 152](https://github.com/osrf/sdformat/issues/152)
 
-### SDFormat 4.3.0 (2017-03-20)
+### libsdformat 4.3.0 (2017-03-20)
 
-1. Choosing models with more recent sdf version with `<include>` tag
+1. Choosing models with more recent SDFormat version with `<include>` tag
     * [Pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
@@ -796,7 +796,7 @@
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
     * [Pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
 
-### SDFormat 4.2.0 (2016-10-10)
+### libsdformat 4.2.0 (2016-10-10)
 
 1. Added tag to specify ODE friction model.
     * [Pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
@@ -807,7 +807,7 @@
 1. Added IMU orientation specification to SDF.
     * [Pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/284)
 
-### SDFormat 4.1.1 (2016-07-08)
+### libsdformat 4.1.1 (2016-07-08)
 
 1. Added documentation and animation to `<actor>` element.
     * [Pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/280)
@@ -815,7 +815,7 @@
 1. Added tag to specify initial joint position
     * [Pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/279)
 
-### SDFormat 4.1.0 (2016-04-01)
+### libsdformat 4.1.0 (2016-04-01)
 
 1. Added SDF conversion functions to parser including sdf::convertFile and sdf::convertString.
     * [Pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/266)
@@ -823,7 +823,7 @@
 1. Added an upload script
     * [Pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/256)
 
-### SDFormat 4.0.0 (2015-01-12)
+### libsdformat 4.0.0 (2015-01-12)
 
 1. Boost pointers and boost::function in the public API have been replaced
    by their std::equivalents (C++11 standard)
@@ -847,15 +847,15 @@
     * [Pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/243)
     * [Pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
 
-## SDFormat 3.0
+## libsdformat 3.0
 
-### SDFormat 3.X.X (201X-XX-XX)
+### libsdformat 3.X.X (201X-XX-XX)
 
 1. Improve precision of floating point parameters
      * [Pull request 273](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/273)
      * [Pull request 276](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/276)
 
-### SDFormat 3.7.0 (2015-11-20)
+### libsdformat 3.7.0 (2015-11-20)
 
 1. Add spring pass through for sdf3
      * [Design document](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/gazebo_design/pull-requests/23)
@@ -867,7 +867,7 @@
 1. Remove boost from SDFExtension
      * [Pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/229)
 
-### SDFormat 3.6.0 (2015-10-27)
+### libsdformat 3.6.0 (2015-10-27)
 
 1. Add light state
     * [Pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/227)
@@ -876,21 +876,21 @@
 1. Fix links in API documentation
     * [Pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/231)
 
-### SDFormat 3.5.0 (2015-10-07)
+### libsdformat 3.5.0 (2015-10-07)
 
 1. Camera lens description (Replaces #213)
     * [Pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/215)
 1. Fix shared pointer reference loop in Element and memory leak (#104)
     * [Pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/230)
 
-### SDFormat 3.4.0 (2015-10-05)
+### libsdformat 3.4.0 (2015-10-05)
 
 1. Support nested model states
     * [Pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/223)
 1. Cleaner way to set SDF_PATH for tests
     * [Pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/226)
 
-### SDFormat 3.3.0 (2015-09-15)
+### libsdformat 3.3.0 (2015-09-15)
 
 1. Windows Boost linking errors
     * [Pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/206)
@@ -901,7 +901,7 @@
 1. Torsional friction default surface radius not infinity
     * [Pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/217)
 
-### SDFormat 3.2.2 (2015-08-24)
+### libsdformat 3.2.2 (2015-08-24)
 
 1. Added battery element (contribution from Olivier Crave)
      * [Pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
@@ -910,17 +910,17 @@
 1. Allow Visual Studio 2015
      * [Pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/208)
 
-### SDFormat 3.1.1 (2015-08-03)
+### libsdformat 3.1.1 (2015-08-03)
 
 1. Fix tinyxml linking error
      * [Pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/209)
 
-### SDFormat 3.1.0 (2015-08-02)
+### libsdformat 3.1.0 (2015-08-02)
 
 1. Added logical camera sensor to SDF
      * [Pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/207)
 
-### SDFormat 3.0.0 (2015-07-24)
+### libsdformat 3.0.0 (2015-07-24)
 
 1. Added battery to SDF
      * [Pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
@@ -960,7 +960,7 @@
      * [Pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/147)
      * [Issue 60](https://github.com/osrf/sdformat/issues/60)
 
-## SDFormat 2.x
+## libsdformat 2.x
 
 1. rename cfm_damping --> implicit_spring_damper
      * [Pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/59)
@@ -972,7 +972,7 @@
      * [Pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/64)
 1. `<use_true_size>` element used by DEM heightmaps
      * [Pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/67)
-1. Do not export urdf symbols in sdformat 1.4
+1. Do not export urdf symbols in SDFormat 1.4
      * [Pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/75)
 1. adding deformable properties per issue #32
      * [Pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/78)
@@ -987,7 +987,7 @@
      * [Gazebo issue 494](https://bitbucket.org/osrf/gazebo/issues/494)
 1. Implement SDF_PROTOCOL_VERSION (issue #51)
      * [Pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/90)
-1. Port sdformat to compile on Windows (MSVC)
+1. Port libsdformat to compile on Windows (MSVC)
      * [Pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/101)
 1. Separate material properties in material.sdf
      * [Pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/104)
@@ -1013,7 +1013,7 @@
      * [Pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/127)
 1. Backport magnetometer
      * [Pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/128)
-1. Add flag for MOI rescaling to sdf 1.4
+1. Add flag for MOI rescaling to SDFormat 1.4
      * [Pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/121)
 1. Parse urdf joint friction parameters, add corresponding test
      * [Pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/129)
@@ -1038,9 +1038,9 @@
 1. Backport fix for latin locales (pull request #147)
      * [Pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/150)
 
-## SDFormat 1.4
+## libsdformat 1.4
 
-### SDFormat 1.4.8 (2013-09-06)
+### libsdformat 1.4.8 (2013-09-06)
 
 1. Fix inertia transformations when reducing fixed joints in URDF
     * [Pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/48/fix-for-issue-22-reducing-inertia-across/diff)
@@ -1050,12 +1050,12 @@
     * [Pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
     * [Commit](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/commits/b15d5a1ecc57abee6691618d02d59bbc3d1b84dc)
 
-### SDFormat 1.4.7 (2013-08-22)
+### libsdformat 1.4.7 (2013-08-22)
 
 1. Direct console messages to std_err
     * [Pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/44/fix-19-direct-all-messages-to-std_err)
 
-### SDFormat 1.4.6 (2013-08-20)
+### libsdformat 1.4.6 (2013-08-20)
 
 1. Add tags for GPS sensor and sensor noise
     * [Pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/36/gps-sensor-sensor-noise-and-spherical)
@@ -1073,7 +1073,7 @@
     * [Pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/38/add-provide_feedback-for-bullet-joint)
 1. Various bug, style and test fixes
 
-### SDFormat 1.4.5 (2013-07-23)
+### libsdformat 1.4.5 (2013-07-23)
 
 1. Deprecated Gazebo's internal SDF code
 1. Use templatized Get functions for retrieving values from SDF files


### PR DESCRIPTION
When writing a response in https://github.com/RobotLocomotion/drake/pull/13105, I realized that this terminology should be put in sync with what's defined for this repo's [current README](https://github.com/osrf/sdformat/tree/96cc8d2fdfac192422268dd16d05b4c861e778e1#sdformat).

I dunno if I should change the PR titles themselves, but I do think there should a practice of explicitly disambiguating spec (SDFormat) vs. implementation (libsdformat), *especially* when it comes to describing version numbers (where both diverge heavily).

FYI @scpeters 