### PR TITLE
Cherry-pick [sdf4] Update BitBucket links -> sdf6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 
 build
 build_*

--- a/Changelog.md
+++ b/Changelog.md
@@ -175,24 +175,24 @@
 ### SDFormat 4.4.0 (2017-10-26)
 
 1. Add ODE parallelization parameters: threaded islands and position correction
-    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/380)
+    * [BitBucket pull request 380](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/380)
 
 1. surface.sdf: expand documentation of friction and slip coefficients
-    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/343)
+    * [BitBucket pull request 343](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/343)
 
 1. Add preserveFixedJoint option to the URDF parser
-    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/352)
+    * [BitBucket pull request 352](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/352)
 
 1. Add light as child of link
-    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/373)
+    * [BitBucket pull request 373](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/373)
 
 ### SDFormat 4.3.2 (2017-07-19)
 
 1. Add documentation for `Element::GetFirstElement()` and `Element::GetNextElement()`
-    * [BitBucket pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/341)
+    * [BitBucket pull request 341](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/341)
 
 1. Fix parser to read plugin child elements within an `<include>`
-    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/350)
+    * [BitBucket pull request 350](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/350)
 
 ### SDFormat 4.3.1 (2017-03-24)
 
@@ -203,83 +203,83 @@
 ### SDFormat 4.3.0 (2017-03-20)
 
 1. Choosing models with more recent sdf version with `<include>` tag
-    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/291)
+    * [BitBucket pull request 291](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/291)
     * [Issue 123](https://github.com/osrf/sdformat/issues/123)
 
 1. Added `<category_bitmask>` to 1.6 surface contact parameters
-    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/318)
+    * [BitBucket pull request 318](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/318)
 
 1. Support light insertion in state
-    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. Case insensitive boolean strings
-    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/322)
+    * [BitBucket pull request 322](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/322)
 
 1. Enable coverage testing
-    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/317)
+    * [BitBucket pull request 317](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/317)
 
 1. Add `friction_model` parameter to ode solver
-    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
-    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
+    * [Gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/1522)
 
 1. Added `sampling` parameter to `<heightmap>` SDF element.
-    * [BitBucket pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/293)
+    * [BitBucket pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/293)
 
 1. Added Migration guide
-    * [BitBucket pull request 290](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/290)
+    * [BitBucket pull request 290](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/290)
 
 1. Add cmake `@PKG_NAME@_LIBRARY_DIRS` variable to cmake config file
-    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/292)
+    * [BitBucket pull request 292](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/292)
 
 ### SDFormat 4.2.0 (2016-10-10)
 
 1. Added tag to specify ODE friction model.
-    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/294)
+    * [BitBucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
 
 1. Fix URDF to SDF `self_collide` bug.
-    * [BitBucket pull request 287](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/287)
+    * [BitBucket pull request 287](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/287)
 
 1. Added IMU orientation specification to SDF.
-    * [BitBucket pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/284)
+    * [BitBucket pull request 284](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/284)
 
 ### SDFormat 4.1.1 (2016-07-08)
 
 1. Added documentation and animation to `<actor>` element.
-    * [BitBucket pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/280)
+    * [BitBucket pull request 280](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/280)
 
 1. Added tag to specify initial joint position
-    * [BitBucket pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/279)
+    * [BitBucket pull request 279](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/279)
 
 ### SDFormat 4.1.0 (2016-04-01)
 
 1. Added SDF conversion functions to parser including sdf::convertFile and sdf::convertString.
-    * [BitBucket pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/266)
+    * [BitBucket pull request 266](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/266)
 
 1. Added an upload script
-    * [BitBucket pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/256)
+    * [BitBucket pull request 256](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/256)
 
 ### SDFormat 4.0.0 (2015-01-12)
 
 1. Boost pointers and boost::function in the public API have been replaced
    by their std::equivalents (C++11 standard)
 1. Move gravity and magnetic_field tags from physics to world
-    * [BitBucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/247)
+    * [BitBucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/247)
 1. Switch lump link prefix from lump:: to lump_
-    * [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/245)
+    * [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
 1. New <wind> element.
    A contribution from Olivier Crave
-    * [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/240)
+    * [BitBucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 1. Add scale to model state
-    * [BitBucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/246)
+    * [BitBucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/246)
 1. Use stof functions to parse hex strings as floating point params.
    A contribution from Rich Mattes
-    * [BitBucket pull request 250](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/250)
+    * [BitBucket pull request 250](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/250)
 1. Fix memory leaks.
    A contribution from Silvio Traversaro
-    * [BitBucket pull request 249](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/249)
+    * [BitBucket pull request 249](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/249)
 1. Update SDF to version 1.6: new style for representing the noise properties
    of an `imu`
-    * [BitBucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/243)
+    * [BitBucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
     * [BitBucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
 
 ## SDFormat 3.0
@@ -293,219 +293,219 @@
 ### SDFormat 3.7.0 (2015-11-20)
 
 1. Add spring pass through for sdf3
-    * [Design document](https://bitbucket.org/osrf/gazebo_design/pull-requests/23)
-    * [BitBucket pull request 242](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/242)
+    * [Design document](https://github.com/osrf/gazebo_design/pull-requests/23)
+    * [BitBucket pull request 242](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/242)
 
 1. Support frame specification in SDF
-    * [BitBucket pull request 237](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/237)
+    * [BitBucket pull request 237](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/237)
 
 1. Remove boost from SDFExtension
-    * [BitBucket pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/229)
+    * [BitBucket pull request 229](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/229)
 
 ### SDFormat 3.6.0 (2015-10-27)
 
 1. Add light state
-    * [BitBucket pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/227)
+    * [BitBucket pull request 227](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/227)
 1. redo pull request #222 for sdf3 branch
-    * [BitBucket pull request 232](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/232)
+    * [BitBucket pull request 232](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/232)
 1. Fix links in API documentation
-    * [BitBucket pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/231)
+    * [BitBucket pull request 231](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/231)
 
 ### SDFormat 3.5.0 (2015-10-07)
 
 1. Camera lens description (Replaces #213)
-    * [BitBucket pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/215)
+    * [BitBucket pull request 215](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/215)
 1. Fix shared pointer reference loop in Element and memory leak (#104)
-    * [BitBucket pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/230)
+    * [BitBucket pull request 230](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/230)
 
 ### SDFormat 3.4.0 (2015-10-05)
 
 1. Support nested model states
-    * [BitBucket pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/223)
+    * [BitBucket pull request 223](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/223)
 1. Cleaner way to set SDF_PATH for tests
-    * [BitBucket pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/226)
+    * [BitBucket pull request 226](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/226)
 
 ### SDFormat 3.3.0 (2015-09-15)
 
 1. Windows Boost linking errors
-    * [BitBucket pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/206)
+    * [BitBucket pull request 206](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/206)
 1. Nested SDF -> sdf3
-    * [BitBucket pull request 221](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/221)
+    * [BitBucket pull request 221](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/221)
 1. Pointer types
-    * [BitBucket pull request 218](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/218)
+    * [BitBucket pull request 218](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/218)
 1. Torsional friction default surface radius not infinity
-    * [BitBucket pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/217)
+    * [BitBucket pull request 217](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/217)
 
 ### SDFormat 3.2.2 (2015-08-24)
 
 1. Added battery element (contribution from Olivier Crave)
-    * [BitBucket pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
+    * [BitBucket pull request #204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
 1. Torsional friction backport
-    * [BitBucket pull request #211](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/211)
+    * [BitBucket pull request #211](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/211)
 1. Allow Visual Studio 2015
-    * [BitBucket pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/208)
+    * [BitBucket pull request #208](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/208)
 
 ### SDFormat 3.1.1 (2015-08-03)
 
 1. Fix tinyxml linking error
-    * [BitBucket pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/209)
+    * [BitBucket pull request #209](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/209)
 
 ### SDFormat 3.1.0 (2015-08-02)
 
 1. Added logical camera sensor to SDF
-    * [BitBucket pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/207)
+    * [BitBucket pull request #207](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/207)
 
 ### SDFormat 3.0.0 (2015-07-24)
 
 1. Added battery to SDF
-    * [BitBucket pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/204)
+    * [BitBucket pull request 204](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/204)
 1. Added altimeter sensor to SDF
-    * [BitBucket pull request #197](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/197)
+    * [BitBucket pull request #197](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/197)
 1. Added magnetometer sensor to SDF
-    * [BitBucket pull request 198](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/198)
+    * [BitBucket pull request 198](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/198)
 1. Fix detection of XML parsing errors
-    * [BitBucket pull request 190](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/190)
+    * [BitBucket pull request 190](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/190)
 1. Support for fixed joints
-    * [BitBucket pull request 194](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/194)
+    * [BitBucket pull request 194](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/194)
 1. Adding iterations to state
-    * [BitBucket pull request 188](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/188)
+    * [BitBucket pull request 188](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/188)
 1. Convert to use ignition-math
-    * [BitBucket pull request 173](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/173)
+    * [BitBucket pull request 173](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/173)
 1. Add world origin to scene
-    * [BitBucket pull request 183](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/183)
+    * [BitBucket pull request 183](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/183)
 1. Fix collide bitmask
-    * [BitBucket pull request 182](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/182)
+    * [BitBucket pull request 182](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/182)
 1. Adding meta information to visuals
-    * [BitBucket pull request 180](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/180)
+    * [BitBucket pull request 180](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/180)
 1. Add projection type to gui camera
-    * [BitBucket pull request 178](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/178)
+    * [BitBucket pull request 178](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/178)
 1. Fix print description to include attribute description
-    * [BitBucket pull request 170](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/170)
+    * [BitBucket pull request 170](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/170)
 1. Add -std=c++11 flag to sdf_config.cmake.in and sdformat.pc.in, needed by downstream code
-    * [BitBucket pull request 172](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/172)
+    * [BitBucket pull request 172](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/172)
 1. Added boost::any accessor for Param and Element
-    * [BitBucket pull request 166](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/166)
+    * [BitBucket pull request 166](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/166)
 1. Remove tinyxml from dependency list
-    * [BitBucket pull request 152](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/152)
+    * [BitBucket pull request 152](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/152)
 1. Added self_collide element for model
-    * [BitBucket pull request 149](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/149)
+    * [BitBucket pull request 149](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/149)
 1. Added a collision bitmask field to sdf-1.5 and c++11 support
-    * [BitBucket pull request 145](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/145)
+    * [BitBucket pull request 145](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/145)
 1. Fix problems with latin locales and decimal numbers (issue #60)
-    * [BitBucket pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/147)
+    * [BitBucket pull request 147](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/147)
     * [Issue 60](https://github.com/osrf/sdformat/issues/60)
 
 ## SDFormat 2.x
 
 1. rename cfm_damping --> implicit_spring_damper
-    * [BitBucket pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/59)
+    * [BitBucket pull request 59](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/59)
 1. add gear_ratio and reference_body for gearbox joint.
-    * [BitBucket pull request 62](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/62)
+    * [BitBucket pull request 62](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/62)
 1. Update joint stop stiffness and dissipation
-    * [BitBucket pull request 61](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/61)
+    * [BitBucket pull request 61](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/61)
 1. Support for GNUInstallDirs
-    * [BitBucket pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/64)
+    * [BitBucket pull request 64](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/64)
 1. `<use_true_size>` element used by DEM heightmaps
-    * [BitBucket pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/67)
+    * [BitBucket pull request 67](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/67)
 1. Do not export urdf symbols in sdformat 1.4
-    * [BitBucket pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/75)
+    * [BitBucket pull request 75](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/75)
 1. adding deformable properties per issue #32
-    * [BitBucket pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/78)
+    * [BitBucket pull request 78](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/78)
     * [Issue 32](https://github.com/osrf/sdformat/issues/32)
 1. Support to use external URDF
-    * [BitBucket pull request 77](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/77)
+    * [BitBucket pull request 77](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/77)
 1. Add lighting element to visual
-    * [BitBucket pull request 79](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/79)
+    * [BitBucket pull request 79](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/79)
 1. SDF 1.5: add flag to fix joint axis frame #43 (gazebo issue 494)
-    * [BitBucket pull request 83](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/83)
+    * [BitBucket pull request 83](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/83)
     * [Issue 43](https://github.com/osrf/sdformat/issues/43)
     * [Gazebo issue 494](https://github.com/osrf/gazebo/issues/494)
 1. Implement SDF_PROTOCOL_VERSION (issue #51)
-    * [BitBucket pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/90)
+    * [BitBucket pull request 90](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/90)
 1. Port sdformat to compile on Windows (MSVC)
-    * [BitBucket pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/101)
+    * [BitBucket pull request 101](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/101)
 1. Separate material properties in material.sdf
-    * [BitBucket pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/104)
+    * [BitBucket pull request 104](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/104)
 1. Add road textures (repeat pull request #104 for sdf_2.0)
-    * [BitBucket pull request 105](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/105)
+    * [BitBucket pull request 105](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/105)
 1. Add Extruded Polylines as a model
-    * [BitBucket pull request 93](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/93)
+    * [BitBucket pull request 93](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/93)
 1. Added polyline for sdf_2.0
-    * [BitBucket pull request 106](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/106)
+    * [BitBucket pull request 106](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/106)
 1. Add spring_reference and spring_stiffness tags to joint axis dynamics
-    * [BitBucket pull request 102](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/102)
+    * [BitBucket pull request 102](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/102)
 1. Fix actor static
-    * [BitBucket pull request 110](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/110)
+    * [BitBucket pull request 110](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/110)
 1. New <Population> element
-    * [BitBucket pull request 112](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/112)
+    * [BitBucket pull request 112](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/112)
 1. Add camera distortion element
-    * [BitBucket pull request 120](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/120)
+    * [BitBucket pull request 120](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/120)
 1. Inclusion of magnetic field strength sensor
-    * [BitBucket pull request 123](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/123)
+    * [BitBucket pull request 123](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/123)
 1. Properly add URDF gazebo extensions blobs to SDF joint elements
-    * [BitBucket pull request 125](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/125)
+    * [BitBucket pull request 125](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/125)
 1. Allow gui plugins to be specified in SDF
-    * [BitBucket pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/127)
+    * [BitBucket pull request 127](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/127)
 1. Backport magnetometer
-    * [BitBucket pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/128)
+    * [BitBucket pull request 128](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/128)
 1. Add flag for MOI rescaling to sdf 1.4
-    * [BitBucket pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/121)
+    * [BitBucket pull request 121](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/121)
 1. Parse urdf joint friction parameters, add corresponding test
-    * [BitBucket pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/129)
+    * [BitBucket pull request 129](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/129)
 1. Allow reading of boolean values from plugin elements.
-    * [BitBucket pull request 132](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/132)
+    * [BitBucket pull request 132](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/132)
 1. Implement generation of XML Schema files (issue #2)
-    * [BitBucket pull request 91](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/91)
+    * [BitBucket pull request 91](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/91)
 1. Fix build for OS X 10.10
-    * [BitBucket pull request 135](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/135)
+    * [BitBucket pull request 135](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/135)
 1. Improve performance in loading <include> SDF elements
-    * [BitBucket pull request 138](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/138)
+    * [BitBucket pull request 138](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/138)
 1. Added urdf gazebo extension option to disable fixed joint lumping
-    * [BitBucket pull request 133](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/133)
+    * [BitBucket pull request 133](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/133)
 1. Support urdfdom 0.3 (alternative to pull request #122)
-    * [BitBucket pull request 141](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/141)
+    * [BitBucket pull request 141](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/141)
 1. Update list of supported joint types
-    * [BitBucket pull request 142](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/142)
+    * [BitBucket pull request 142](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/142)
 1. Ignore unknown elements
-    * [BitBucket pull request 148](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/148)
+    * [BitBucket pull request 148](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/148)
 1. Physics preset attributes
-    * [BitBucket pull request 146](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/146)
+    * [BitBucket pull request 146](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/146)
 1. Backport fix for latin locales (pull request #147)
-    * [BitBucket pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/150)
+    * [BitBucket pull request 150](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/150)
 
 ## SDFormat 1.4
 
 ### SDFormat 1.4.8 (2013-09-06)
 
 1. Fix inertia transformations when reducing fixed joints in URDF
-    * [BitBucket pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/48/fix-for-issue-22-reducing-inertia-across/diff)
+    * [BitBucket pull request 48](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/48/fix-for-issue-22-reducing-inertia-across/diff)
 1. Add <use_terrain_paging> element to support terrain paging in gazebo
-    * [BitBucket pull request 47](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/47/add-element-inside-heightmap/diff)
+    * [BitBucket pull request 47](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/47/add-element-inside-heightmap/diff)
 1. Further reduce console output when using URDF models
-    * [BitBucket pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
+    * [BitBucket pull request 46](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/46/convert-a-few-more-sdfwarns-to-sdflog-fix/diff)
     * [Commit](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/commits/b15d5a1ecc57abee6691618d02d59bbc3d1b84dc)
 
 ### SDFormat 1.4.7 (2013-08-22)
 
 1. Direct console messages to std_err
-    * [BitBucket pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/44/fix-19-direct-all-messages-to-std_err)
+    * [BitBucket pull request 44](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/44/fix-19-direct-all-messages-to-std_err)
 
 ### SDFormat 1.4.6 (2013-08-20)
 
 1. Add tags for GPS sensor and sensor noise
-    * [BitBucket pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/36/gps-sensor-sensor-noise-and-spherical)
+    * [BitBucket pull request 36](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/36/gps-sensor-sensor-noise-and-spherical)
 1. Add tags for wireless transmitter/receiver models
-    * [BitBucket pull request 34](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/34/transceiver-support)
-    * [BitBucket pull request 43](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/43/updated-description-of-the-transceiver-sdf)
+    * [BitBucket pull request 34](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/34/transceiver-support)
+    * [BitBucket pull request 43](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/43/updated-description-of-the-transceiver-sdf)
 1. Add tags for playback of audio files in Gazebo
-    * [BitBucket pull request 26](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/26/added-audio-tags)
-    * [BitBucket pull request 35](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/35/move-audio-to-link-and-playback-on-contact)
+    * [BitBucket pull request 26](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/26/added-audio-tags)
+    * [BitBucket pull request 35](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/35/move-audio-to-link-and-playback-on-contact)
 1. Add tags for simbody physics parameters
-    * [BitBucket pull request 32](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/32/merging-some-updates-from-simbody-branch)
+    * [BitBucket pull request 32](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/32/merging-some-updates-from-simbody-branch)
 1. Log messages to a file, reduce console output
-    * [BitBucket pull request 33](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/33/log-messages-to-file-8)
+    * [BitBucket pull request 33](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/33/log-messages-to-file-8)
 1. Generalize ode's <provide_feedback> element
-    * [BitBucket pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/38/add-provide_feedback-for-bullet-joint)
+    * [BitBucket pull request 38](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/38/add-provide_feedback-for-bullet-joint)
 1. Various bug, style and test fixes
 
 ### SDFormat 1.4.5 (2013-07-23)

--- a/Migration.md
+++ b/Migration.md
@@ -90,7 +90,7 @@ but with improved human-readability..
 
 1. **Lump:: prefix in link names**
     + Changed to \_fixed_joint_lump__ to avoid confusion with scoped names
-    + [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/245)
+    + [BitBucket pull request 245](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/245)
 
 ## SDF protocol 1.5 to 1.6
 
@@ -177,7 +177,7 @@ but with improved human-readability..
     + [BitBucket pull request 495](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/495)
 
 1. **state.sdf** allow `light` tags within `insertions` element
-    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-request/325)
+    * [BitBucket pull request 325](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/325)
 
 1. **surface.sdf** `category_bitmask` element
     + description: Bitmask for category of collision filtering.

--- a/sdf/1.4/physics.sdf
+++ b/sdf/1.4/physics.sdf
@@ -177,7 +177,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.5/joint.sdf
+++ b/sdf/1.5/joint.sdf
@@ -55,7 +55,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">
@@ -114,7 +114,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">

--- a/sdf/1.5/physics.sdf
+++ b/sdf/1.5/physics.sdf
@@ -189,7 +189,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/1.6/joint.sdf
+++ b/sdf/1.6/joint.sdf
@@ -60,7 +60,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">
@@ -124,7 +124,7 @@
       <description>
         Flag to interpret the axis xyz element in the parent model frame instead
         of joint frame. Provided for Gazebo compatibility
-        (see https://bitbucket.org/osrf/gazebo/issue/494 ).
+        (see https://github.com/osrf/gazebo/issue/494 ).
       </description>
     </element>
     <element name="dynamics" required="0">

--- a/sdf/1.6/physics.sdf
+++ b/sdf/1.6/physics.sdf
@@ -200,7 +200,7 @@
         <description>
           Flag to enable dynamic rescaling of moment of inertia in constrained directions.
           See gazebo pull request 1114 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1114
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1114
         </description>
       </element>
       <element name="friction_model" type="string" default="pyramid_model" required="0">
@@ -213,8 +213,8 @@
           cone_model: friction force magnitude limited in proportion to normal force.
 
           See gazebo pull request 1522 for the implementation of this feature.
-          https://bitbucket.org/osrf/gazebo/pull-request/1522
-          https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c
+          https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522
+          https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f
         </description>
       </element>
     </element> <!-- End Solver -->

--- a/sdf/Migration.md
+++ b/sdf/Migration.md
@@ -24,14 +24,14 @@ but with improved human-readability.
     + type: unsigned int
     + default: 2
     + required: 0
-    + [pull request 293](https://bitbucket.org/osrf/sdformat/pull-requests/293)
+    + [Bitbucket pull request 293](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/293)
 
 1. **link.sdf** `enable_wind` element
     + description: If true, the link is affected by the wind
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **model.sdf** `enable_wind` element
     + description: If set to true, all links in the model
@@ -40,14 +40,14 @@ but with improved human-readability.
     + type: bool
     + default: false
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **model_state.sdf** `scale` element
     + description: Scale for the 3 dimensions of the model.
     + type: vector3
     + default: "1 1 1"
     + required: 0
-    + [pull request 246](https://bitbucket.org/osrf/sdformat/pull-requests/246)
+    + [Bitbucket pull request 246](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/246)
 
 1. **physics.sdf** `friction_model` element
     + description: Name of ODE friction model to use. Valid values include:
@@ -55,39 +55,39 @@ but with improved human-readability.
           in proportion to normal force.
         + box_model: friction forces limited to constant in two directions.
         + cone_model: friction force magnitude limited in proportion to normal force.
-          See [gazebo pull request 1522](https://bitbucket.org/osrf/gazebo/pull-request/1522)
-          (merged in [gazebo 8c05ad64967c](https://bitbucket.org/osrf/gazebo/commits/8c05ad64967c))
+          See [gazebo pull request 1522](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-request/1522)
+          (merged in [gazebo 8c05ad64967c](https://github.com/osrf/gazebo/commit/968dccafdfbfca09c9b3326f855612076fed7e6f))
           for the implementation of this feature.
     + type: string
     + default: "pyramid_model"
     + required: 0
-    + [pull request 294](https://bitbucket.org/osrf/sdformat/pull-requests/294)
+    + [Bitbucket pull request 294](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/294)
 
 1. **world.sdf** `wind` element
     + description: The wind tag specifies the type and properties of the wind.
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 1. **world.sdf** `wind::linear_velocity` element
     + description: Linear velocity of the wind.
     + type: vector3
     + default: "0 0 0"
     + required: 0
-    + [pull request 240](https://bitbucket.org/osrf/sdformat/pull-requests/240)
+    + [Bitbucket pull request 240](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/240)
 
 ### Modifications
 
 1. `gravity` and `magnetic_field` elements are moved
     from `physics` to `world`
-    + [pull request 247](https://bitbucket.org/osrf/sdformat/pull-requests/247)
-    + [gazebo pull request 2090](https://bitbucket.org/osrf/gazebo/pull-requests/2090)
+    + [Bitbucket pull request 247](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/247)
+    + [gazebo pull request 2090](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2090)
 
 1. A new style for representing the noise properties of an `imu` was implemented
-   in [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
+   in [Bitbucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
    for sdf 1.5 and the old style was declared as deprecated.
    The old style has been removed from sdf 1.6 with the conversion script
    updating to the new style.
-    + [pull request 199](https://bitbucket.org/osrf/sdformat/pull-requests/199)
-    + [pull request 243](https://bitbucket.org/osrf/sdformat/pull-requests/243)
-    + [pull request 244](https://bitbucket.org/osrf/sdformat/pull-requests/244)
+    + [Bitbucket pull request 199](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/199)
+    + [Bitbucket pull request 243](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/243)
+    + [Bitbucket pull request 244](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/244)
 

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -158,7 +158,7 @@ TEST(Param, HexUInt)
 TEST(Param, HexFloat)
 {
 // Microsoft does not parse hex values properly.
-// https://bitbucket.org/osrf/sdformat/issues/114
+// https://github.com/osrf/sdformat/issues/114
 #ifndef _MSC_VER
   sdf::Param floatParam("key", "float", "0", false, "description");
   float value;
@@ -193,7 +193,7 @@ TEST(Param, HexDouble)
   EXPECT_DOUBLE_EQ(value, 0.0);
 
 // Microsoft does not parse hex values properly.
-// https://bitbucket.org/osrf/sdformat/issues/114
+// https://github.com/osrf/sdformat/issues/114
 #ifndef _MSC_VER
   EXPECT_TRUE(doubleParam.SetFromString("0x01"));
   EXPECT_TRUE(doubleParam.Get<double>(value));


### PR DESCRIPTION
Cherry-picking #248 forward to `sdf6` as an alternative to #257.