### PR TITLE
sdf 1.8: support specifying frames as joint child/parent

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -221,6 +221,10 @@ but with improved human-readability..
 
 ## SDF protocol 1.7 to 1.8
 
+### Modifications
+
+1. **joint.sdf** `child` and `parent` elements accept frame names instead of only link names
+
 ### Deprecations
 
 1. **joint.sdf** `initial_position` element in `<joint><axis>` and `<joint><axis2>` is deprecated

--- a/Migration.md
+++ b/Migration.md
@@ -35,7 +35,7 @@ but with improved human-readability..
 1. + Removed the `parser_urdf.hh` header file and its `URDF2SDF` class
    + [Pull request 276](https://github.com/osrf/sdformat/pull/276)
 
-1. + Removed the deprecated `Pose()`, `SetPose(), and `*PoseFrame()` API's in all DOM classes:
+1. + Removed the deprecated `Pose()`, `SetPose()`, and `*PoseFrame()` API's in all DOM classes:
    + const ignition::math::Pose3d &Pose()
    + void SetPose(const ignition::math::Pose3d &)
    + const std::string &PoseFrame()

--- a/Migration.md
+++ b/Migration.md
@@ -232,6 +232,7 @@ but with improved human-readability..
 ### Modifications
 
 1. **joint.sdf** `child` and `parent` elements accept frame names instead of only link names
+    * [Issue 204](https://github.com/osrf/sdformat/issues/204)
 
 ### Deprecations
 

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,14 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## SDFormat 10.x to 11.0
+
+### Additions
+
+1. **sdf/Joint.hh**
+    + Errors ResolveChildLink(std::string&) const
+    + Errors ResolveParentLink(std::string&) const
+
 ## SDFormat 9.x to 10.0
 
 ### Modifications

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -35,6 +35,7 @@ namespace sdf
   // Forward declarations.
   class JointAxis;
   class JointPrivate;
+  struct FrameAttachedToGraph;
   struct PoseRelativeToGraph;
 
   /// \enum JointType
@@ -147,6 +148,18 @@ namespace sdf
     /// \param[in] _name Name of the child link.
     public: void SetChildLinkName(const std::string &_name);
 
+    /// \brief Resolve the name of the child link from the
+    /// FrameAttachedToGraph.
+    /// \param[out] _body Name of child link of this joint.
+    /// \return Errors.
+    public: Errors ResolveChildLink(std::string &_link) const;
+
+    /// \brief Resolve the name of the parent link from the
+    /// FrameAttachedToGraph. It will return the name of a link or "world".
+    /// \param[out] _body Name of parent link of this joint.
+    /// \return Errors.
+    public: Errors ResolveParentLink(std::string &_link) const;
+
     /// \brief Get a joint axis.
     /// \param[in] _index This value specifies which axis to get. A value of
     /// zero corresponds to the first axis, which is the <axis> SDF
@@ -207,6 +220,13 @@ namespace sdf
     /// poses.
     /// \return SemanticPose object for this link.
     public: sdf::SemanticPose SemanticPose() const;
+
+    /// \brief Give a weak pointer to the FrameAttachedToGraph to be used
+    /// for resolving parent and child link names. This is private and is
+    /// intended to be called by  Model::Load.
+    /// \param[in] _graph Weak pointer to FrameAttachedToGraph.
+    private: void SetFrameAttachedToGraph(
+        std::weak_ptr<const FrameAttachedToGraph> _graph);
 
     /// \brief Give a weak pointer to the PoseRelativeToGraph to be used
     /// for resolving poses. This is private and is intended to be called by

--- a/sdf/1.8/joint.sdf
+++ b/sdf/1.8/joint.sdf
@@ -21,11 +21,11 @@
   </attribute>
 
   <element name="parent" type="string" default="__default__" required="1">
-    <description>Name of the parent link or "world".</description>
+    <description>Name of the parent frame or "world".</description>
   </element> <!-- End Parent -->
 
   <element name="child" type="string" default="__default__" required="1">
-    <description>Name of the child link. The value "world" may not be specified.</description>
+    <description>Name of the child frame. The value "world" may not be specified.</description>
   </element> <!-- End Child -->
 
   <element name="gearbox_ratio" type="double" default="1.0" required="0">

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -24,6 +24,7 @@
 #include "sdf/Joint.hh"
 #include "sdf/JointAxis.hh"
 #include "sdf/Types.hh"
+#include "FrameSemantics.hh"
 #include "Utils.hh"
 
 using namespace sdf;
@@ -73,6 +74,9 @@ class sdf::JointPrivate
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf;
 
+  /// \brief Weak pointer to model's Frame Attached-To Graph.
+  public: std::weak_ptr<const sdf::FrameAttachedToGraph> frameAttachedToGraph;
+
   /// \brief Weak pointer to model's Pose Relative-To Graph.
   public: std::weak_ptr<const sdf::PoseRelativeToGraph> poseRelativeToGraph;
 };
@@ -87,6 +91,7 @@ JointPrivate::JointPrivate(const JointPrivate &_jointPrivate)
       poseRelativeTo(_jointPrivate.poseRelativeTo),
       threadPitch(_jointPrivate.threadPitch),
       sdf(_jointPrivate.sdf),
+      frameAttachedToGraph(_jointPrivate.frameAttachedToGraph),
       poseRelativeToGraph(_jointPrivate.poseRelativeToGraph)
 {
   for (std::size_t i = 0; i < _jointPrivate.axis.size(); ++i)
@@ -355,6 +360,13 @@ void Joint::SetPoseRelativeTo(const std::string &_frame)
 }
 
 /////////////////////////////////////////////////
+void Joint::SetFrameAttachedToGraph(
+    std::weak_ptr<const FrameAttachedToGraph> _graph)
+{
+  this->dataPtr->frameAttachedToGraph = _graph;
+}
+
+/////////////////////////////////////////////////
 void Joint::SetPoseRelativeToGraph(
     std::weak_ptr<const PoseRelativeToGraph> _graph)
 {
@@ -368,6 +380,50 @@ void Joint::SetPoseRelativeToGraph(
       axis->SetPoseRelativeToGraph(this->dataPtr->poseRelativeToGraph);
     }
   }
+}
+
+/////////////////////////////////////////////////
+Errors Joint::ResolveChildLink(std::string &_link) const
+{
+  Errors errors;
+
+  auto graph = this->dataPtr->frameAttachedToGraph.lock();
+  if (!graph)
+  {
+    errors.push_back({ErrorCode::ELEMENT_INVALID,
+        "Frame has invalid pointer to FrameAttachedToGraph."});
+    return errors;
+  }
+
+  std::string link;
+  errors = resolveFrameAttachedToBody(link, *graph, this->ChildLinkName());
+  if (errors.empty())
+  {
+    _link = link;
+  }
+  return errors;
+}
+
+/////////////////////////////////////////////////
+Errors Joint::ResolveParentLink(std::string &_link) const
+{
+  Errors errors;
+
+  auto graph = this->dataPtr->frameAttachedToGraph.lock();
+  if (!graph)
+  {
+    errors.push_back({ErrorCode::ELEMENT_INVALID,
+        "Frame has invalid pointer to FrameAttachedToGraph."});
+    return errors;
+  }
+
+  std::string link;
+  errors = resolveFrameAttachedToBody(link, *graph, this->ParentLinkName());
+  if (errors.empty())
+  {
+    _link = link;
+  }
+  return errors;
 }
 
 /////////////////////////////////////////////////

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -409,6 +409,14 @@ Errors Joint::ResolveParentLink(std::string &_link) const
 {
   Errors errors;
 
+  // special case for world, return without resolving since it's not in a
+  // model's FrameAttachedToGraph
+  if ("world" == this->ParentLinkName())
+  {
+    _link = "world";
+    return errors;
+  }
+
   auto graph = this->dataPtr->frameAttachedToGraph.lock();
   if (!graph)
   {

--- a/src/Joint_TEST.cc
+++ b/src/Joint_TEST.cc
@@ -64,6 +64,12 @@ TEST(DOMJoint, Construction)
   joint.SetChildLinkName("child");
   EXPECT_EQ("child", joint.ChildLinkName());
 
+  std::string body;
+  EXPECT_FALSE(joint.ResolveChildLink(body).empty());
+  EXPECT_TRUE(body.empty());
+  EXPECT_FALSE(joint.ResolveParentLink(body).empty());
+  EXPECT_TRUE(body.empty());
+
   joint.SetType(sdf::JointType::BALL);
   EXPECT_EQ(sdf::JointType::BALL, joint.Type());
   joint.SetType(sdf::JointType::CONTINUOUS);

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -114,6 +114,7 @@ Model::Model(const Model &_model)
   }
   for (auto &joint : this->dataPtr->joints)
   {
+    joint.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
     joint.SetPoseRelativeToGraph(this->dataPtr->poseGraph);
   }
   for (auto &frame : this->dataPtr->frames)
@@ -328,6 +329,10 @@ Errors Model::Load(ElementPtr _sdf)
       validateFrameAttachedToGraph(*this->dataPtr->frameAttachedToGraph);
     errors.insert(errors.end(), validateFrameAttachedGraphErrors.begin(),
                                 validateFrameAttachedGraphErrors.end());
+    for (auto &joint : this->dataPtr->joints)
+    {
+      joint.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);
+    }
     for (auto &frame : this->dataPtr->frames)
     {
       frame.SetFrameAttachedToGraph(this->dataPtr->frameAttachedToGraph);

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -254,6 +254,21 @@ TEST(check, SDF)
               std::string::npos) << output;
   }
 
+  // Check an SDF file with a joint with parent parent frame that resolves
+  // to the same value as the child.
+  {
+    std::string path =
+        pathBase + "/joint_invalid_resolved_parent_same_as_child.sdf";
+
+    // Check joint_invalid_resolved_parent_same_as_child.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("specified parent frame [J1] and child frame [L2] "
+                          "that both resolve to [L2], but they should resolve "
+                          "to different values."),
+              std::string::npos) << output;
+  }
+
   // Check an SDF file with the world specified as a child link.
   {
     std::string path = pathBase +"/joint_child_world.sdf";

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -277,7 +277,7 @@ TEST(check, SDF)
     EXPECT_EQ("Valid.\n", output) << output;
   }
 
-  // Check an SDF file with the world specified as a parent link.
+  // Check an SDF file with a frame specified as the joint child.
   // This is a valid file.
   {
     std::string path = pathBase +"/joint_child_frame.sdf";
@@ -288,7 +288,7 @@ TEST(check, SDF)
     EXPECT_EQ("Valid.\n", output) << output;
   }
 
-  // Check an SDF file with the world specified as a parent link.
+  // Check an SDF file with a frame specified as the joint parent.
   // This is a valid file.
   {
     std::string path = pathBase +"/joint_parent_frame.sdf";

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -197,7 +197,7 @@ TEST(check, SDF)
     // Check joint_invalid_child.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
-    EXPECT_NE(output.find("Error: Child link with name[invalid] specified by "
+    EXPECT_NE(output.find("Error: Child frame with name[invalid] specified by "
                           "joint with name[joint] not found in model with "
                           "name[joint_invalid_child]."),
               std::string::npos) << output;
@@ -210,9 +210,34 @@ TEST(check, SDF)
     // Check joint_invalid_parent.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
-    EXPECT_NE(output.find("Error: parent link with name[invalid] specified by "
+    EXPECT_NE(output.find("Error: parent frame with name[invalid] specified by "
                           "joint with name[joint] not found in model with "
                           "name[joint_invalid_parent]."),
+              std::string::npos) << output;
+  }
+
+  // Check an SDF file with a joint with an invalid child link.
+  {
+    std::string path = pathBase +"/joint_invalid_self_child.sdf";
+
+    // Check joint_invalid_self_child.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("Error: FrameAttachedToGraph cycle detected, "
+                          "already visited vertex [self]."),
+              std::string::npos) << output;
+  }
+
+  // Check an SDF file with a joint with an invalid parent link.
+  {
+    std::string path = pathBase +"/joint_invalid_self_parent.sdf";
+
+    // Check joint_invalid_self_parent.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("Error: joint with name[self] in model with "
+                          "name[joint_invalid_self_parent] must not specify "
+                          "its own name as the parent frame."),
               std::string::npos) << output;
   }
 
@@ -247,6 +272,28 @@ TEST(check, SDF)
     std::string path = pathBase +"/joint_parent_world.sdf";
 
     // Check joint_parent_world.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with the world specified as a parent link.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_child_frame.sdf";
+
+    // Check joint_child_frame.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with the world specified as a parent link.
+  // This is a valid file.
+  {
+    std::string path = pathBase +"/joint_parent_frame.sdf";
+
+    // Check joint_parent_frame.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
     EXPECT_EQ("Valid.\n", output) << output;

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -216,7 +216,7 @@ TEST(check, SDF)
               std::string::npos) << output;
   }
 
-  // Check an SDF file with a joint with an invalid child link.
+  // Check an SDF file with a joint that names itself as the child frame.
   {
     std::string path = pathBase +"/joint_invalid_self_child.sdf";
 
@@ -228,7 +228,7 @@ TEST(check, SDF)
               std::string::npos) << output;
   }
 
-  // Check an SDF file with a joint with an invalid parent link.
+  // Check an SDF file with a joint that names itself as the parent frame.
   {
     std::string path = pathBase +"/joint_invalid_self_parent.sdf";
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1892,13 +1892,39 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
         modelResult = false;
       }
 
-      if (childName == parentName)
+      // Check that parent and child frames resolve to different links
+      std::string resolvedChildName;
+      std::string resolvedParentName;
+      auto errors = joint->ResolveChildLink(resolvedChildName);
+      if (!errors.empty())
+      {
+        std::cerr << "Error when attempting to resolve child link name:"
+                  << std::endl;
+        for (auto error : errors)
+        {
+          std::cerr << error.Message() << std::endl;
+        }
+        modelResult = false;
+      }
+      errors = joint->ResolveParentLink(resolvedParentName);
+      if (!errors.empty())
+      {
+        std::cerr << "Error when attempting to resolve parent link name:"
+                  << std::endl;
+        for (auto error : errors)
+        {
+          std::cerr << error.Message() << std::endl;
+        }
+        modelResult = false;
+      }
+      if (resolvedChildName == resolvedParentName)
       {
         std::cerr << "Error: joint with name[" << joint->Name()
                   << "] in model with name[" << _model->Name()
-                  << "] must specify different link names for "
-                  << "parent and child, while [" << childName
-                  << "] was specified for both."
+                  << "] specified parent frame [" << parentName
+                  << "] and child frame [" << childName
+                  << "] that both resolve to [" << resolvedChildName
+                  << "], but they should resolve to different values."
                   << std::endl;
         modelResult = false;
       }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1839,9 +1839,11 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
       auto joint = _model->JointByIndex(j);
 
       const std::string &parentName = joint->ParentLinkName();
-      if (parentName != "world" && !_model->LinkNameExists(parentName))
+      if (parentName != "world" && !_model->LinkNameExists(parentName) &&
+          !_model->JointNameExists(parentName) &&
+          !_model->FrameNameExists(parentName))
       {
-        std::cerr << "Error: parent link with name[" << parentName
+        std::cerr << "Error: parent frame with name[" << parentName
                   << "] specified by joint with name[" << joint->Name()
                   << "] not found in model with name[" << _model->Name()
                   << "]."
@@ -1850,12 +1852,42 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
       }
 
       const std::string &childName = joint->ChildLinkName();
-      if (childName != "world" && !_model->LinkNameExists(childName))
+      if (childName == "world")
       {
-        std::cerr << "Error: child link with name[" << childName
+        std::cerr << "Error: invalid child name[world"
+                  << "] specified by joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "]."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (!_model->LinkNameExists(childName) &&
+          !_model->JointNameExists(childName) &&
+          !_model->FrameNameExists(childName))
+      {
+        std::cerr << "Error: child frame with name[" << childName
                   << "] specified by joint with name[" << joint->Name()
                   << "] not found in model with name[" << _model->Name()
                   << "]."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (childName == joint->Name())
+      {
+        std::cerr << "Error: joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "] must not specify its own name as the child frame."
+                  << std::endl;
+        modelResult = false;
+      }
+
+      if (parentName == joint->Name())
+      {
+        std::cerr << "Error: joint with name[" << joint->Name()
+                  << "] in model with name[" << _model->Name()
+                  << "] must not specify its own name as the parent frame."
                   << std::endl;
         modelResult = false;
       }

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -221,7 +221,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[1].Message().find(
-      "Child link with name[world] specified by joint with name[joint] "
+      "Child frame with name[world] specified by joint with name[joint] "
       "not found in model with name[joint_child_world]"));
 }
 
@@ -366,7 +366,7 @@ TEST(DOMJoint, LoadInvalidChild)
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
-      "Child link with name[invalid] specified by joint with name[joint] not "
+      "Child frame with name[invalid] specified by joint with name[joint] not "
       "found"));
   EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::FRAME_ATTACHED_TO_GRAPH_ERROR);
   EXPECT_NE(std::string::npos,

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -20,6 +20,7 @@
 
 #include "sdf/Element.hh"
 #include "sdf/Filesystem.hh"
+#include "sdf/Frame.hh"
 #include "sdf/Joint.hh"
 #include "sdf/JointAxis.hh"
 #include "sdf/Link.hh"
@@ -223,6 +224,176 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
     errors[1].Message().find(
       "Child frame with name[world] specified by joint with name[joint] "
       "not found in model with name[joint_child_world]"));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMJoint, LoadJointParentFrame)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "joint_parent_frame.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  EXPECT_TRUE(root.Load(testFile).empty());
+
+  using Pose = ignition::math::Pose3d;
+
+  // Get the first model
+  const sdf::Model *model = root.ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ("joint_parent_frame", model->Name());
+  EXPECT_EQ(2u, model->LinkCount());
+  EXPECT_NE(nullptr, model->LinkByIndex(0));
+  EXPECT_NE(nullptr, model->LinkByIndex(1));
+  EXPECT_EQ(nullptr, model->LinkByIndex(2));
+  EXPECT_EQ(Pose(0, 0, 0, 0, 0, 0), model->RawPose());
+  EXPECT_EQ("", model->PoseRelativeTo());
+
+  ASSERT_TRUE(model->LinkNameExists("parent_link"));
+  ASSERT_TRUE(model->LinkNameExists("child_link"));
+  EXPECT_TRUE(model->LinkByName("parent_link")->PoseRelativeTo().empty());
+  EXPECT_TRUE(model->LinkByName("child_link")->PoseRelativeTo().empty());
+
+  EXPECT_EQ(Pose(0, 0, 1, 0, 0, 0),
+            model->LinkByName("parent_link")->RawPose());
+  EXPECT_EQ(Pose(0, 0, 10, 0, 0, 0),
+            model->LinkByName("child_link")->RawPose());
+
+  EXPECT_TRUE(model->CanonicalLinkName().empty());
+
+  EXPECT_EQ(1u, model->JointCount());
+  EXPECT_NE(nullptr, model->JointByIndex(0));
+  EXPECT_EQ(nullptr, model->JointByIndex(1));
+  ASSERT_TRUE(model->JointNameExists("joint"));
+  EXPECT_EQ("child_link", model->JointByName("joint")->ChildLinkName());
+  EXPECT_EQ("parent_frame", model->JointByName("joint")->ParentLinkName());
+  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
+
+  EXPECT_EQ(Pose(0, 1, 0, 0, 0, 0), model->JointByName("joint")->RawPose());
+
+  EXPECT_EQ(1u, model->FrameCount());
+  EXPECT_NE(nullptr, model->FrameByIndex(0));
+  EXPECT_EQ(nullptr, model->FrameByIndex(1));
+
+  ASSERT_TRUE(model->FrameNameExists("parent_frame"));
+
+  EXPECT_EQ(Pose(1, 0, 0, 0, 0, 0),
+            model->FrameByName("parent_frame")->RawPose());
+
+  // Test ResolveFrame to get each link, joint and frame pose in model frame.
+  Pose pose;
+  EXPECT_TRUE(
+    model->LinkByName("parent_link")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(0, 0, 1, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->LinkByName("child_link")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(0, 0, 10, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(0, 1, 10, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->FrameByName("parent_frame")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(1, 0, 1, 0, 0, 0), pose);
+
+  // joint frame relative to parent and child links
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "child_link").empty());
+  EXPECT_EQ(Pose(0, 1, 0, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "parent_link").empty());
+  EXPECT_EQ(Pose(0, 1, 9, 0, 0, 0), pose);
+}
+
+/////////////////////////////////////////////////
+TEST(DOMJoint, LoadJointChildFrame)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "joint_child_frame.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  EXPECT_TRUE(root.Load(testFile).empty());
+
+  using Pose = ignition::math::Pose3d;
+
+  // Get the first model
+  const sdf::Model *model = root.ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ("joint_child_frame", model->Name());
+  EXPECT_EQ(2u, model->LinkCount());
+  EXPECT_NE(nullptr, model->LinkByIndex(0));
+  EXPECT_NE(nullptr, model->LinkByIndex(1));
+  EXPECT_EQ(nullptr, model->LinkByIndex(2));
+  EXPECT_EQ(Pose(0, 0, 0, 0, 0, 0), model->RawPose());
+  EXPECT_EQ("", model->PoseRelativeTo());
+
+  ASSERT_TRUE(model->LinkNameExists("parent_link"));
+  ASSERT_TRUE(model->LinkNameExists("child_link"));
+  EXPECT_TRUE(model->LinkByName("parent_link")->PoseRelativeTo().empty());
+  EXPECT_TRUE(model->LinkByName("child_link")->PoseRelativeTo().empty());
+
+  EXPECT_EQ(Pose(0, 0, 1, 0, 0, 0),
+            model->LinkByName("parent_link")->RawPose());
+  EXPECT_EQ(Pose(0, 0, 10, 0, 0, 0),
+            model->LinkByName("child_link")->RawPose());
+
+  EXPECT_TRUE(model->CanonicalLinkName().empty());
+
+  EXPECT_EQ(1u, model->JointCount());
+  EXPECT_NE(nullptr, model->JointByIndex(0));
+  EXPECT_EQ(nullptr, model->JointByIndex(1));
+  ASSERT_TRUE(model->JointNameExists("joint"));
+  EXPECT_EQ("child_frame", model->JointByName("joint")->ChildLinkName());
+  EXPECT_EQ("parent_link", model->JointByName("joint")->ParentLinkName());
+  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
+
+  EXPECT_EQ(Pose(0, 1, 0, 0, 0, 0), model->JointByName("joint")->RawPose());
+
+  EXPECT_EQ(1u, model->FrameCount());
+  EXPECT_NE(nullptr, model->FrameByIndex(0));
+  EXPECT_EQ(nullptr, model->FrameByIndex(1));
+
+  ASSERT_TRUE(model->FrameNameExists("child_frame"));
+
+  EXPECT_EQ(Pose(1, 0, 0, 0, 0, 0),
+            model->FrameByName("child_frame")->RawPose());
+
+  // Test ResolveFrame to get each link, joint and frame pose in model frame.
+  Pose pose;
+  EXPECT_TRUE(
+    model->LinkByName("parent_link")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(0, 0, 1, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->LinkByName("child_link")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(0, 0, 10, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(1, 1, 10, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->FrameByName("child_frame")->
+      SemanticPose().Resolve(pose, "__model__").empty());
+  EXPECT_EQ(Pose(1, 0, 10, 0, 0, 0), pose);
+
+  // joint frame relative to parent and child links
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "child_link").empty());
+  EXPECT_EQ(Pose(1, 1, 0, 0, 0, 0), pose);
+  EXPECT_TRUE(
+    model->JointByName("joint")->
+      SemanticPose().Resolve(pose, "parent_link").empty());
+  EXPECT_EQ(Pose(1, 1, 9, 0, 0, 0), pose);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -268,8 +268,16 @@ TEST(DOMJoint, LoadJointParentFrame)
   ASSERT_TRUE(model->JointNameExists("joint"));
   EXPECT_EQ("child_link", model->JointByName("joint")->ChildLinkName());
   EXPECT_EQ("parent_frame", model->JointByName("joint")->ParentLinkName());
-  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
 
+  std::string resolvedLinkName;
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveChildLink(resolvedLinkName).empty());
+  EXPECT_EQ("child_link", resolvedLinkName);
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveParentLink(resolvedLinkName).empty());
+  EXPECT_EQ("parent_link", resolvedLinkName);
+
+  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
   EXPECT_EQ(Pose(0, 1, 0, 0, 0, 0), model->JointByName("joint")->RawPose());
 
   EXPECT_EQ(1u, model->FrameCount());
@@ -353,8 +361,16 @@ TEST(DOMJoint, LoadJointChildFrame)
   ASSERT_TRUE(model->JointNameExists("joint"));
   EXPECT_EQ("child_frame", model->JointByName("joint")->ChildLinkName());
   EXPECT_EQ("parent_link", model->JointByName("joint")->ParentLinkName());
-  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
 
+  std::string resolvedLinkName;
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveChildLink(resolvedLinkName).empty());
+  EXPECT_EQ("child_link", resolvedLinkName);
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveParentLink(resolvedLinkName).empty());
+  EXPECT_EQ("parent_link", resolvedLinkName);
+
+  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
   EXPECT_EQ(Pose(0, 1, 0, 0, 0, 0), model->JointByName("joint")->RawPose());
 
   EXPECT_EQ(1u, model->FrameCount());

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -397,15 +397,15 @@ TEST(DOMJoint, LoadLinkJointSameName17Invalid)
   for (auto e : errors)
     std::cout << e << std::endl;
   EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(2u, errors.size());
+  EXPECT_EQ(7u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::DUPLICATE_NAME);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
       "Joint with non-unique name [attachment] detected in model with name "
       "[link_joint_same_name]."));
-  EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::DUPLICATE_NAME);
+  EXPECT_EQ(errors[3].Code(), sdf::ErrorCode::DUPLICATE_NAME);
   EXPECT_NE(std::string::npos,
-    errors[1].Message().find(
+    errors[3].Message().find(
       "Joint with non-unique name [attachment] detected in model with name "
       "[link_joint_same_name]."));
 }

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -193,9 +193,16 @@ TEST(DOMJoint, LoadJointParentWorld)
   ASSERT_TRUE(model->JointNameExists("joint"));
   EXPECT_EQ("link", model->JointByName("joint")->ChildLinkName());
   EXPECT_EQ("world", model->JointByName("joint")->ParentLinkName());
-  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
+  std::string resolvedLinkName;
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveChildLink(resolvedLinkName).empty());
+  EXPECT_EQ("link", resolvedLinkName);
+  EXPECT_TRUE(
+    model->JointByName("joint")->ResolveParentLink(resolvedLinkName).empty());
+  EXPECT_EQ("world", resolvedLinkName);
 
   EXPECT_EQ(Pose(0, 0, 3, 0, 0, 0), model->JointByName("joint")->RawPose());
+  EXPECT_TRUE(model->JointByName("joint")->PoseRelativeTo().empty());
 
   EXPECT_EQ(0u, model->FrameCount());
   EXPECT_EQ(nullptr, model->FrameByIndex(0));

--- a/test/sdf/joint_child_frame.sdf
+++ b/test/sdf/joint_child_frame.sdf
@@ -1,11 +1,17 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
   <model name="joint_child_frame">
+    <!--
+      For ease of unittesting unique values,
+      each link's pose is displaced along the z-axis,
+      frames are displaced along the y-axis,
+      and joints are displaced along the x-axis.
+    -->
     <link name="parent_link">
       <pose>0 0 1 0 0 0</pose>
     </link>
     <link name="child_link">
-      <pose>0 0 3 0 0 0</pose>
+      <pose>0 0 10 0 0 0</pose>
     </link>
     <frame name="child_frame" attached_to="child_link">
       <pose>1 0 0 0 0 0</pose>

--- a/test/sdf/joint_child_frame.sdf
+++ b/test/sdf/joint_child_frame.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_child_frame">
+    <link name="parent_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <link name="child_link">
+      <pose>0 0 3 0 0 0</pose>
+    </link>
+    <frame name="child_frame" attached_to="child_link">
+      <pose>1 0 0 0 0 0</pose>
+    </frame>
+    <joint name="joint" type="fixed">
+      <pose>0 1 0 0 0 0</pose>
+      <parent>parent_link</parent>
+      <child>child_frame</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_resolved_parent_same_as_child.sdf
+++ b/test/sdf/joint_invalid_resolved_parent_same_as_child.sdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_invalid_resolved_parent_same_as_child.sdf">
+    <link name="L1"/>
+
+    <joint name="J1" type="prismatic">
+      <parent>L1</parent>
+      <child>J2</child>
+      <axis>
+        <xyz>1 0 0</xyz>
+      </axis>
+    </joint>
+
+    <joint name="J2" type="prismatic">
+      <parent>J1</parent>
+      <child>L2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+      </axis>
+    </joint>
+
+    <link name="L2"/>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_self_child.sdf
+++ b/test/sdf/joint_invalid_self_child.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.6">
+<sdf version="1.8">
   <model name="joint_invalid_self_child">
     <link name="link">
       <pose>0 0 1 0 0 0</pose>

--- a/test/sdf/joint_invalid_self_child.sdf
+++ b/test/sdf/joint_invalid_self_child.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_invalid_self_child">
+    <link name="link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <joint name="self" type="fixed">
+      <pose>0 0 3 0 0 0</pose>
+      <parent>link</parent>
+      <child>self</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_self_parent.sdf
+++ b/test/sdf/joint_invalid_self_parent.sdf
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_invalid_self_parent">
+    <link name="link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <joint name="self" type="fixed">
+      <pose>0 0 3 0 0 0</pose>
+      <parent>self</parent>
+      <child>link</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_invalid_self_parent.sdf
+++ b/test/sdf/joint_invalid_self_parent.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.6">
+<sdf version="1.8">
   <model name="joint_invalid_self_parent">
     <link name="link">
       <pose>0 0 1 0 0 0</pose>

--- a/test/sdf/joint_parent_frame.sdf
+++ b/test/sdf/joint_parent_frame.sdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+  <model name="joint_parent_frame">
+    <link name="parent_link">
+      <pose>0 0 1 0 0 0</pose>
+    </link>
+    <link name="child_link">
+      <pose>0 0 3 0 0 0</pose>
+    </link>
+    <frame name="parent_frame" attached_to="parent_link">
+      <pose>1 0 0 0 0 0</pose>
+    </frame>
+    <joint name="joint" type="fixed">
+      <pose>0 1 0 0 0 0</pose>
+      <parent>parent_frame</parent>
+      <child>child_link</child>
+    </joint>
+  </model>
+</sdf>

--- a/test/sdf/joint_parent_frame.sdf
+++ b/test/sdf/joint_parent_frame.sdf
@@ -1,11 +1,17 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
   <model name="joint_parent_frame">
+    <!--
+      For ease of unittesting unique values,
+      each link's pose is displaced along the z-axis,
+      frames are displaced along the y-axis,
+      and joints are displaced along the x-axis.
+    -->
     <link name="parent_link">
       <pose>0 0 1 0 0 0</pose>
     </link>
     <link name="child_link">
-      <pose>0 0 3 0 0 0</pose>
+      <pose>0 0 10 0 0 0</pose>
     </link>
     <frame name="parent_frame" attached_to="parent_link">
       <pose>1 0 0 0 0 0</pose>


### PR DESCRIPTION
Resolves #204, replacement for #300.

This changes the definition of the `//joint/child` and `//joint/parent` elements in SDFormat 1.8 so that they may specify a frame name instead of only a link name, per the [composition proposal](http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&#1-2-interface-elements). I've added some example models using this behavior in 85ab1c5. The parsing stages used to construct the `FrameAttachedToGraph` and `PoseRelativeToGraph` were changed a bit in de80f92 in order to support this feature, as noted in https://github.com/osrf/sdf_tutorials/commit/77b0db1f4e8e91b6cbdefe5f318f056001855712 (currently blocked by https://github.com/osrf/sdf_tutorials/pull/28).

Methods for resolving the name of a joint's parent and child links are added in 655833c:

* `Joint::ResolveChildLink`
* `Joint::ResolveParentLink`

I've redacted the deprecations from #301 from this PR to reduce the noise. We can rename API's in a follow-up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdformat/304)
<!-- Reviewable:end -->
