### PR TITLE
Param_TEST: test parsing +Inf and -Inf

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@
 1. Change bitbucket links to GitHub.
     * [Pull request 240](https://github.com/osrf/sdformat/pull/240)
 
+1. Param_TEST: test parsing +Inf and -Inf.
+    * [Pull request 277](https://github.com/osrf/sdformat/pull/277)
+
+1. Observe the CMake variable `BUILD_TESTING` if it is defined.
+    * [Pull request 269](https://github.com/osrf/sdformat/pull/269)
+
 1. Collision: don't load Surface without `<surface>`.
     * [Pull request 268](https://github.com/osrf/sdformat/pull/268)
 

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <any>
 #include <cstdint>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -25,7 +26,7 @@
 #include "sdf/Exception.hh"
 #include "sdf/Param.hh"
 
-bool check_double(std::string num)
+bool check_double(const std::string &num)
 {
   const std::string name = "number";
   const std::string type = "double";
@@ -98,6 +99,42 @@ TEST(Param, Bool)
 TEST(SetFromString, Decimals)
 {
   ASSERT_TRUE(check_double("0.2345"));
+}
+
+////////////////////////////////////////////////////
+/// Test Inf
+TEST(SetFromString, DoublePositiveInf)
+{
+  ASSERT_TRUE(std::numeric_limits<double>::has_infinity);
+  std::vector<std::string> positiveInfStrings{
+    "inf", "Inf", "INF", "+inf", "+Inf", "+INF"};
+  for (const auto &infString : positiveInfStrings)
+  {
+    sdf::Param doubleParam("key", "double", "0", false, "description");
+    double value = 0.;
+
+    EXPECT_TRUE(doubleParam.SetFromString(infString));
+    doubleParam.Get<double>(value);
+    EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), value);
+  }
+}
+
+////////////////////////////////////////////////////
+/// Test -Inf
+TEST(SetFromString, DoubleNegativeInf)
+{
+  ASSERT_TRUE(std::numeric_limits<double>::is_iec559);
+  std::vector<std::string> negativeInfStrings{
+    "-inf", "-Inf", "-INF"};
+  for (const auto &infString : negativeInfStrings)
+  {
+    sdf::Param doubleParam("key", "double", "0", false, "description");
+    double value = 0.;
+
+    EXPECT_TRUE(doubleParam.SetFromString(infString));
+    doubleParam.Get<double>(value);
+    EXPECT_DOUBLE_EQ(- std::numeric_limits<double>::infinity(), value);
+  }
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
This adds a test confirming that "Inf", "+Inf', and "-Inf" and several lower-case and upper-case variations will parse to the `double` value of `std::numeric_limits<double>::infinity` or `-std::numeric_limits<double>::infinity` (as long as `std::numeric_limits<double>::is_iec559` is true).

Closes #261.