### PR TITLE
Fix Actor.cc copy operators and restructure tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### SDFormat 8.X.X (202X-XX-XX)
 
+1. Fix Actor copy operators and increase test coverage.
+    * [Pull request 301](https://github.com/osrf/sdformat/pull/301)
+
 1. Increase output precision of URDF to SDF conversion, output -0 as 0.
     * [BitBucket pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)
 

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -129,9 +129,8 @@ Animation::~Animation()
 
 //////////////////////////////////////////////////
 Animation::Animation(const Animation &_animation)
-  : dataPtr(new AnimationPrivate)
+  : dataPtr(new AnimationPrivate(*_animation.dataPtr))
 {
-  this->CopyFrom(_animation);
 }
 
 /////////////////////////////////////////////////
@@ -156,6 +155,7 @@ Animation &Animation::operator=(Animation &&_animation)
 /////////////////////////////////////////////////
 void Animation::CopyFrom(const Animation &_animation)
 {
+  // TODO(anyone) Deprecate function
   this->dataPtr->name = _animation.dataPtr->name;
   this->dataPtr->filename = _animation.dataPtr->filename;
   this->dataPtr->scale = _animation.dataPtr->scale;
@@ -269,9 +269,8 @@ Waypoint::~Waypoint()
 
 //////////////////////////////////////////////////
 Waypoint::Waypoint(const Waypoint &_waypoint)
-  : dataPtr(new WaypointPrivate)
+  : dataPtr(new WaypointPrivate(*_waypoint.dataPtr))
 {
-  this->CopyFrom(_waypoint);
 }
 
 /////////////////////////////////////////////////
@@ -296,6 +295,7 @@ Waypoint &Waypoint::operator=(Waypoint &&_waypoint)
 /////////////////////////////////////////////////
 void Waypoint::CopyFrom(const Waypoint &_waypoint)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->time = _waypoint.dataPtr->time;
   this->dataPtr->pose = _waypoint.dataPtr->pose;
 }
@@ -364,9 +364,8 @@ Trajectory::~Trajectory()
 
 //////////////////////////////////////////////////
 Trajectory::Trajectory(const Trajectory &_trajectory)
-  : dataPtr(new TrajectoryPrivate)
+  : dataPtr(new TrajectoryPrivate(*_trajectory.dataPtr))
 {
-  this->CopyFrom(_trajectory);
 }
 
 /////////////////////////////////////////////////
@@ -391,6 +390,7 @@ Trajectory &Trajectory::operator=(Trajectory &&_trajectory)
 /////////////////////////////////////////////////
 void Trajectory::CopyFrom(const Trajectory &_trajectory)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->id = _trajectory.dataPtr->id;
   this->dataPtr->type = _trajectory.dataPtr->type;
   this->dataPtr->tension = _trajectory.dataPtr->tension;
@@ -501,9 +501,8 @@ Actor::~Actor()
 
 //////////////////////////////////////////////////
 Actor::Actor(const Actor &_actor)
-  : dataPtr(new ActorPrivate)
+  : dataPtr(new ActorPrivate(*_actor.dataPtr))
 {
-  this->CopyFrom(_actor);
 }
 
 /////////////////////////////////////////////////
@@ -528,6 +527,7 @@ Actor &Actor::operator=(Actor &&_actor)
 //////////////////////////////////////////////////
 void Actor::CopyFrom(const Actor &_actor)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->name             = _actor.dataPtr->name;
   this->dataPtr->pose             = _actor.dataPtr->pose;
   this->dataPtr->poseFrame        = _actor.dataPtr->poseFrame;

--- a/src/Actor_TEST.cc
+++ b/src/Actor_TEST.cc
@@ -61,7 +61,7 @@ bool TrajectoriesEqual(const sdf::Trajectory &_traj1,
     const sdf::Trajectory &_traj2)
 {
   constexpr double EPS = 1e-6;
-  bool waypoints_equal = true;
+  bool waypointsEqual = true;
   if (_traj1.WaypointCount() != _traj2.WaypointCount())
   {
     return false;
@@ -70,10 +70,10 @@ bool TrajectoriesEqual(const sdf::Trajectory &_traj1,
   {
     auto wp1 = _traj1.WaypointByIndex(wp_idx);
     auto wp2 = _traj2.WaypointByIndex(wp_idx);
-    waypoints_equal &= (std::abs(wp1->Time() - wp2->Time()) < EPS) &&
+    waypointsEqual &= (std::abs(wp1->Time() - wp2->Time()) < EPS) &&
       wp1->Pose() == wp2->Pose();
   }
-  return waypoints_equal &&
+  return waypointsEqual &&
     (_traj1.Id() == _traj2.Id()) &&
     (_traj1.Type() == _traj2.Type()) &&
     (std::abs(_traj1.Tension() - _traj2.Tension()) < EPS);
@@ -103,29 +103,29 @@ bool ActorsEqual(const sdf::Actor &_actor1, const sdf::Actor &_actor2)
 {
   constexpr double EPS = 1e-6;
   // Check animations, trajectories and properties
-  bool animations_equal = true;
+  bool animationsEqual = true;
   if (_actor1.AnimationCount() != _actor2.AnimationCount())
   {
     return false;
   }
   for (uint64_t anim_idx = 0; anim_idx < _actor1.AnimationCount(); ++anim_idx)
   {
-    animations_equal &= AnimationsEqual(
+    animationsEqual &= AnimationsEqual(
         *_actor1.AnimationByIndex(anim_idx),
         *_actor2.AnimationByIndex(anim_idx));
   }
-  bool trajectories_equal = true;
+  bool trajectoriesEqual = true;
   if (_actor1.TrajectoryCount() != _actor2.TrajectoryCount())
   {
     return false;
   }
   for (uint64_t traj_idx = 0; traj_idx < _actor1.TrajectoryCount(); ++traj_idx)
   {
-    trajectories_equal &= TrajectoriesEqual(
+    trajectoriesEqual &= TrajectoriesEqual(
         *_actor1.TrajectoryByIndex(traj_idx),
         *_actor2.TrajectoryByIndex(traj_idx));
   }
-  return animations_equal && trajectories_equal &&
+  return animationsEqual && trajectoriesEqual &&
     (_actor1.Name() == _actor2.Name()) &&
     (_actor1.Pose() == _actor2.Pose()) &&
     (_actor1.PoseFrame() == _actor2.PoseFrame()) &&

--- a/src/Actor_TEST.cc
+++ b/src/Actor_TEST.cc
@@ -20,6 +20,127 @@
 #include "sdf/Actor.hh"
 
 /////////////////////////////////////////////////
+sdf::Animation CreateDummyAnimation()
+{
+  sdf::Animation animation;
+  animation.SetName("animation");
+  animation.SetFilename("animation_filename");
+  animation.SetFilePath("animation_filepath");
+  animation.SetScale(1.234);
+  animation.SetInterpolateX(true);
+  return animation;
+}
+
+/////////////////////////////////////////////////
+bool AnimationsEqual(const sdf::Animation &_anim1, const sdf::Animation &_anim2)
+{
+  constexpr double EPS = 1e-6;
+  return (_anim1.Name() == _anim2.Name()) &&
+    (_anim1.Filename() == _anim2.Filename()) &&
+    (_anim1.FilePath() == _anim2.FilePath()) &&
+    (std::abs(_anim1.Scale() - _anim2.Scale()) < EPS) &&
+    (_anim1.InterpolateX() == _anim2.InterpolateX());
+}
+
+/////////////////////////////////////////////////
+sdf::Trajectory CreateDummyTrajectory()
+{
+  sdf::Trajectory trajectory;
+  sdf::Waypoint waypoint;
+  waypoint.SetTime(0.12);
+  waypoint.SetPose({3, 2, 1, 0, IGN_PI, 0});
+  trajectory.SetId(1234);
+  trajectory.SetType("trajectory_type");
+  trajectory.SetTension(4.567);
+  trajectory.AddWaypoint(waypoint);
+  return trajectory;
+}
+
+/////////////////////////////////////////////////
+bool TrajectoriesEqual(const sdf::Trajectory &_traj1,
+    const sdf::Trajectory &_traj2)
+{
+  constexpr double EPS = 1e-6;
+  bool waypoints_equal = true;
+  if (_traj1.WaypointCount() != _traj2.WaypointCount())
+  {
+    return false;
+  }
+  for (uint64_t wp_idx = 0; wp_idx < _traj1.WaypointCount(); ++wp_idx)
+  {
+    auto wp1 = _traj1.WaypointByIndex(wp_idx);
+    auto wp2 = _traj2.WaypointByIndex(wp_idx);
+    waypoints_equal &= (std::abs(wp1->Time() - wp2->Time()) < EPS) &&
+      wp1->Pose() == wp2->Pose();
+  }
+  return waypoints_equal &&
+    (_traj1.Id() == _traj2.Id()) &&
+    (_traj1.Type() == _traj2.Type()) &&
+    (std::abs(_traj1.Tension() - _traj2.Tension()) < EPS);
+}
+
+/////////////////////////////////////////////////
+sdf::Actor CreateDummyActor()
+{
+  sdf::Actor actor;
+  actor.SetName("test_dummy_actor");
+  actor.SetPose({3, 2, 1, 0, IGN_PI, 0});
+  actor.SetPoseFrame("ground_plane");
+  actor.SetSkinFilename("walk.dae");
+  actor.SetSkinScale(2.0);
+  actor.SetScriptLoop(true);
+  actor.SetScriptDelayStart(2.8);
+  actor.SetScriptAutoStart(false);
+  actor.SetFilePath("/home/path/to/model.sdf");
+  // Add a dummy trajectory and animation as well
+  actor.AddTrajectory(CreateDummyTrajectory());
+  actor.AddAnimation(CreateDummyAnimation());
+  return actor;
+}
+
+/////////////////////////////////////////////////
+bool ActorsEqual(const sdf::Actor &_actor1, const sdf::Actor &_actor2)
+{
+  constexpr double EPS = 1e-6;
+  // Check animations, trajectories and properties
+  bool animations_equal = true;
+  if (_actor1.AnimationCount() != _actor2.AnimationCount())
+  {
+    return false;
+  }
+  for (uint64_t anim_idx = 0; anim_idx < _actor1.AnimationCount(); ++anim_idx)
+  {
+    animations_equal &= AnimationsEqual(
+        *_actor1.AnimationByIndex(anim_idx),
+        *_actor2.AnimationByIndex(anim_idx));
+  }
+  bool trajectories_equal = true;
+  if (_actor1.TrajectoryCount() != _actor2.TrajectoryCount())
+  {
+    return false;
+  }
+  for (uint64_t traj_idx = 0; traj_idx < _actor1.TrajectoryCount(); ++traj_idx)
+  {
+    trajectories_equal &= TrajectoriesEqual(
+        *_actor1.TrajectoryByIndex(traj_idx),
+        *_actor2.TrajectoryByIndex(traj_idx));
+  }
+  return animations_equal && trajectories_equal &&
+    (_actor1.Name() == _actor2.Name()) &&
+    (_actor1.Pose() == _actor2.Pose()) &&
+    (_actor1.PoseFrame() == _actor2.PoseFrame()) &&
+    (_actor1.SkinFilename() == _actor2.SkinFilename()) &&
+    (std::abs(_actor1.SkinScale() - _actor2.SkinScale()) < EPS) &&
+    (_actor1.ScriptLoop() == _actor2.ScriptLoop()) &&
+    (std::abs(_actor1.ScriptDelayStart() - _actor2.ScriptDelayStart()) < EPS) &&
+    (_actor1.ScriptAutoStart() == _actor2.ScriptAutoStart()) &&
+    (_actor1.FilePath() == _actor2.FilePath()) &&
+    (_actor1.LinkCount() == _actor2.LinkCount()) &&
+    (_actor1.JointCount() == _actor2.JointCount()) &&
+    (_actor1.Element() == _actor2.Element());
+}
+
+/////////////////////////////////////////////////
 TEST(DOMActor, DefaultConstruction)
 {
   sdf::Actor actor;
@@ -63,227 +184,42 @@ TEST(DOMActor, DefaultConstruction)
 /////////////////////////////////////////////////
 TEST(DOMActor, CopyConstructor)
 {
-  sdf::Actor actor;
-  actor.SetName("test_copy_actor");
-  actor.SetPose({3, 2, 1, 0, IGN_PI, 0});
-  actor.SetPoseFrame("ground_plane");
-  actor.SetSkinFilename("walk.dae");
-  actor.SetSkinScale(2.0);
-  actor.SetScriptLoop(true);
-  actor.SetScriptDelayStart(2.8);
-  actor.SetScriptAutoStart(false);
-  actor.SetFilePath("/home/path/to/model.sdf");
-
+  sdf::Actor actor = CreateDummyActor();
   sdf::Actor actor2(actor);
-  EXPECT_EQ("test_copy_actor", actor2.Name());
-  EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), actor2.Pose());
-  EXPECT_EQ("ground_plane", actor2.PoseFrame());
-  EXPECT_EQ("/home/path/to/model.sdf", actor2.FilePath());
-
-  EXPECT_EQ(0u, actor2.AnimationCount());
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(0));
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(1));
-  EXPECT_FALSE(actor2.AnimationNameExists(""));
-  EXPECT_FALSE(actor2.AnimationNameExists("default"));
-
-  EXPECT_EQ("walk.dae", actor2.SkinFilename());
-  EXPECT_DOUBLE_EQ(2.0, actor2.SkinScale());
-
-  EXPECT_EQ(0u, actor2.TrajectoryCount());
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(0));
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(1));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(0));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(1));
-
-  EXPECT_TRUE(actor2.ScriptLoop());
-  EXPECT_DOUBLE_EQ(2.8, actor2.ScriptDelayStart());
-  EXPECT_FALSE(actor2.ScriptAutoStart());
-
-  EXPECT_EQ(0u, actor2.LinkCount());
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(0));
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(1));
-  EXPECT_FALSE(actor2.LinkNameExists(""));
-
-  EXPECT_EQ(0u, actor2.JointCount());
-  EXPECT_EQ(nullptr, actor2.JointByIndex(0));
-  EXPECT_EQ(nullptr, actor2.JointByIndex(1));
-  EXPECT_FALSE(actor2.JointNameExists(""));
+  EXPECT_TRUE(ActorsEqual(actor, actor2));
 }
 
 /////////////////////////////////////////////////
 TEST(DOMActor, CopyAssignmentOperator)
 {
-  sdf::Actor actor;
-  actor.SetName("test_actor_assignment");
-  actor.SetPose({3, 2, 1, 0, IGN_PI, 0});
-  actor.SetPoseFrame("ground_plane");
-  actor.SetSkinFilename("walk.dae");
-  actor.SetSkinScale(2.0);
-  actor.SetScriptLoop(true);
-  actor.SetScriptDelayStart(2.8);
-  actor.SetScriptAutoStart(false);
-  actor.SetFilePath("/home/path/to/model.sdf");
-
+  sdf::Actor actor = CreateDummyActor();
   sdf::Actor actor2;
   actor2 = actor;
-  EXPECT_EQ("test_actor_assignment", actor2.Name());
-  EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), actor2.Pose());
-  EXPECT_EQ("ground_plane", actor2.PoseFrame());
-  EXPECT_EQ("/home/path/to/model.sdf", actor2.FilePath());
-
-  EXPECT_EQ(0u, actor2.AnimationCount());
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(0));
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(1));
-  EXPECT_FALSE(actor2.AnimationNameExists(""));
-  EXPECT_FALSE(actor2.AnimationNameExists("default"));
-
-  EXPECT_EQ("walk.dae", actor2.SkinFilename());
-  EXPECT_DOUBLE_EQ(2.0, actor2.SkinScale());
-
-  EXPECT_EQ(0u, actor2.TrajectoryCount());
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(0));
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(1));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(0));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(1));
-
-  EXPECT_TRUE(actor2.ScriptLoop());
-  EXPECT_DOUBLE_EQ(2.8, actor2.ScriptDelayStart());
-  EXPECT_FALSE(actor2.ScriptAutoStart());
-
-  EXPECT_EQ(0u, actor2.LinkCount());
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(0));
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(1));
-  EXPECT_FALSE(actor2.LinkNameExists(""));
-
-  EXPECT_EQ(0u, actor2.JointCount());
-  EXPECT_EQ(nullptr, actor2.JointByIndex(0));
-  EXPECT_EQ(nullptr, actor2.JointByIndex(1));
-  EXPECT_FALSE(actor2.JointNameExists(""));
+  EXPECT_TRUE(ActorsEqual(actor, actor2));
 }
 
 /////////////////////////////////////////////////
 TEST(DOMActor, MoveConstructor)
 {
-  sdf::Actor actor;
-  actor.SetName("test_actor_assignment");
-  actor.SetPose({3, 2, 1, 0, IGN_PI, 0});
-  actor.SetPoseFrame("ground_plane");
-  actor.SetSkinFilename("walk.dae");
-  actor.SetSkinScale(2.0);
-  actor.SetScriptLoop(true);
-  actor.SetScriptDelayStart(2.8);
-  actor.SetScriptAutoStart(false);
-  actor.SetFilePath("/home/path/to/model.sdf");
-
+  sdf::Actor actor = CreateDummyActor();
   sdf::Actor actor2(std::move(actor));
-  EXPECT_EQ("test_actor_assignment", actor2.Name());
-  EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), actor2.Pose());
-  EXPECT_EQ("ground_plane", actor2.PoseFrame());
-  EXPECT_EQ("/home/path/to/model.sdf", actor2.FilePath());
-
-  EXPECT_EQ(0u, actor2.AnimationCount());
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(0));
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(1));
-  EXPECT_FALSE(actor2.AnimationNameExists(""));
-  EXPECT_FALSE(actor2.AnimationNameExists("default"));
-
-  EXPECT_EQ("walk.dae", actor2.SkinFilename());
-  EXPECT_DOUBLE_EQ(2.0, actor2.SkinScale());
-
-  EXPECT_EQ(0u, actor2.TrajectoryCount());
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(0));
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(1));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(0));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(1));
-
-  EXPECT_TRUE(actor2.ScriptLoop());
-  EXPECT_DOUBLE_EQ(2.8, actor2.ScriptDelayStart());
-  EXPECT_FALSE(actor2.ScriptAutoStart());
-
-  EXPECT_EQ(0u, actor2.LinkCount());
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(0));
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(1));
-  EXPECT_FALSE(actor2.LinkNameExists(""));
-
-  EXPECT_EQ(0u, actor2.JointCount());
-  EXPECT_EQ(nullptr, actor2.JointByIndex(0));
-  EXPECT_EQ(nullptr, actor2.JointByIndex(1));
-  EXPECT_FALSE(actor2.JointNameExists(""));
+  EXPECT_TRUE(ActorsEqual(CreateDummyActor(), actor2));
 }
 
 /////////////////////////////////////////////////
 TEST(DOMActor, MoveAssignment)
 {
-  sdf::Actor actor;
-  actor.SetName("test_actor_assignment");
-  actor.SetPose({3, 2, 1, 0, IGN_PI, 0});
-  actor.SetPoseFrame("ground_plane");
-  actor.SetSkinFilename("walk.dae");
-  actor.SetSkinScale(2.0);
-  actor.SetScriptLoop(true);
-  actor.SetScriptDelayStart(2.8);
-  actor.SetScriptAutoStart(false);
-  actor.SetFilePath("/home/path/to/model.sdf");
-
+  sdf::Actor actor = CreateDummyActor();
   sdf::Actor actor2;
   actor2 = std::move(actor);
-  EXPECT_EQ("test_actor_assignment", actor2.Name());
-  EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), actor2.Pose());
-  EXPECT_EQ("ground_plane", actor2.PoseFrame());
-  EXPECT_EQ("/home/path/to/model.sdf", actor2.FilePath());
-
-  EXPECT_EQ(0u, actor2.AnimationCount());
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(0));
-  EXPECT_EQ(nullptr, actor2.AnimationByIndex(1));
-  EXPECT_FALSE(actor2.AnimationNameExists(""));
-  EXPECT_FALSE(actor2.AnimationNameExists("default"));
-
-  EXPECT_EQ("walk.dae", actor2.SkinFilename());
-  EXPECT_DOUBLE_EQ(2.0, actor2.SkinScale());
-
-  EXPECT_EQ(0u, actor2.TrajectoryCount());
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(0));
-  EXPECT_EQ(nullptr, actor2.TrajectoryByIndex(1));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(0));
-  EXPECT_FALSE(actor2.TrajectoryIdExists(1));
-
-  EXPECT_TRUE(actor2.ScriptLoop());
-  EXPECT_DOUBLE_EQ(2.8, actor2.ScriptDelayStart());
-  EXPECT_FALSE(actor2.ScriptAutoStart());
-
-  EXPECT_EQ(0u, actor2.LinkCount());
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(0));
-  EXPECT_EQ(nullptr, actor2.LinkByIndex(1));
-  EXPECT_FALSE(actor2.LinkNameExists(""));
-
-  EXPECT_EQ(0u, actor2.JointCount());
-  EXPECT_EQ(nullptr, actor2.JointByIndex(0));
-  EXPECT_EQ(nullptr, actor2.JointByIndex(1));
-  EXPECT_FALSE(actor2.JointNameExists(""));
+  EXPECT_TRUE(ActorsEqual(CreateDummyActor(), actor2));
 }
 
 /////////////////////////////////////////////////
 TEST(DOMActor, CopyAssignmentAfterMove)
 {
-  sdf::Actor actor1;
-  actor1.SetName("actor1");
-  actor1.SetPose({3, 2, 1, 0, IGN_PI, 0});
-  actor1.SetPoseFrame("ground_plane_1");
-  actor1.SetSkinFilename("walk.dae");
-  actor1.SetSkinScale(2.0);
-  actor1.SetScriptLoop(true);
-  actor1.SetScriptDelayStart(2.8);
-  actor1.SetScriptAutoStart(false);
-
+  sdf::Actor actor1 = CreateDummyActor();
   sdf::Actor actor2;
-  actor2.SetName("actor2");
-  actor2.SetPose({1, 2, 3, 0, IGN_PI, 0});
-  actor2.SetPoseFrame("ground_plane_2");
-  actor2.SetSkinFilename("run.dae");
-  actor2.SetSkinScale(0.5);
-  actor2.SetScriptLoop(false);
-  actor2.SetScriptDelayStart(0.8);
-  actor2.SetScriptAutoStart(true);
 
   // This is similar to what std::swap does except it uses std::move for each
   // assignment
@@ -291,29 +227,8 @@ TEST(DOMActor, CopyAssignmentAfterMove)
   actor1 = actor2;
   actor2 = tmp;
 
-  EXPECT_EQ("actor2", actor1.Name());
-  EXPECT_EQ("actor1", actor2.Name());
-
-  EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, IGN_PI, 0), actor1.Pose());
-  EXPECT_EQ(ignition::math::Pose3d(3, 2, 1, 0, IGN_PI, 0), actor2.Pose());
-
-  EXPECT_EQ("ground_plane_2", actor1.PoseFrame());
-  EXPECT_EQ("ground_plane_1", actor2.PoseFrame());
-
-  EXPECT_EQ("run.dae", actor1.SkinFilename());
-  EXPECT_EQ("walk.dae", actor2.SkinFilename());
-
-  EXPECT_DOUBLE_EQ(0.5, actor1.SkinScale());
-  EXPECT_DOUBLE_EQ(2.0, actor2.SkinScale());
-
-  EXPECT_FALSE(actor1.ScriptLoop());
-  EXPECT_TRUE(actor2.ScriptLoop());
-
-  EXPECT_DOUBLE_EQ(0.8, actor1.ScriptDelayStart());
-  EXPECT_DOUBLE_EQ(2.8, actor2.ScriptDelayStart());
-
-  EXPECT_TRUE(actor1.ScriptAutoStart());
-  EXPECT_FALSE(actor2.ScriptAutoStart());
+  EXPECT_TRUE(ActorsEqual(sdf::Actor(), actor1));
+  EXPECT_TRUE(ActorsEqual(CreateDummyActor(), actor2));
 }
 
 //////////////////////////////////////////////////
@@ -379,4 +294,213 @@ TEST(DOMActor, Add)
   EXPECT_EQ(2u, actor.TrajectoryCount());
   EXPECT_EQ(456u, actor.TrajectoryByIndex(1)->Id());
   EXPECT_EQ("trajectory2", actor.TrajectoryByIndex(1)->Type());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMAnimation, DefaultConstruction)
+{
+  sdf::Animation anim;
+
+  EXPECT_EQ(anim.Name(), "__default__");
+  EXPECT_EQ(anim.Filename(), "__default__");
+  EXPECT_EQ(anim.FilePath(), "");
+  EXPECT_DOUBLE_EQ(anim.Scale(), 1.0);
+  EXPECT_EQ(anim.InterpolateX(), false);
+}
+
+//////////////////////////////////////////////////
+TEST(DOMAnimation, CopyConstructor)
+{
+  sdf::Animation anim1 = CreateDummyAnimation();
+  sdf::Animation anim2(anim1);
+  EXPECT_TRUE(AnimationsEqual(anim1, anim2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMAnimation, CopyAssignmentOperator)
+{
+  sdf::Animation anim1 = CreateDummyAnimation();
+  sdf::Animation anim2;
+  anim2 = anim1;
+  EXPECT_TRUE(AnimationsEqual(anim1, anim2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMAnimation, MoveConstructor)
+{
+  sdf::Animation anim1 = CreateDummyAnimation();
+  sdf::Animation anim2(std::move(anim1));
+  EXPECT_TRUE(AnimationsEqual(CreateDummyAnimation(), anim2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMAnimation, MoveAssignment)
+{
+
+  sdf::Animation anim1 = CreateDummyAnimation();
+  sdf::Animation anim2;
+  anim2 = std::move(anim1);
+  EXPECT_TRUE(AnimationsEqual(CreateDummyAnimation(), anim2));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMAnimation, CopyAssignmentAfterMove)
+{
+  sdf::Animation anim1 = CreateDummyAnimation();
+  sdf::Animation anim2;
+
+  // This is similar to what std::swap does except it uses std::move for each
+  // assignment
+  sdf::Animation tmp = std::move(anim1);
+  anim1 = anim2;
+  anim2 = tmp;
+
+  EXPECT_TRUE(AnimationsEqual(sdf::Animation(), anim1));
+  EXPECT_TRUE(AnimationsEqual(CreateDummyAnimation(), anim2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMWaypoint, DefaultConstruction)
+{
+  sdf::Waypoint waypoint;
+  EXPECT_DOUBLE_EQ(waypoint.Time(), 0.0);
+  EXPECT_EQ(waypoint.Pose(), ignition::math::Pose3d::Zero);
+}
+
+//////////////////////////////////////////////////
+TEST(DOMWaypoint, CopyConstructor)
+{
+  sdf::Waypoint waypoint1;
+  waypoint1.SetTime(1.23);
+  waypoint1.SetPose({3, 2, 1, 0, IGN_PI, 0});
+
+  sdf::Waypoint waypoint2(waypoint1);
+  EXPECT_DOUBLE_EQ(waypoint1.Time(), waypoint2.Time());
+  EXPECT_EQ(waypoint1.Pose(), waypoint2.Pose());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMWaypoint, CopyAssignmentOperator)
+{
+  sdf::Waypoint waypoint1;
+  waypoint1.SetTime(1.23);
+  waypoint1.SetPose({3, 2, 1, 0, IGN_PI, 0});
+
+  sdf::Waypoint waypoint2;
+  waypoint2 = waypoint1;
+  EXPECT_DOUBLE_EQ(waypoint1.Time(), waypoint2.Time());
+  EXPECT_EQ(waypoint1.Pose(), waypoint2.Pose());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMWaypoint, MoveConstructor)
+{
+  sdf::Waypoint waypoint1;
+  ignition::math::Pose3d pose1(3, 2, 1, 0, IGN_PI, 0);
+  waypoint1.SetTime(1.23);
+  waypoint1.SetPose(pose1);
+
+  sdf::Waypoint waypoint2(std::move(waypoint1));
+  EXPECT_DOUBLE_EQ(1.23, waypoint2.Time());
+  EXPECT_EQ(pose1, waypoint2.Pose());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMWaypoint, MoveAssignment)
+{
+  sdf::Waypoint waypoint1;
+  ignition::math::Pose3d pose1(3, 2, 1, 0, IGN_PI, 0);
+  waypoint1.SetTime(1.23);
+  waypoint1.SetPose(pose1);
+
+  sdf::Waypoint waypoint2;
+  waypoint2 = std::move(waypoint1);
+  EXPECT_DOUBLE_EQ(1.23, waypoint2.Time());
+  EXPECT_EQ(pose1, waypoint2.Pose());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMWaypoint, CopyAssignmentAfterMove)
+{
+  sdf::Waypoint waypoint1;
+  ignition::math::Pose3d pose1(3, 2, 1, 0, IGN_PI, 0);
+  waypoint1.SetTime(1.23);
+  waypoint1.SetPose(pose1);
+  sdf::Waypoint waypoint2;
+  ignition::math::Pose3d pose2(1, 2, 3, 1, 2, IGN_PI);
+  waypoint2.SetTime(3.45);
+  waypoint2.SetPose(pose2);
+
+  // This is similar to what std::swap does except it uses std::move for each
+  // assignment
+  sdf::Waypoint tmp = std::move(waypoint1);
+  waypoint1 = waypoint2;
+  waypoint2 = tmp;
+
+  EXPECT_DOUBLE_EQ(1.23, waypoint2.Time());
+  EXPECT_EQ(pose1, waypoint2.Pose());
+  EXPECT_DOUBLE_EQ(3.45, waypoint1.Time());
+  EXPECT_EQ(pose2, waypoint1.Pose());
+}
+
+//////////////////////////////////////////////////
+TEST(DOMTrajectory, DefaultConstruction)
+{
+  sdf::Trajectory trajectory;
+
+  EXPECT_EQ(trajectory.Id(), 0u);
+  EXPECT_EQ(trajectory.Type(), "__default__");
+  EXPECT_DOUBLE_EQ(trajectory.Tension(), 0.0);
+  EXPECT_EQ(trajectory.WaypointCount(), 0u);
+}
+
+//////////////////////////////////////////////////
+TEST(DOMTrajectory, CopyConstructor)
+{
+  sdf::Trajectory trajectory1 = CreateDummyTrajectory();
+  sdf::Trajectory trajectory2(trajectory1);
+  EXPECT_TRUE(TrajectoriesEqual(trajectory1, trajectory2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMTrajectory, CopyAssignmentOperator)
+{
+  sdf::Trajectory trajectory1 = CreateDummyTrajectory();
+  sdf::Trajectory trajectory2;
+  trajectory2 = trajectory1;
+  EXPECT_TRUE(TrajectoriesEqual(trajectory1, trajectory2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMTrajectory, MoveConstructor)
+{
+  sdf::Trajectory trajectory1 = CreateDummyTrajectory();
+  sdf::Trajectory trajectory2(std::move(trajectory1));
+  EXPECT_TRUE(TrajectoriesEqual(CreateDummyTrajectory(), trajectory2));
+}
+
+//////////////////////////////////////////////////
+TEST(DOMTrajectory, MoveAssignment)
+{
+
+  sdf::Trajectory trajectory1 = CreateDummyTrajectory();
+  sdf::Trajectory trajectory2;
+  trajectory2 = std::move(trajectory1);
+  EXPECT_TRUE(TrajectoriesEqual(CreateDummyTrajectory(), trajectory2));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMTrajectory, CopyAssignmentAfterMove)
+{
+  sdf::Trajectory trajectory1 = CreateDummyTrajectory();
+  sdf::Trajectory trajectory2;
+
+  // This is similar to what std::swap does except it uses std::move for each
+  // assignment
+  sdf::Trajectory tmp = std::move(trajectory1);
+  trajectory1 = trajectory2;
+  trajectory2 = tmp;
+
+  EXPECT_TRUE(TrajectoriesEqual(sdf::Trajectory(), trajectory1));
+  EXPECT_TRUE(TrajectoriesEqual(CreateDummyTrajectory(), trajectory2));
 }

--- a/src/Actor_TEST.cc
+++ b/src/Actor_TEST.cc
@@ -336,7 +336,6 @@ TEST(DOMAnimation, MoveConstructor)
 //////////////////////////////////////////////////
 TEST(DOMAnimation, MoveAssignment)
 {
-
   sdf::Animation anim1 = CreateDummyAnimation();
   sdf::Animation anim2;
   anim2 = std::move(anim1);
@@ -482,7 +481,6 @@ TEST(DOMTrajectory, MoveConstructor)
 //////////////////////////////////////////////////
 TEST(DOMTrajectory, MoveAssignment)
 {
-
   sdf::Trajectory trajectory1 = CreateDummyTrajectory();
   sdf::Trajectory trajectory2;
   trajectory2 = std::move(trajectory1);

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -136,3 +136,22 @@ TEST(DOMActor, LoadActors)
   EXPECT_TRUE(actor2->ScriptAutoStart());
 }
 
+//////////////////////////////////////////////////
+TEST(DOMActor, CopySdfElementPtr)
+{
+  // Verify that copying an actor also copies the underling ElementPtr
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+
+  ASSERT_NE(nullptr, root.Element());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  const sdf::Actor *actor1 = world->ActorByIndex(0);
+  sdf::Actor actor2(*actor1);
+
+  EXPECT_EQ(actor1->Element().get(), actor2.Element().get());
+}

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -134,12 +134,16 @@ TEST(DOMActor, LoadActors)
   EXPECT_TRUE(actor2->ScriptLoop());
   EXPECT_DOUBLE_EQ(1.0, actor2->ScriptDelayStart());
   EXPECT_TRUE(actor2->ScriptAutoStart());
+
+  EXPECT_EQ(actor2->LinkCount(), 2u);
+  EXPECT_EQ(actor2->JointCount(), 1u);
 }
 
 //////////////////////////////////////////////////
-TEST(DOMActor, CopySdfElementPtr)
+TEST(DOMActor, CopySdfLoadedProperties)
 {
   // Verify that copying an actor also copies the underling ElementPtr
+  // Joints and Links
   const std::string testFile =
     sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
         "world_complete.sdf");
@@ -150,8 +154,10 @@ TEST(DOMActor, CopySdfElementPtr)
   ASSERT_NE(nullptr, root.Element());
 
   const sdf::World *world = root.WorldByIndex(0);
-  const sdf::Actor *actor1 = world->ActorByIndex(0);
-  sdf::Actor actor2(*actor1);
+  const sdf::Actor *actor2 = world->ActorByIndex(1);
+  sdf::Actor actor1(*actor2);
 
-  EXPECT_EQ(actor1->Element().get(), actor2.Element().get());
+  EXPECT_EQ(actor1.Element().get(), actor2->Element().get());
+  EXPECT_EQ(actor1.LinkCount(), actor2->LinkCount());
+  EXPECT_EQ(actor1.JointCount(), actor2->JointCount());
 }

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -142,7 +142,7 @@ TEST(DOMActor, LoadActors)
 //////////////////////////////////////////////////
 TEST(DOMActor, CopySdfLoadedProperties)
 {
-  // Verify that copying an actor also copies the underling ElementPtr
+  // Verify that copying an actor also copies the underlying ElementPtr
   // Joints and Links
   const std::string testFile =
     sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -135,8 +135,8 @@ TEST(DOMActor, LoadActors)
   EXPECT_DOUBLE_EQ(1.0, actor2->ScriptDelayStart());
   EXPECT_TRUE(actor2->ScriptAutoStart());
 
-  EXPECT_EQ(actor2->LinkCount(), 2u);
-  EXPECT_EQ(actor2->JointCount(), 1u);
+  EXPECT_EQ(2u, actor2->LinkCount());
+  EXPECT_EQ(1u, actor2->JointCount());
 }
 
 //////////////////////////////////////////////////

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -160,6 +160,15 @@
           </waypoint>
         </trajectory>
       </script>
+      <link name="link1">
+      </link>
+      <link name="link2">
+      </link>
+      <joint name="fixed_joint" type="fixed">
+        <pose>0 0 0 1 0 0</pose>
+        <child>link1</child>
+        <parent>link2</parent>
+      </joint>
     </actor>
 
   </world>


### PR DESCRIPTION
This PR is a followup of #299, it changes all the copy operators to use the default copy operator of the private data object, fixing a few properties that were not copied in the manual copy (such as the actor properties trajectories, joints, links, sdf element).

I also took the chance to implement unit tests for every class (before only actors were being tested) and restructure the tests a bit to reduce code duplication.
The tests are now much more comprehensive. What can be set through setter functions is tested in the unit tests. The parts that are set on SDF parsing are tested in the integration test (the example sdf has also been updated to add joints and links, previously untested).

Open to feedback about what to do with the CopyFrom functions, right now they are broken since they don't copy all the properties, I wanted to deprecate them but is that OK to do in a minor release?