### PR TITLE
Collision: don't load Surface without <surface>

### DIFF
--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -130,8 +130,11 @@ Errors Collision::Load(ElementPtr _sdf)
   Errors geomErr = this->dataPtr->geom.Load(_sdf->GetElement("geometry"));
   errors.insert(errors.end(), geomErr.begin(), geomErr.end());
 
-  // Load the surface parameters
-  this->dataPtr->surface.Load(_sdf->GetElement("surface"));
+  // Load the surface parameters if they are given
+  if (_sdf->HasElement("surface"))
+  {
+    this->dataPtr->surface.Load(_sdf->GetElement("surface"));
+  }
 
   return errors;
 }


### PR DESCRIPTION
There was a minor behavior change in [Bitbucket pull request 660](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/660) that started adding empty `<surface>` elements to the sdf element in a Collision DOM element if it didn't already have a `<surface>` element. This has caused some issues for downstream users ( https://github.com/RobotLocomotion/drake/pull/13201 ), and it's a minor thing to change, so I've reverted the behavior change. I also recommended where to change the downstream code to be less brittle ( https://github.com/RobotLocomotion/drake/pull/13201#issuecomment-622613872 ).

This was originally reported in https://github.com/osrf/sdformat/issues/267.