### PR TITLE
Bump master branch to major version 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(UNIX AND NOT WIN32)
  endif(CMAKE_UNAME)
 endif()
 
-project (sdformat10)
+project (sdformat11)
 
 # The protocol version has nothing to do with the package version set below.
 # It represents the current version of sdformat implement by the software

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ project (sdformat10)
 # It represents the current version of sdformat implement by the software
 set (SDF_PROTOCOL_VERSION 1.8)
 
-set (SDF_MAJOR_VERSION 10)
+set (SDF_MAJOR_VERSION 11)
 set (SDF_MINOR_VERSION 0)
 set (SDF_PATCH_VERSION 0)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,15 @@
+## libsdformat 11.X
+
+### libsdformat 11.X.X (202X-XX-XX)
+
+### libsdformat 11.0.0 (202X-XX-XX)
+
+1. Initial version of SDFormat 1.8 specification.
+    * [BitBucket pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
+
+1. SDFormat 1.8: Deprecate //joint/axis/initial_position.
+    * [BitBucket pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
+
 ## libsdformat 10.X
 
 ### libsdformat 10.X.X (202X-XX-XX)
@@ -9,12 +21,6 @@
 
 1. Changed the default radius of a Cylinder from 1.0 to 0.5 meters.
     * [BitBucket pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)
-
-1. Initial version of SDFormat 1.8 specification.
-    * [BitBucket pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
-
-1. SDFormat 1.8: Deprecate //joint/axis/initial_position.
-    * [BitBucket pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
 
 ## libsdformat 9.X
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
-find_package(sdformat10 REQUIRED)
+find_package(sdformat11 REQUIRED)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 


### PR DESCRIPTION
We are planning to release `libsdformat10` with dome in September, but save the SDFormat 1.8 specification changes for December. Since the master branch already has some 1.8 specification files, bump this branch to major version 11 and create an `sdf10` branch that doesn't have the 1.8 specification changes.