### PR TITLE
Changelog: Explicitly cite "Custom elements and attributes" proposal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -154,6 +154,9 @@
 
 1. Enforce rules about reserved names and unique names among sibling elements.
     * [BitBucket pull request 600](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/600)
+    * This also implements changes necessary for parsing custom elements and
+    attributes per the following proposal:
+    [Custom elements and attributes](http://sdformat.org/tutorials?tut=custom_elements_attributes_proposal)
 
 1. Relax name checking, so name collisions generate warnings and names are automatically changed.
     * [BitBucket pull request 621](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/621)


### PR DESCRIPTION
It was hard to trace the implementation of this proposal; from https://github.com/ros/urdfdom_headers/issues/59#issuecomment-626209288, I ended up finding it in this commit and PR:
> ~(Er, not sure where this is in the release notes; will try to find.)~
> EDIT: Took more sleuthing than desirable, but it's this spot:
> https://github.com/osrf/sdformat/blame/3bbd303c8b94b20244d102eae095ffcbaa4c550d/Changelog.md#L143-L144
> https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/600