### PR TITLE
Don't install deprecated parser_urdf.hh header

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### libsdformat 10.0.0 (202X-XX-XX)
 
+1. Don't install deprecated parser_urdf.hh header file, fix cmake warning about newline file, fix cmake warning about newlines.
+    * [Pull request 276](https://github.com/osrf/sdformat/pull/276)
+
 1. Changed the default radius of a Cylinder from 1.0 to 0.5 meters.
     * [BitBucket pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,15 @@
 
 ### libsdformat 9.X.X (202X-XX-XX)
 
+1. Change bitbucket links to GitHub.
+    * [Pull request 240](https://github.com/osrf/sdformat/pull/240)
+
+1. Collision: don't load Surface without `<surface>`.
+    * [Pull request 268](https://github.com/osrf/sdformat/pull/268)
+
+1. Properly handle the requirement of C++17 at the CMake exported target level.
+    * [Pull request 251](https://github.com/osrf/sdformat/pull/251)
+
 1. Fix homebrew build with external urdfdom.
     * [BitBucket pull request 677](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/677)
     * [BitBucket pull request 686](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/686)

--- a/cmake/SDFUtils.cmake
+++ b/cmake/SDFUtils.cmake
@@ -156,12 +156,12 @@ macro (sdf_build_tests)
     link_directories(${IGNITION-MATH_LIBRARY_DIRS})
 
     if (USE_EXTERNAL_TINYXML)
-      target_link_libraries(${BINARY_NAME}
+      target_link_libraries(${BINARY_NAME} PRIVATE
         ${tinyxml_LIBRARIES})
     endif()
 
     if (UNIX)
-      target_link_libraries(${BINARY_NAME}
+      target_link_libraries(${BINARY_NAME} PRIVATE
         libgtest.a
         libgtest_main.a
         ${sdf_target}
@@ -169,7 +169,7 @@ macro (sdf_build_tests)
         ${IGNITION-MATH_LIBRARIES}
       )
     elseif(WIN32)
-      target_link_libraries(${BINARY_NAME}
+      target_link_libraries(${BINARY_NAME} PRIVATE
         gtest.lib
         gtest_main.lib
         ${sdf_target}

--- a/include/sdf/CMakeLists.txt
+++ b/include/sdf/CMakeLists.txt
@@ -55,5 +55,5 @@ endforeach()
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/sdf.hh.in
                 ${CMAKE_CURRENT_BINARY_DIR}/sdf.hh)
 
-sdf_install_includes("" ${headers} parser_urdf.hh
+sdf_install_includes("" ${headers}
   ${CMAKE_CURRENT_BINARY_DIR}/sdf.hh)

--- a/include/sdf/CMakeLists.txt
+++ b/include/sdf/CMakeLists.txt
@@ -49,8 +49,7 @@ set (headers
 
 set (sdf_headers "" CACHE INTERNAL "SDF headers" FORCE)
 foreach (hdr ${headers})
-  APPEND_TO_CACHED_STRING(sdf_headers
-    "SDF Headers" "#include <sdf/${hdr}>\n")
+  set(sdf_headers "${sdf_headers}#include <sdf/${hdr}>\n")
 endforeach()
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/sdf.hh.in
                 ${CMAKE_CURRENT_BINARY_DIR}/sdf.hh)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,6 @@ set (gtest_sources
   Mesh_TEST.cc
   Model_TEST.cc
   Noise_TEST.cc
-  parser_urdf_TEST.cc
   Param_TEST.cc
   parser_TEST.cc
   Pbr_TEST.cc
@@ -161,6 +160,18 @@ endif()
 if (NOT WIN32)
   set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Converter.cc EmbeddedSdf.cc)
   sdf_build_tests(Converter_TEST.cc)
+endif()
+
+if (NOT WIN32)
+  set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS SDFExtension.cc parser_urdf.cc)
+  sdf_build_tests(parser_urdf_TEST.cc)
+  if (NOT USE_INTERNAL_URDF)
+    target_compile_options(UNIT_parser_urdf_TEST PRIVATE ${URDF_CFLAGS})
+    if (${CMAKE_VERSION} VERSION_GREATER 3.13)
+      target_link_options(UNIT_parser_urdf_TEST PRIVATE ${URDF_LDFLAGS})
+    endif()
+    target_link_libraries(UNIT_parser_urdf_TEST PRIVATE ${URDF_LIBRARIES})
+  endif()
 endif()
 
 sdf_add_library(${sdf_target} ${sources})

--- a/src/SDFExtension.hh
+++ b/src/SDFExtension.hh
@@ -120,9 +120,7 @@ namespace sdf
     // blobs into body or robot
     public: std::vector<std::shared_ptr<TiXmlElement> > blobs;
 
-    SDF_SUPPRESS_DEPRECATED_BEGIN
     friend class URDF2SDF;
-    SDF_SUPPRESS_DEPRECATED_END
   };
   }
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -33,12 +33,12 @@
 #include "sdf/SDFImpl.hh"
 #include "sdf/World.hh"
 #include "sdf/parser.hh"
-#include "sdf/parser_urdf.hh"
 #include "sdf/sdf_config.h"
 
 #include "Converter.hh"
 #include "FrameSemantics.hh"
 #include "parser_private.hh"
+#include "parser_urdf.hh"
 
 namespace sdf
 {
@@ -406,7 +406,6 @@ bool readFileInternal(const std::string &_filename, SDFPtr _sdf,
   }
 
   // Suppress deprecation for sdf::URDF2SDF
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   if (readDoc(&xmlDoc, _sdf, filename, _convert, _errors))
   {
     return true;
@@ -426,7 +425,6 @@ bool readFileInternal(const std::string &_filename, SDFPtr _sdf,
       return false;
     }
   }
-  SDF_SUPPRESS_DEPRECATED_END
 
   return false;
 }
@@ -474,9 +472,7 @@ bool readStringInternal(const std::string &_xmlString, SDFPtr _sdf,
   }
   else
   {
-    SDF_SUPPRESS_DEPRECATED_BEGIN
     URDF2SDF u2g;
-    SDF_SUPPRESS_DEPRECATED_END
     TiXmlDocument doc = u2g.InitModelString(_xmlString);
     if (sdf::readDoc(&doc, _sdf, "urdf string", _convert, _errors))
     {

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -31,10 +31,10 @@
 #include <urdf_model/link.h>
 #include <urdf_parser/urdf_parser.h>
 
-#include "sdf/parser_urdf.hh"
 #include "sdf/sdf.hh"
 
 #include "SDFExtension.hh"
+#include "parser_urdf.hh"
 
 using namespace sdf;
 

--- a/src/parser_urdf.hh
+++ b/src/parser_urdf.hh
@@ -37,7 +37,7 @@ namespace sdf
   /// This is now deprecated for external usage and will be removed in the next
   /// major version of libsdformat. Instead, consider using `sdf::readFile` or
   /// `sdf::readString`, which automatically convert URDF to SDF.
-  class SDFORMAT_VISIBLE SDF_DEPRECATED(9.2) URDF2SDF
+  class URDF2SDF
   {
     /// \brief constructor
     public: URDF2SDF();
@@ -68,15 +68,15 @@ namespace sdf
     /// \return True if _filename is a URDF model.
     public: static bool IsURDF(const std::string &_filename);
 
+    /// list extensions for debugging
+    public: void ListSDFExtensions();
+
+    /// list extensions for debugging
+    public: void ListSDFExtensions(const std::string &_reference);
+
     /// things that do not belong in urdf but should be mapped into sdf
     /// @todo: do this using sdf definitions, not hard coded stuff
     private: void ParseSDFExtension(TiXmlDocument &_urdfXml);
-
-    /// list extensions for debugging
-    private: void ListSDFExtensions();
-
-    /// list extensions for debugging
-    private: void ListSDFExtensions(const std::string &_reference);
   };
   }
 }

--- a/src/parser_urdf_TEST.cc
+++ b/src/parser_urdf_TEST.cc
@@ -20,7 +20,7 @@
 #include <list>
 
 #include "sdf/sdf.hh"
-#include "sdf/parser_urdf.hh"
+#include "parser_urdf.hh"
 
 /////////////////////////////////////////////////
 std::string getMinimalUrdfTxt()
@@ -35,9 +35,7 @@ std::string getMinimalUrdfTxt()
 /////////////////////////////////////////////////
 std::string convertUrdfStrToSdfStr(const std::string &_urdf)
 {
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   TiXmlDocument sdf_result = parser_.InitModelString(_urdf);
   TiXmlPrinter printer;
   sdf_result.Accept(&printer);
@@ -55,27 +53,23 @@ void convertUrdfStrToSdf(const std::string &_urdf, sdf::SDF &_sdf)
 TEST(URDFParser, InitModelDoc_EmptyDoc_NoThrow)
 {
   // Suppress deprecation for sdf::URDF2SDF
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   ASSERT_NO_THROW(
     TiXmlDocument doc = TiXmlDocument();
     sdf::URDF2SDF parser_;
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   );    // NOLINT(whitespace/parens)
-  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////
 TEST(URDFParser, InitModelDoc_BasicModel_NoThrow)
 {
   // Suppress deprecation for sdf::URDF2SDF
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   ASSERT_NO_THROW(
     TiXmlDocument doc;
     doc.Parse(getMinimalUrdfTxt().c_str());
     sdf::URDF2SDF parser_;
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   );    // NOLINT(whitespace/parens)
-  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////
@@ -84,9 +78,7 @@ TEST(URDFParser, ParseResults_BasicModel_ParseEqualToModel)
   // URDF -> SDF
   TiXmlDocument doc;
   doc.Parse(getMinimalUrdfTxt().c_str());
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   std::string sdf_result_str;
   sdf_result_str << sdf_result;
@@ -115,9 +107,7 @@ TEST(URDFParser, ParseRobotOriginXYZBlank)
          << "</robot>";
   TiXmlDocument doc;
   doc.Parse(stream.str().c_str());
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   TiXmlElement *sdf = sdf_result.FirstChildElement("sdf");
   ASSERT_NE(nullptr, sdf);
@@ -136,9 +126,7 @@ TEST(URDFParser, ParseRobotOriginRPYBlank)
          << "  <link name=\"link\" />"
          << "</robot>";
   TiXmlDocument doc;
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   doc.Parse(stream.str().c_str());
   TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   TiXmlElement *sdf = sdf_result.FirstChildElement("sdf");
@@ -172,9 +160,7 @@ TEST(URDFParser, ParseRobotMaterialBlank)
          << "</robot>";
   TiXmlDocument doc;
   doc.Parse(stream.str().c_str());
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser;
-  SDF_SUPPRESS_DEPRECATED_END
   auto sdfXml = parser.InitModelDoc(&doc);
   auto sdfElem = sdfXml.FirstChildElement("sdf");
   ASSERT_NE(nullptr, sdfElem);
@@ -187,6 +173,9 @@ TEST(URDFParser, ParseRobotMaterialBlank)
 
   auto materialElem = visualElem->FirstChildElement("material");
   ASSERT_EQ(nullptr, materialElem);
+
+  parser.ListSDFExtensions();
+  parser.ListSDFExtensions("link");
 }
 
 /////////////////////////////////////////////////
@@ -212,9 +201,7 @@ TEST(URDFParser, ParseRobotMaterialName)
          << "</robot>";
   TiXmlDocument doc;
   doc.Parse(stream.str().c_str());
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser;
-  SDF_SUPPRESS_DEPRECATED_END
   auto sdfXml = parser.InitModelDoc(&doc);
   auto sdfElem = sdfXml.FirstChildElement("sdf");
   ASSERT_NE(nullptr, sdfElem);
@@ -236,6 +223,9 @@ TEST(URDFParser, ParseRobotMaterialName)
   ASSERT_NE(nullptr, uriElem);
   EXPECT_EQ("file://media/materials/scripts/gazebo.material",
       std::string(uriElem->GetText()));
+
+  parser.ListSDFExtensions();
+  parser.ListSDFExtensions("link");
 }
 
 /////////////////////////////////////////////////
@@ -247,9 +237,7 @@ TEST(URDFParser, ParseRobotOriginInvalidXYZ)
          << "  <link name=\"link\" />"
          << "</robot>";
   TiXmlDocument doc;
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   doc.Parse(stream.str().c_str());
   TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
   TiXmlElement *sdf = sdf_result.FirstChildElement("sdf");
@@ -310,9 +298,7 @@ TEST(URDFParser, ParseGazeboLinkFactors)
            << "</robot>";
 
     TiXmlDocument doc;
-    SDF_SUPPRESS_DEPRECATED_BEGIN
     sdf::URDF2SDF parser_;
-    SDF_SUPPRESS_DEPRECATED_END
     doc.Parse(stream.str().c_str());
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
@@ -329,6 +315,9 @@ TEST(URDFParser, ParseGazeboLinkFactors)
 
     // For the last element, check that it is exactly what we expect
     EXPECT_EQ(tmp->FirstChild()->ValueStr(), it->second[i]);
+
+    parser_.ListSDFExtensions();
+    parser_.ListSDFExtensions("wheel_left_link");
   }
 }
 
@@ -348,12 +337,13 @@ TEST(URDFParser, ParseGazeboInvalidDampingFactor)
          << "  </gazebo>"
          << "</robot>";
   TiXmlDocument doc;
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser_;
-  SDF_SUPPRESS_DEPRECATED_END
   doc.Parse(stream.str().c_str());
   ASSERT_THROW(TiXmlDocument sdf_result = parser_.InitModelDoc(&doc),
                std::invalid_argument);
+
+  parser_.ListSDFExtensions();
+  parser_.ListSDFExtensions("link");
 }
 
 /////////////////////////////////////////////////
@@ -419,9 +409,7 @@ TEST(URDFParser, ParseGazeboJointElements)
            << "</robot>";
 
     TiXmlDocument doc;
-    SDF_SUPPRESS_DEPRECATED_BEGIN
     sdf::URDF2SDF parser_;
-    SDF_SUPPRESS_DEPRECATED_END
     doc.Parse(stream.str().c_str());
     TiXmlDocument sdf_result = parser_.InitModelDoc(&doc);
 
@@ -438,6 +426,9 @@ TEST(URDFParser, ParseGazeboJointElements)
 
     // For the last element, check that it is exactly what we expect
     EXPECT_EQ(tmp->FirstChild()->ValueStr(), it->second[i]);
+
+    parser_.ListSDFExtensions();
+    parser_.ListSDFExtensions("head_j0");
   }
 }
 
@@ -807,9 +798,7 @@ TEST(URDFParser, OutputPrecision)
         </link>
     </robot>)";
 
-  SDF_SUPPRESS_DEPRECATED_BEGIN
   sdf::URDF2SDF parser;
-  SDF_SUPPRESS_DEPRECATED_END
   TiXmlDocument sdfResult = parser.InitModelString(str);
 
   auto root = sdfResult.RootElement();

--- a/test/integration/element_memory_leak.cc
+++ b/test/integration/element_memory_leak.cc
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 #include "sdf/sdf.hh"
-#include "sdf/parser_urdf.hh"
 
 #include "test_config.h"
 

--- a/test/integration/locale_fix.cc
+++ b/test/integration/locale_fix.cc
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 #include "sdf/sdf.hh"
-#include "sdf/parser_urdf.hh"
 
 #include "test_config.h"
 

--- a/test/performance/parser_urdf.cc
+++ b/test/performance/parser_urdf.cc
@@ -20,7 +20,6 @@
 #include <gtest/gtest.h>
 
 #include "sdf/sdf.hh"
-#include "sdf/parser_urdf.hh"
 
 #include "test_config.h"
 


### PR DESCRIPTION
The `URDF2SDF` class in `parser_urdf.hh` was deprecated in [bitbucket pr #658](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/658/page/1), and I believe the plan was to remove it from the public API in `libsdformat10`, so this PR removes it from the list of installed headers and moves it to the `src` folder.

I included two additional changes:

* 5e99d80: I removed the deprecation macros from the private header as well as the warning suppression macros.
* 04f84ec: fix a cmake warning about multiline strings (see also https://github.com/osrf/gazebo/issues/2664 and [bitbucket gazebo pr #3138](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/3138/page/1))

~~I did not remove the `SDFORMAT_VISIBLE` macro for `URDF2SDF` as it was starting to take a while to figure out how to fix it, so I just left that part out.~~ I removed the `SDFORMAT_VISIBLE` macro in b763472.