### PR TITLE
sdf 1.8: support specifying frames as joint child/parent 

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -189,6 +189,10 @@ but with improved human-readability..
 
 ## SDF protocol 1.7 to 1.8
 
+### Modifications
+
+1. **joint.sdf** `child` and `parent` elements accept frame names instead of only link names
+
 ### Deprecations
 
 1. **joint.sdf** `initial_position` element in `<joint><axis>` and `<joint><axis2>` is deprecated

--- a/Migration.md
+++ b/Migration.md
@@ -26,6 +26,10 @@ but with improved human-readability..
    + ***Deprecation:*** void SetParentLinkName(const std::string &)
    + ***Replacement:*** void SetParentName(const std::string &)
 
+1. **sdf/parser.hh**
+   + ***Deprecation:*** bool checkJointParentChildLinkNames(const sdf::Root \*)
+   + ***Replacement:*** bool checkJointParentChildNames(const sdf::Root \*)
+
 ## SDFormat 8.x to 9.0
 
 ### Additions

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,20 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## SDFormat 9.x to 10.0
+
+### Deprecations
+
+1. **sdf/Joint.hh**
+   + ***Deprecation:*** const std::string &ChildLinkName() const
+   + ***Replacement:*** const std::string &ChildName() const
+   + ***Deprecation:*** const std::string &ParentLinkName() const
+   + ***Replacement:*** const std::string &ParentName() const
+   + ***Deprecation:*** void SetChildLinkName(const std::string &)
+   + ***Replacement:*** void SetChildName(const std::string &)
+   + ***Deprecation:*** void SetParentLinkName(const std::string &)
+   + ***Replacement:*** void SetParentName(const std::string &)
+
 ## SDFormat 8.x to 9.0
 
 ### Additions

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -133,19 +133,43 @@ namespace sdf
 
     /// \brief Get the name of this joint's parent link.
     /// \return The name of the parent link.
-    public: const std::string &ParentLinkName() const;
+    /// \deprecated See ParentName.
+    public: const std::string &ParentLinkName() const
+        SDF_DEPRECATED(11.0);
 
     /// \brief Set the name of the parent link.
     /// \param[in] _name Name of the parent link.
-    public: void SetParentLinkName(const std::string &_name);
+    /// \deprecated See SetParentName.
+    public: void SetParentLinkName(const std::string &_name)
+        SDF_DEPRECATED(11.0);
 
     /// \brief Get the name of this joint's child link.
     /// \return The name of the child link.
-    public: const std::string &ChildLinkName() const;
+    /// \deprecated See ChildName.
+    public: const std::string &ChildLinkName() const
+        SDF_DEPRECATED(11.0);
 
     /// \brief Set the name of the child link.
     /// \param[in] _name Name of the child link.
-    public: void SetChildLinkName(const std::string &_name);
+    /// \deprecated See SetChildName.
+    public: void SetChildLinkName(const std::string &_name)
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get the name of this joint's parent frame.
+    /// \return The name of the parent frame.
+    public: const std::string &ParentName() const;
+
+    /// \brief Set the name of the parent frame.
+    /// \param[in] _name Name of the parent frame.
+    public: void SetParentName(const std::string &_name);
+
+    /// \brief Get the name of this joint's child frame.
+    /// \return The name of the child frame.
+    public: const std::string &ChildName() const;
+
+    /// \brief Set the name of the child frame.
+    /// \param[in] _name Name of the child frame.
+    public: void SetChildName(const std::string &_name);
 
     /// \brief Get a joint axis.
     /// \param[in] _index This value specifies which axis to get. A value of

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -261,14 +261,26 @@ namespace sdf
   bool checkFrameAttachedToNames(const sdf::Root *_root);
 
   /// \brief Check that all joints in contained models specify parent
-  /// and child link names that match the names of sibling links.
+  /// and child names that match the names of sibling frames.
+  /// This checks recursively and should check the files exhaustively
+  /// rather than terminating early when the first error is found.
+  /// \param[in] _root sdf Root object to check recursively.
+  /// \return True if all models have joints with valid parent and child
+  /// link names.
+  /// \deprecated See checkJointParentChildNames.
+  SDFORMAT_VISIBLE
+  bool checkJointParentChildLinkNames(const sdf::Root *_root)
+      SDF_DEPRECATED(11.0);
+
+  /// \brief Check that all joints in contained models specify parent
+  /// and child names that match the names of sibling frames.
   /// This checks recursively and should check the files exhaustively
   /// rather than terminating early when the first error is found.
   /// \param[in] _root sdf Root object to check recursively.
   /// \return True if all models have joints with valid parent and child
   /// link names.
   SDFORMAT_VISIBLE
-  bool checkJointParentChildLinkNames(const sdf::Root *_root);
+  bool checkJointParentChildNames(const sdf::Root *_root);
 
   /// \brief For the world and each model, check that the attached_to graphs
   /// build without errors and have no cycles.

--- a/sdf/1.8/joint.sdf
+++ b/sdf/1.8/joint.sdf
@@ -21,11 +21,11 @@
   </attribute>
 
   <element name="parent" type="string" default="__default__" required="1">
-    <description>Name of the parent link or "world".</description>
+    <description>Name of the parent frame or "world".</description>
   </element> <!-- End Parent -->
 
   <element name="child" type="string" default="__default__" required="1">
-    <description>Name of the child link. The value "world" may not be specified.</description>
+    <description>Name of the child frame. The value "world" may not be specified.</description>
   </element> <!-- End Child -->
 
   <element name="gearbox_ratio" type="double" default="1.0" required="0">

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -255,11 +255,11 @@ Errors buildFrameAttachedToGraph(
         _out.graph.AddVertex(joint->Name(), sdf::FrameType::JOINT).Id();
     _out.map[joint->Name()] = jointId;
 
-    auto childLink = _model->LinkByName(joint->ChildLinkName());
+    auto childLink = _model->LinkByName(joint->ChildName());
     if (nullptr == childLink)
     {
       errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-        "Child link with name[" + joint->ChildLinkName() +
+        "Child link with name[" + joint->ChildName() +
         "] specified by joint with name[" + joint->Name() +
         "] not found in model with name[" + _model->Name() + "]."});
       continue;
@@ -499,11 +499,11 @@ Errors buildPoseRelativeToGraph(
     if (joint->PoseRelativeTo().empty())
     {
       // relative_to is empty, so add edge from joint to child link
-      auto childLink = _model->LinkByName(joint->ChildLinkName());
+      auto childLink = _model->LinkByName(joint->ChildName());
       if (nullptr == childLink)
       {
         errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-          "Child link with name[" + joint->ChildLinkName() +
+          "Child link with name[" + joint->ChildName() +
           "] specified by joint with name[" + joint->Name() +
           "] not found in model with name[" + _model->Name() + "]."});
         continue;

--- a/src/FrameSemantics.cc
+++ b/src/FrameSemantics.cc
@@ -239,7 +239,7 @@ Errors buildFrameAttachedToGraph(
     }
   }
 
-  // add joint vertices and edges to child link
+  // add joint vertices
   for (uint64_t j = 0; j < _model->JointCount(); ++j)
   {
     auto joint = _model->JointByIndex(j);
@@ -254,18 +254,6 @@ Errors buildFrameAttachedToGraph(
     auto jointId =
         _out.graph.AddVertex(joint->Name(), sdf::FrameType::JOINT).Id();
     _out.map[joint->Name()] = jointId;
-
-    auto childLink = _model->LinkByName(joint->ChildName());
-    if (nullptr == childLink)
-    {
-      errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-        "Child link with name[" + joint->ChildName() +
-        "] specified by joint with name[" + joint->Name() +
-        "] not found in model with name[" + _model->Name() + "]."});
-      continue;
-    }
-    auto childLinkId = _out.map.at(childLink->Name());
-    _out.graph.AddEdge({jointId, childLinkId}, true);
   }
 
   // add frame vertices
@@ -283,6 +271,24 @@ Errors buildFrameAttachedToGraph(
     auto frameId =
         _out.graph.AddVertex(frame->Name(), sdf::FrameType::FRAME).Id();
     _out.map[frame->Name()] = frameId;
+  }
+
+  // add edges from joint to child frames
+  for (uint64_t j = 0; j < _model->JointCount(); ++j)
+  {
+    auto joint = _model->JointByIndex(j);
+    auto jointId = _out.map.at(joint->Name());
+    auto childFrameName = joint->ChildName();
+    if (_out.map.count(childFrameName) != 1)
+    {
+      errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
+        "Child frame with name[" + childFrameName +
+        "] specified by joint with name[" + joint->Name() +
+        "] not found in model with name[" + _model->Name() + "]."});
+      continue;
+    }
+    auto childFrameId = _out.map.at(childFrameName);
+    _out.graph.AddEdge({jointId, childFrameId}, true);
   }
 
   // add frame edges
@@ -480,7 +486,7 @@ Errors buildPoseRelativeToGraph(
     }
   }
 
-  // add joint vertices and default edge if relative_to is empty
+  // add joint vertices
   for (uint64_t j = 0; j < _model->JointCount(); ++j)
   {
     auto joint = _model->JointByIndex(j);
@@ -495,22 +501,6 @@ Errors buildPoseRelativeToGraph(
     auto jointId =
         _out.graph.AddVertex(joint->Name(), sdf::FrameType::JOINT).Id();
     _out.map[joint->Name()] = jointId;
-
-    if (joint->PoseRelativeTo().empty())
-    {
-      // relative_to is empty, so add edge from joint to child link
-      auto childLink = _model->LinkByName(joint->ChildName());
-      if (nullptr == childLink)
-      {
-        errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
-          "Child link with name[" + joint->ChildName() +
-          "] specified by joint with name[" + joint->Name() +
-          "] not found in model with name[" + _model->Name() + "]."});
-        continue;
-      }
-      auto childLinkId = _out.map.at(childLink->Name());
-      _out.graph.AddEdge({childLinkId, jointId}, joint->RawPose());
-    }
   }
 
   // add frame vertices and default edge if both
@@ -579,11 +569,11 @@ Errors buildPoseRelativeToGraph(
   {
     auto joint = _model->JointByIndex(j);
 
-    // check if we've already added a default edge
-    const std::string relativeTo = joint->PoseRelativeTo();
-    if (joint->PoseRelativeTo().empty())
+    std::string relativeTo = joint->PoseRelativeTo();
+    if (relativeTo.empty())
     {
-      continue;
+      // since nothing else was specified, use the joint's child frame
+      relativeTo = joint->ChildName();
     }
 
     auto jointId = _out.map.at(joint->Name());

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -48,11 +48,11 @@ class sdf::JointPrivate
   /// \brief Name of the joint.
   public: std::string name = "";
 
-  /// \brief Name of the parent link.
-  public: std::string parentLinkName = "";
+  /// \brief Name of the parent frame.
+  public: std::string parentName = "";
 
-  /// \brief Name of the child link.
-  public: std::string childLinkName = "";
+  /// \brief Name of the child frame.
+  public: std::string childName = "";
 
   /// \brief the joint type.
   public: JointType type = JointType::INVALID;
@@ -80,8 +80,8 @@ class sdf::JointPrivate
 /////////////////////////////////////////////////
 JointPrivate::JointPrivate(const JointPrivate &_jointPrivate)
     : name(_jointPrivate.name),
-      parentLinkName(_jointPrivate.parentLinkName),
-      childLinkName(_jointPrivate.childLinkName),
+      parentName(_jointPrivate.parentName),
+      childName(_jointPrivate.childName),
       type(_jointPrivate.type),
       pose(_jointPrivate.pose),
       poseRelativeTo(_jointPrivate.poseRelativeTo),
@@ -176,7 +176,7 @@ Errors Joint::Load(ElementPtr _sdf)
     _sdf->Get<std::string>("parent", "");
   if (parentPair.second)
   {
-    this->dataPtr->parentLinkName = parentPair.first;
+    this->dataPtr->parentName = parentPair.first;
   }
   else
   {
@@ -188,7 +188,7 @@ Errors Joint::Load(ElementPtr _sdf)
   std::pair<std::string, bool> childPair = _sdf->Get<std::string>("child", "");
   if (childPair.second)
   {
-    this->dataPtr->childLinkName = childPair.first;
+    this->dataPtr->childName = childPair.first;
   }
   else
   {
@@ -196,19 +196,19 @@ Errors Joint::Load(ElementPtr _sdf)
         "The child element is missing."});
   }
 
-  if (this->dataPtr->childLinkName == "world")
+  if (this->dataPtr->childName == "world")
   {
     errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
         "Joint with name[" + this->dataPtr->name +
         "] specified invalid child link [world]."});
   }
 
-  if (this->dataPtr->childLinkName == this->dataPtr->parentLinkName)
+  if (this->dataPtr->childName == this->dataPtr->parentName)
   {
     errors.push_back({ErrorCode::JOINT_PARENT_SAME_AS_CHILD,
         "Joint with name[" + this->dataPtr->name +
         "] must specify different link names for "
-        "parent and child, while [" + this->dataPtr->childLinkName +
+        "parent and child, while [" + this->dataPtr->childName +
         "] was specified for both."});
   }
 
@@ -302,7 +302,7 @@ const std::string &Joint::ParentLinkName() const
 /////////////////////////////////////////////////
 const std::string &Joint::ParentName() const
 {
-  return this->dataPtr->parentLinkName;
+  return this->dataPtr->parentName;
 }
 
 /////////////////////////////////////////////////
@@ -314,7 +314,7 @@ void Joint::SetParentLinkName(const std::string &_name)
 /////////////////////////////////////////////////
 void Joint::SetParentName(const std::string &_name)
 {
-  this->dataPtr->parentLinkName = _name;
+  this->dataPtr->parentName = _name;
 }
 
 /////////////////////////////////////////////////
@@ -326,7 +326,7 @@ const std::string &Joint::ChildLinkName() const
 /////////////////////////////////////////////////
 const std::string &Joint::ChildName() const
 {
-  return this->dataPtr->childLinkName;
+  return this->dataPtr->childName;
 }
 
 /////////////////////////////////////////////////
@@ -338,7 +338,7 @@ void Joint::SetChildLinkName(const std::string &_name)
 /////////////////////////////////////////////////
 void Joint::SetChildName(const std::string &_name)
 {
-  this->dataPtr->childLinkName = _name;
+  this->dataPtr->childName = _name;
 }
 
 /////////////////////////////////////////////////

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -424,7 +424,7 @@ sdf::SemanticPose Joint::SemanticPose() const
   return sdf::SemanticPose(
       this->dataPtr->pose,
       this->dataPtr->poseRelativeTo,
-      this->ChildLinkName(),
+      this->ChildName(),
       this->dataPtr->poseRelativeToGraph);
 }
 

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -296,11 +296,23 @@ void Joint::SetType(const JointType _jointType)
 /////////////////////////////////////////////////
 const std::string &Joint::ParentLinkName() const
 {
+  return this->ParentName();
+}
+
+/////////////////////////////////////////////////
+const std::string &Joint::ParentName() const
+{
   return this->dataPtr->parentLinkName;
 }
 
 /////////////////////////////////////////////////
 void Joint::SetParentLinkName(const std::string &_name)
+{
+  this->SetParentName(_name);
+}
+
+/////////////////////////////////////////////////
+void Joint::SetParentName(const std::string &_name)
 {
   this->dataPtr->parentLinkName = _name;
 }
@@ -308,11 +320,23 @@ void Joint::SetParentLinkName(const std::string &_name)
 /////////////////////////////////////////////////
 const std::string &Joint::ChildLinkName() const
 {
+  return this->ChildName();
+}
+
+/////////////////////////////////////////////////
+const std::string &Joint::ChildName() const
+{
   return this->dataPtr->childLinkName;
 }
 
 /////////////////////////////////////////////////
 void Joint::SetChildLinkName(const std::string &_name)
+{
+  this->SetChildName(_name);
+}
+
+/////////////////////////////////////////////////
+void Joint::SetChildName(const std::string &_name)
 {
   this->dataPtr->childLinkName = _name;
 }

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -212,6 +212,20 @@ Errors Joint::Load(ElementPtr _sdf)
         "] was specified for both."});
   }
 
+  if (this->dataPtr->childName == this->dataPtr->name)
+  {
+    errors.push_back({ErrorCode::JOINT_CHILD_LINK_INVALID,
+        "Joint with name[" + this->dataPtr->name +
+        "] must not specify its own name as the child link."});
+  }
+
+  if (this->dataPtr->parentName == this->dataPtr->name)
+  {
+    errors.push_back({ErrorCode::JOINT_PARENT_LINK_INVALID,
+        "Joint with name[" + this->dataPtr->name +
+        "] must not specify its own name as the parent link."});
+  }
+
   if (_sdf->HasElement("axis"))
   {
     this->dataPtr->axis[0].reset(new JointAxis());

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -26,8 +26,8 @@ TEST(DOMJoint, Construction)
   sdf::Joint joint;
   EXPECT_TRUE(joint.Name().empty());
   EXPECT_EQ(sdf::JointType::INVALID, joint.Type());
-  EXPECT_TRUE(joint.ParentLinkName().empty());
-  EXPECT_TRUE(joint.ChildLinkName().empty());
+  EXPECT_TRUE(joint.ParentName().empty());
+  EXPECT_TRUE(joint.ChildName().empty());
   EXPECT_EQ(ignition::math::Pose3d::Zero, joint.RawPose());
   EXPECT_TRUE(joint.PoseRelativeTo().empty());
   EXPECT_EQ(nullptr, joint.Element());
@@ -58,11 +58,11 @@ TEST(DOMJoint, Construction)
   joint.SetName("test_joint");
   EXPECT_EQ("test_joint", joint.Name());
 
-  joint.SetParentLinkName("parent");
-  EXPECT_EQ("parent", joint.ParentLinkName());
+  joint.SetParentName("parent");
+  EXPECT_EQ("parent", joint.ParentName());
 
-  joint.SetChildLinkName("child");
-  EXPECT_EQ("child", joint.ChildLinkName());
+  joint.SetChildName("child");
+  EXPECT_EQ("child", joint.ChildName());
 
   joint.SetType(sdf::JointType::BALL);
   EXPECT_EQ(sdf::JointType::BALL, joint.Type());

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -48,7 +48,7 @@ extern "C" SDFORMAT_VISIBLE int cmdCheck(const char *_path)
     result = -1;
   }
 
-  if (!sdf::checkJointParentChildLinkNames(&root))
+  if (!sdf::checkJointParentChildNames(&root))
   {
     result = -1;
   }

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -197,7 +197,7 @@ TEST(check, SDF)
     // Check joint_invalid_child.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
-    EXPECT_NE(output.find("Error: Child link with name[invalid] specified by "
+    EXPECT_NE(output.find("Error: Child frame with name[invalid] specified by "
                           "joint with name[joint] not found in model with "
                           "name[joint_invalid_child]."),
               std::string::npos) << output;
@@ -210,9 +210,33 @@ TEST(check, SDF)
     // Check joint_invalid_parent.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
-    EXPECT_NE(output.find("Error: parent link with name[invalid] specified by "
+    EXPECT_NE(output.find("Error: parent frame with name[invalid] specified by "
                           "joint with name[joint] not found in model with "
                           "name[joint_invalid_parent]."),
+              std::string::npos) << output;
+  }
+
+  // Check an SDF file with a joint with an invalid child link.
+  {
+    std::string path = pathBase +"/joint_invalid_self_child.sdf";
+
+    // Check joint_invalid_self_child.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("Joint with name[self] must not specify its own "
+                          "name as the child link."),
+              std::string::npos) << output;
+  }
+
+  // Check an SDF file with a joint with an invalid parent link.
+  {
+    std::string path = pathBase +"/joint_invalid_self_parent.sdf";
+
+    // Check joint_invalid_self_parent.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("Joint with name[self] must not specify its own "
+                          "name as the parent link."),
               std::string::npos) << output;
   }
 
@@ -247,6 +271,28 @@ TEST(check, SDF)
     std::string path = pathBase +"/joint_parent_world.sdf";
 
     // Check joint_parent_world.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with the world specified as a parent link.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_child_frame.sdf";
+
+    // Check joint_child_frame.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with the world specified as a parent link.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_parent_frame.sdf";
+
+    // Check joint_parent_frame.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
     EXPECT_EQ("Valid.\n", output) << output;

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1823,7 +1823,7 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
     {
       auto joint = _model->JointByIndex(j);
 
-      const std::string &parentName = joint->ParentLinkName();
+      const std::string &parentName = joint->ParentName();
       if (parentName != "world" && !_model->LinkNameExists(parentName))
       {
         std::cerr << "Error: parent link with name[" << parentName
@@ -1834,7 +1834,7 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
         modelResult = false;
       }
 
-      const std::string &childName = joint->ChildLinkName();
+      const std::string &childName = joint->ChildName();
       if (childName != "world" && !_model->LinkNameExists(childName))
       {
         std::cerr << "Error: child link with name[" << childName

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1813,6 +1813,12 @@ bool checkPoseRelativeToGraph(const sdf::Root *_root)
 //////////////////////////////////////////////////
 bool checkJointParentChildLinkNames(const sdf::Root *_root)
 {
+  return checkJointParentChildNames(_root);
+}
+
+//////////////////////////////////////////////////
+bool checkJointParentChildNames(const sdf::Root *_root)
+{
   bool result = true;
 
   auto checkModelJointParentChildNames = [](

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1824,9 +1824,11 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
       auto joint = _model->JointByIndex(j);
 
       const std::string &parentName = joint->ParentName();
-      if (parentName != "world" && !_model->LinkNameExists(parentName))
+      if (parentName != "world" && !_model->LinkNameExists(parentName) &&
+          !_model->JointNameExists(parentName) &&
+          !_model->FrameNameExists(parentName))
       {
-        std::cerr << "Error: parent link with name[" << parentName
+        std::cerr << "Error: parent frame with name[" << parentName
                   << "] specified by joint with name[" << joint->Name()
                   << "] not found in model with name[" << _model->Name()
                   << "]."
@@ -1835,12 +1837,42 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
       }
 
       const std::string &childName = joint->ChildName();
-      if (childName != "world" && !_model->LinkNameExists(childName))
+      if (childName == "world")
       {
-        std::cerr << "Error: child link with name[" << childName
+        std::cerr << "Error: invalid child name[world"
+                  << "] specified by joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "]."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (!_model->LinkNameExists(childName) &&
+          !_model->JointNameExists(childName) &&
+          !_model->FrameNameExists(childName))
+      {
+        std::cerr << "Error: child frame with name[" << childName
                   << "] specified by joint with name[" << joint->Name()
                   << "] not found in model with name[" << _model->Name()
                   << "]."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (childName == joint->Name())
+      {
+        std::cerr << "Error: joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "] must not specify its own name as the child frame."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (parentName == joint->Name())
+      {
+        std::cerr << "Error: joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "] must not specify its own name as the parent frame."
                   << std::endl;
         modelResult = false;
       }

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -221,7 +221,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[1].Message().find(
-      "Child link with name[world] specified by joint with name[joint] "
+      "Child frame with name[world] specified by joint with name[joint] "
       "not found in model with name[joint_child_world]"));
 }
 
@@ -366,7 +366,7 @@ TEST(DOMJoint, LoadInvalidChild)
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
-      "Child link with name[invalid] specified by joint with name[joint] not "
+      "Child frame with name[invalid] specified by joint with name[joint] not "
       "found"));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR);
   EXPECT_NE(std::string::npos,

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -87,10 +87,10 @@ TEST(DOMJoint, DoublePendulum)
   ASSERT_NE(nullptr, lowerJoint);
 
   // Check the parent and child link values
-  EXPECT_EQ("base", upperJoint->ParentLinkName());
-  EXPECT_EQ("upper_link", upperJoint->ChildLinkName());
-  EXPECT_EQ("upper_link", lowerJoint->ParentLinkName());
-  EXPECT_EQ("lower_link", lowerJoint->ChildLinkName());
+  EXPECT_EQ("base", upperJoint->ParentName());
+  EXPECT_EQ("upper_link", upperJoint->ChildName());
+  EXPECT_EQ("upper_link", lowerJoint->ParentName());
+  EXPECT_EQ("lower_link", lowerJoint->ChildName());
 
   // Check that the pose relative_to values are empty
   EXPECT_TRUE(upperJoint->PoseRelativeTo().empty());
@@ -190,8 +190,8 @@ TEST(DOMJoint, LoadJointParentWorld)
   EXPECT_NE(nullptr, model->JointByIndex(0));
   EXPECT_EQ(nullptr, model->JointByIndex(1));
   ASSERT_TRUE(model->JointNameExists("joint"));
-  EXPECT_EQ("link", model->JointByName("joint")->ChildLinkName());
-  EXPECT_EQ("world", model->JointByName("joint")->ParentLinkName());
+  EXPECT_EQ("link", model->JointByName("joint")->ChildName());
+  EXPECT_EQ("world", model->JointByName("joint")->ParentName());
   EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
 
   EXPECT_EQ(Pose(0, 0, 3, 0, 0, 0), model->JointByName("joint")->RawPose());

--- a/test/sdf/joint_child_frame.sdf
+++ b/test/sdf/joint_child_frame.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_child_frame">
+    <link name="parent_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <link name="child_link">
+      <pose>0 0 3 0 0 0</pose>
+    </link>
+    <frame name="child_frame" attached_to="child_link">
+      <pose>1 0 0 0 0 0</pose>
+    </frame>
+    <joint name="joint" type="fixed">
+      <pose>0 1 0 0 0 0</pose>
+      <parent>parent_link</parent>
+      <child>child_frame</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_self_child.sdf
+++ b/test/sdf/joint_invalid_self_child.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_invalid_self_child">
+    <link name="link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <joint name="self" type="fixed">
+      <pose>0 0 3 0 0 0</pose>
+      <parent>link</parent>
+      <child>self</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_self_parent.sdf
+++ b/test/sdf/joint_invalid_self_parent.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_invalid_self_parent">
+    <link name="link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <joint name="self" type="fixed">
+      <pose>0 0 3 0 0 0</pose>
+      <parent>self</parent>
+      <child>link</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_parent_frame.sdf
+++ b/test/sdf/joint_parent_frame.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_parent_frame">
+    <link name="parent_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <link name="child_link">
+      <pose>0 0 3 0 0 0</pose>
+    </link>
+    <frame name="parent_frame" attached_to="parent_link">
+      <pose>1 0 0 0 0 0</pose>
+    </frame>
+    <joint name="joint" type="fixed">
+      <pose>0 1 0 0 0 0</pose>
+      <parent>parent_frame</parent>
+      <child>child_link</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/model_link_joint_same_name.sdf
+++ b/test/sdf/model_link_joint_same_name.sdf
@@ -1,16 +1,19 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
-  <model name="link_joint_same_name">
+  <model name="model_link_joint_same_name">
     <link name="base">
       <pose>1 0 0 0 0 0</pose>
     </link>
-    <link name="attachment">
+    <link name="child">
+      <pose>2 0 0 0 0 0</pose>
+    </link>
+    <link name="same">
       <pose>0 2 0 0 0 0</pose>
     </link>
-    <joint name="attachment" type="fixed">
+    <joint name="same" type="fixed">
       <pose>0 0 3 0 0 0</pose>
       <parent>base</parent>
-      <child>attachment</child>
+      <child>child</child>
     </joint>
   </model>
 </sdf>


### PR DESCRIPTION
Resolves #204.

The meat of this PR is in 53bdf38, which modifies the `sdf/1.8/joint.sdf` documentation and 
cf095f3, which changes how the graphs are constructed in FrameSemantics.cc. There's a bit of noise from deprecation of API's like `Joint::ChildLinkName` and tests, so start with those two commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdformat/300)
<!-- Reviewable:end -->
