### PR TITLE
Enforce minimum/maximum values specified in SDFormat description files (Retry PR)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 ### libsdformat 10.0.0 (202X-XX-XX)
 
+1. Enforce minimum/maximum values specified in SDFormat description files
+    * [Pull request 303](https://github.com/osrf/sdformat/pull/303)
+
 1. Make parsing of values syntactically more strict with bad values generating an error
     * [Pull request 244](https://github.com/osrf/sdformat/pull/244)
 

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,24 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## SDFormat 9.x to 10.0
+
+### Modifications
+
+1. + Minimum/maximum values specified in SDFormat description files are now enforced
+   + [Pull request 303](https://github.com/osrf/sdformat/pull/303)
+
+### Additions
+
+1. **sdf/Element.hh**
+    + void AddValue(const std::string &, const std::string &, bool, const std::string &, const std::string &, const std::string &)
+
+1. **sdf/Param.hh**
+    + Param(const std::string &, const std::string &e, const std::string &, bool, const std::string &, const std::string &, const std::string &)
+    + std::optional<std::string> GetMinValueAsString() const;
+    + std::optional<std::string> GetMaxValueAsString() const;
+    + bool ValidateValue() const;
+
 ## SDFormat 8.x to 9.0
 
 ### Additions

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -174,14 +174,29 @@ namespace sdf
                               const std::string &_description="");
 
     /// \brief Add a value to this Element.
-    /// \param[in] _type Type of data the attribute will hold.
-    /// \param[in] _defaultValue Default value for the attribute.
+    /// \param[in] _type Type of data the parameter will hold.
+    /// \param[in] _defaultValue Default value for the parameter.
     /// \param[in] _required Requirement string. \as Element::SetRequired.
-    /// \param[in] _description A text description of the attribute.
+    /// \param[in] _description A text description of the parameter.
     /// \throws sdf::AssertionInternalError if an invalid type is given.
     public: void AddValue(const std::string &_type,
                           const std::string &_defaultValue, bool _required,
                           const std::string &_description="");
+
+    /// \brief Add a value to this Element. This override allows passing min and
+    /// max values of the parameter.
+    /// \param[in] _type Type of data the parameter will hold.
+    /// \param[in] _defaultValue Default value for the parameter.
+    /// \param[in] _required Requirement string. \as Element::SetRequired.
+    /// \param[in] _minValue Minimum allowed value for the parameter.
+    /// \param[in] _maxValue Maximum allowed value for the parameter.
+    /// \param[in] _description A text description of the parameter.
+    /// \throws sdf::AssertionInternalError if an invalid type is given.
+    public: void AddValue(const std::string &_type,
+                          const std::string &_defaultValue, bool _required,
+                          const std::string &_minValue,
+                          const std::string &_maxValue,
+                          const std::string &_description = "");
 
     /// \brief Get the param of an attribute.
     /// \param[in] _key the name of the attribute.

--- a/include/sdf/Param.hh
+++ b/include/sdf/Param.hh
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <typeinfo>
@@ -105,6 +106,41 @@ namespace sdf
                   const std::string &_default, bool _required,
                   const std::string &_description = "");
 
+    /// \brief Constructor with min and max values.
+    /// \param[in] _key Key for the parameter.
+    /// \param[in] _typeName String name for the value type (double,
+    /// int,...).
+    /// \param[in] _default Default value.
+    /// \param[in] _required True if the parameter is required to be set.
+    /// \param[in] _minValue Minimum allowed value for the parameter.
+    /// \param[in] _maxValue Maximum allowed value for the parameter.
+    /// \param[in] _description Description of the parameter.
+    /// \throws sdf::AssertionInternalError if an invalid type is given.
+    public: Param(const std::string &_key, const std::string &_typeName,
+                  const std::string &_default, bool _required,
+                  const std::string &_minValue, const std::string &_maxValue,
+                  const std::string &_description = "");
+
+    /// \brief Copy constructor
+    /// Note that the updateFunc member does not get copied
+    /// \param[in] _param Param to copy
+    public: Param(const Param &_param);
+
+    /// \brief Move constructor
+    /// \param[in] _param Param to move from
+    public: Param(Param &&_param) noexcept = default;
+
+    /// \brief Copy assignment operator
+    /// Note that the updateFunc member will not get copied
+    /// \param[in] _param The parameter to set values from.
+    /// \return *This
+    public: Param &operator=(const Param &_param);
+
+    /// \brief Move assignment operator
+    /// \param[in] _param Param to move from
+    /// \returns Reference to this
+    public: Param &operator=(Param &&_param) noexcept = default;
+
     /// \brief Destructor
     public: virtual ~Param();
 
@@ -115,6 +151,18 @@ namespace sdf
     /// \brief Get the default value as a string.
     /// \return String containing the default value of the parameter.
     public: std::string GetDefaultAsString() const;
+
+    /// \brief Get the minimum allowed value as a string
+    /// \return Returns a string containing the minimum allowed value of the
+    /// parameter if the minimum value is specified in the SDFormat description
+    /// of the parameter. nullopt otherwise.
+    public: std::optional<std::string> GetMinValueAsString() const;
+
+    /// \brief Get the maximum allowed value as a string
+    /// \return Returns a string containing the maximum allowed value of the
+    /// parameter if the maximum value is specified in the SDFormat description
+    /// of the parameter. nullopt otherwise.
+    public: std::optional<std::string> GetMaxValueAsString() const;
 
     /// \brief Set the parameter value from a string.
     /// \param[in] _value New value for the parameter in string form.
@@ -186,12 +234,6 @@ namespace sdf
     public: template<typename T>
             bool GetDefault(T &_value) const;
 
-    /// \brief Equal operator. Set's the value and default value from the
-    /// provided Param.
-    /// \param[in] _param The parameter to set values from.
-    /// \return *This
-    public: Param &operator=(const Param &_param);
-
     /// \brief Set the description of the parameter.
     /// \param[in] _desc New description for the parameter.
     public: void SetDescription(const std::string &_desc);
@@ -199,6 +241,10 @@ namespace sdf
     /// \brief Get the description of the parameter.
     /// \return The description of the parameter.
     public: std::string GetDescription() const;
+
+    /// \brief Validate the value against minimum and maximum allowed values
+    /// \return True if the value is valid
+    public: bool ValidateValue() const;
 
     /// \brief Ostream operator. Outputs the parameter's value.
     /// \param[in] _out Output stream.
@@ -258,6 +304,12 @@ namespace sdf
 
     /// \brief This parameter's default value
     public: ParamVariant defaultValue;
+
+    /// \brief This parameter's minimum allowed value
+    public: std::optional<ParamVariant> minValue;
+
+    /// \brief This parameter's maximum allowed value
+    public: std::optional<ParamVariant> maxValue;
   };
 
   ///////////////////////////////////////////////

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -122,6 +122,19 @@ void Element::AddValue(const std::string &_type,
 }
 
 /////////////////////////////////////////////////
+void Element::AddValue(const std::string &_type,
+                       const std::string &_defaultValue,
+                       bool _required,
+                       const std::string &_minValue,
+                       const std::string &_maxValue,
+                       const std::string &_description)
+{
+  this->dataPtr->value =
+      std::make_shared<Param>(this->dataPtr->name, _type, _defaultValue,
+                              _required, _minValue, _maxValue, _description);
+}
+
+/////////////////////////////////////////////////
 ParamPtr Element::CreateParam(const std::string &_key,
                               const std::string &_type,
                               const std::string &_defaultValue,
@@ -251,6 +264,17 @@ void Element::PrintDescription(const std::string &_prefix) const
               << "'"
               << " default ='" << this->dataPtr->value->GetDefaultAsString()
               << "'";
+    auto minValue = this->dataPtr->value->GetMinValueAsString();
+    if (minValue.has_value())
+    {
+      std::cout << " min ='" << *minValue << "'";
+    }
+
+    auto maxValue = this->dataPtr->value->GetMaxValueAsString();
+    if (maxValue.has_value())
+    {
+      std::cout << " max ='" << *maxValue << "'";
+    }
   }
 
   std::cout << ">\n";

--- a/src/Param.cc
+++ b/src/Param.cc
@@ -608,6 +608,7 @@ bool Param::GetSet() const
   return this->dataPtr->set;
 }
 
+/////////////////////////////////////////////////
 bool Param::ValidateValue() const
 {
   return std::visit(

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -391,6 +391,26 @@ TEST(Param, SetTemplate)
   EXPECT_DOUBLE_EQ(value, 25.456);
 }
 
+////////////////////////////////////////////////////
+TEST(Param, MinMaxViolation)
+{
+  sdf::Param doubleParam("key", "double", "1.0", false, "0", "10.0",
+                         "description");
+  {
+    double value;
+    EXPECT_TRUE(doubleParam.Get<double>(value));
+    EXPECT_DOUBLE_EQ(value, 1.0);
+  }
+
+  EXPECT_FALSE(doubleParam.Set<double>(-1));
+
+  {
+    double value;
+    EXPECT_TRUE(doubleParam.Get<double>(value));
+    EXPECT_DOUBLE_EQ(value, 1.0);
+  }
+}
+
 /////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)

--- a/src/Param_TEST.cc
+++ b/src/Param_TEST.cc
@@ -402,12 +402,14 @@ TEST(Param, MinMaxViolation)
     EXPECT_DOUBLE_EQ(value, 1.0);
   }
 
-  EXPECT_FALSE(doubleParam.Set<double>(-1));
+  EXPECT_FALSE(doubleParam.Set<double>(-1.));
+  EXPECT_FALSE(doubleParam.Set<double>(11.));
+  EXPECT_TRUE(doubleParam.Set<double>(5.));
 
   {
     double value;
     EXPECT_TRUE(doubleParam.Get<double>(value));
-    EXPECT_DOUBLE_EQ(value, 1.0);
+    EXPECT_DOUBLE_EQ(value, 5.0);
   }
 }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -224,7 +224,22 @@ bool initXml(TiXmlElement *_xml, ElementPtr _sdf)
       description = descChild->GetText();
     }
 
-    _sdf->AddValue(elemTypeString, elemDefaultValue, required, description);
+    std::string minValue;
+    const char *elemMinValue = _xml->Attribute("min");
+    if (nullptr != elemMinValue)
+    {
+      minValue = elemMinValue;
+    }
+
+    std::string maxValue;
+    const char *elemMaxValue = _xml->Attribute("max");
+    if (nullptr != elemMaxValue)
+    {
+      maxValue = elemMaxValue;
+    }
+
+    _sdf->AddValue(elemTypeString, elemDefaultValue, required, minValue,
+                   maxValue, description);
   }
 
   // Get all attributes

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -536,16 +536,20 @@ TEST(Parser, SyntaxErrorInValues)
 /// Fixture for setting up stream redirection
 class ValueConstraintsFixture : public ::testing::Test
 {
+  public: ValueConstraintsFixture() = default;
+
   public: void ClearErrorBuffer()
   {
     this->errBuffer.str("");
   }
 
+  // cppcheck-suppress unusedFunction
   protected: void SetUp() override
   {
     oldRdbuf = std::cerr.rdbuf(errBuffer.rdbuf());
   }
 
+  // cppcheck-suppress unusedFunction
   protected: void TearDown() override
   {
     std::cerr.rdbuf(oldRdbuf);

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -546,6 +546,7 @@ class ValueConstraintsFixture : public ::testing::Test
   // cppcheck-suppress unusedFunction
   protected: void SetUp() override
   {
+    sdf::Console::Instance()->SetQuiet(false);
     oldRdbuf = std::cerr.rdbuf(errBuffer.rdbuf());
   }
 
@@ -553,6 +554,9 @@ class ValueConstraintsFixture : public ::testing::Test
   protected: void TearDown() override
   {
     std::cerr.rdbuf(oldRdbuf);
+#ifdef _WIN32
+    sdf::Console::Instance()->SetQuiet(true);
+#endif
   }
 
   public: std::stringstream errBuffer;

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -533,6 +533,100 @@ TEST(Parser, SyntaxErrorInValues)
 }
 
 /////////////////////////////////////////////////
+/// Fixture for setting up stream redirection
+class ValueConstraintsFixture : public ::testing::Test
+{
+  public: void ClearErrorBuffer()
+  {
+    this->errBuffer.str("");
+  }
+
+  protected: void SetUp() override
+  {
+    oldRdbuf = std::cerr.rdbuf(errBuffer.rdbuf());
+  }
+
+  protected: void TearDown() override
+  {
+    std::cerr.rdbuf(oldRdbuf);
+  }
+
+  public: std::stringstream errBuffer;
+  private: std::streambuf *oldRdbuf;
+};
+
+/////////////////////////////////////////////////
+/// Check if minimum/maximum values are valided
+TEST_F(ValueConstraintsFixture, ElementMinMaxValues)
+{
+  std::string sdfDescPath = std::string(PROJECT_SOURCE_PATH) +
+                            "/test/sdf/stricter_semantics_desc.sdf";
+
+  auto sdfTest = std::make_shared<sdf::SDF>();
+  sdf::initFile(sdfDescPath, sdfTest);
+
+  // Initialize the root.sdf description and add our test description as one of
+  // its children
+  auto sdf = InitSDF();
+  sdf->Root()->AddElementDescription(sdfTest->Root());
+
+  auto wrapInSdf = [](std::string _xml) -> std::string
+  {
+    std::stringstream ss;
+    ss << "<sdf version=\"" << SDF_PROTOCOL_VERSION << "\"><test>" << _xml
+       << "</test></sdf>";
+    return ss.str();
+  };
+
+  {
+    auto elem = sdf->Root()->Clone();
+    sdf::Errors errors;
+    EXPECT_TRUE(sdf::readString(
+        wrapInSdf("<int_t>0</int_t><double_t>0</double_t>"), elem, errors));
+    EXPECT_TRUE(errors.empty()) << errors[0];
+  }
+
+  auto errorContains =
+      [](const std::string &_expStr, const std::string &_errs)
+  {
+    return _errs.find(_expStr) != std::string::npos;
+  };
+
+  {
+    this->ClearErrorBuffer();
+    auto elem = sdf->Root()->Clone();
+    EXPECT_FALSE(sdf::readString(
+        wrapInSdf("<int_t>-1</int_t>"), elem));
+    EXPECT_PRED2(errorContains,
+                 "The value [-1] is less than the minimum allowed value of [0] "
+                 "for key [int_t]",
+                 this->errBuffer.str());
+  }
+
+  {
+    this->ClearErrorBuffer();
+    auto elem = sdf->Root()->Clone();
+    EXPECT_FALSE(sdf::readString(
+        wrapInSdf("<double_t>-1.0</double_t>"), elem));
+
+    EXPECT_PRED2(
+        errorContains,
+        "The value [-1] is less than the minimum allowed value of [0] for key "
+        "[double_t]",
+        this->errBuffer.str());
+  }
+
+  {
+    this->ClearErrorBuffer();
+    auto elem = sdf->Root()->Clone();
+    EXPECT_FALSE(sdf::readString(wrapInSdf("<int_t>20</int_t>"), elem));
+    EXPECT_PRED2(
+        errorContains,
+        "The value [20] is greater than the maximum allowed value of [10]",
+        this->errBuffer.str());
+  }
+}
+
 /////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -41,13 +41,29 @@ namespace sdf
   static std::string getBestSupportedModelVersion(TiXmlElement *_modelXML,
                                                   std::string &_modelFileName);
 
-  /// \brief Initialize the SDF interface using a TinyXML document
+  /// \brief Initialize the SDF interface using a TinyXML document.
+  ///
+  /// This actually forwards to initXml after converting the inputs
+  /// \param[in] _xmlDoc TinyXML document containing the SDFormat description
+  /// file that corresponds with the input SDFPtr
+  /// \param[in] _sdf SDF interface to be initialized
   static bool initDoc(TiXmlDocument *_xmlDoc, SDFPtr _sdf);
 
-  /// \brief Initialize and SDF Element using a TinyXML document
+  /// \brief Initialize the SDF Element using a TinyXML document
+  ///
+  /// This actually forwards to initXml after converting the inputs
+  /// \param[in] _xmlDoc TinyXML document containing the SDFormat description
+  /// file that corresponds with the input ElementPtr
+  /// \param[in] _sdf SDF Element to be initialized
   static bool initDoc(TiXmlDocument *_xmlDoc, ElementPtr _sdf);
 
-  /// \brief For internal use only. Do not use this function.
+  /// \brief Initialize the SDF Element by parsing the SDFormat description in
+  /// the input TinyXML element. This is where SDFormat spec/description files
+  /// are parsed
+  /// \remark For internal use only. Do not use this function.
+  /// \param[in] _xml TinyXML element containing the SDFormat description
+  /// file that corresponds with the input ElementPtr
+  /// \param[in] _sdf SDF ElementPtr to be initialized
   static bool initXml(TiXmlElement *_xml, ElementPtr _sdf);
 
   /// \brief Populate the SDF values from a TinyXML document
@@ -55,11 +71,15 @@ namespace sdf
                       const std::string &_source, bool _convert,
                       Errors &_errors);
 
+  /// \brief Populate the SDF values from a TinyXML document
   static bool readDoc(TiXmlDocument *_xmlDoc, ElementPtr _sdf,
       const std::string &_source, bool _convert, Errors &_errors);
 
-  /// \brief For internal use only. Do not use this function.
-  /// \param[in] _xml Pointer to the XML document
+  /// \brief Populate an SDF Element from the XML input. The XML input here is
+  /// an actual SDFormat file or string, not the description of the SDFormat
+  /// spec.
+  /// \remark For internal use only. Do not use this function.
+  /// \param[in] _xml Pointer to the TinyXML element
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.

--- a/test/sdf/stricter_semantics_desc.sdf
+++ b/test/sdf/stricter_semantics_desc.sdf
@@ -1,0 +1,5 @@
+<element name="test" required="1">
+  <element name="int_t" required="0" type="int" min="0" max="10" default="0"/>
+  <element name="double_t" required="0" type="double" min="0.0" max="10.0" default="0"/>
+</element>
+


### PR DESCRIPTION
Currently, some SDFormat description files contain min and max values, but the parser does not enforce those values in any way. This PR adds a validation step in the parser that checks if scalar values are within the allowed range. Note that this PR addresses only element values, not attributes.

Toward #260.

This is a retry of #259.
