### PR TITLE
Remove deprecated Pose(), PoseFrame() functions from sdf10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,14 +4,17 @@
 
 ### libsdformat 10.0.0 (202X-XX-XX)
 
-1. Enforce minimum/maximum values specified in SDFormat description files
+1. Enforce minimum/maximum values specified in SDFormat description files.
     * [Pull request 303](https://github.com/osrf/sdformat/pull/303)
 
-1. Make parsing of values syntactically more strict with bad values generating an error
+1. Make parsing of values syntactically more strict with bad values generating an error.
     * [Pull request 244](https://github.com/osrf/sdformat/pull/244)
 
 1. Don't install deprecated parser_urdf.hh header file, fix cmake warning about newline file, fix cmake warning about newlines.
     * [Pull request 276](https://github.com/osrf/sdformat/pull/276)
+
+1. Remove deprecated Pose(), PoseFrame() functions from DOM objects.
+    * [Pull request 308](https://github.com/osrf/sdformat/pull/308)
 
 1. Changed the default radius of a Cylinder from 1.0 to 0.5 meters.
     * [BitBucket pull request 643](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/643)

--- a/Migration.md
+++ b/Migration.md
@@ -27,6 +27,10 @@ but with improved human-readability..
 1. + Removed the `parser_urdf.hh` header file and its `URDF2SDF` class
    + [Pull request 276](https://github.com/osrf/sdformat/pull/276)
 
+1. + Removed the `PoseFrame()` API's in all DOM classes:
+   + const std::string &PoseFrame()
+   + void SetPoseFrame(const std::string &)
+
 ### Additions
 
 1. **sdf/Element.hh**

--- a/Migration.md
+++ b/Migration.md
@@ -27,7 +27,9 @@ but with improved human-readability..
 1. + Removed the `parser_urdf.hh` header file and its `URDF2SDF` class
    + [Pull request 276](https://github.com/osrf/sdformat/pull/276)
 
-1. + Removed the `PoseFrame()` API's in all DOM classes:
+1. + Removed the deprecated `Pose()`, `SetPose(), and `*PoseFrame()` API's in all DOM classes:
+   + const ignition::math::Pose3d &Pose()
+   + void SetPose(const ignition::math::Pose3d &)
    + const std::string &PoseFrame()
    + void SetPoseFrame(const std::string &)
 

--- a/Migration.md
+++ b/Migration.md
@@ -19,6 +19,14 @@ but with improved human-readability..
 1. + Minimum/maximum values specified in SDFormat description files are now enforced
    + [Pull request 303](https://github.com/osrf/sdformat/pull/303)
 
+1. + Parsing of bad values generates an error
+   + [Pull request 244](https://github.com/osrf/sdformat/pull/244)
+
+### Deletions
+
+1. + Removed the `parser_urdf.hh` header file and its `URDF2SDF` class
+   + [Pull request 276](https://github.com/osrf/sdformat/pull/276)
+
 ### Additions
 
 1. **sdf/Element.hh**

--- a/include/sdf/Actor.hh
+++ b/include/sdf/Actor.hh
@@ -325,22 +325,6 @@ namespace sdf
     /// typically used to express the position and rotation of an actor in a
     /// global coordinate frame.
     /// \return The pose of the actor.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the actor.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new actor pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the actor. This is the pose of the actor
-    /// as specified in SDF (<actor> <pose> ... </pose></actor>), and is
-    /// typically used to express the position and rotation of an actor in a
-    /// global coordinate frame.
-    /// \return The pose of the actor.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the actor.

--- a/include/sdf/Actor.hh
+++ b/include/sdf/Actor.hh
@@ -360,22 +360,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this actor's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this actor's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief The path to the file where this element was loaded from.
     /// \return Full path to the file on disk.
     public: const std::string &FilePath() const;

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -329,22 +329,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this camera's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// parent link.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this camera's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// parent link.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get the lens type. This is the type of the lens mapping.
     /// Supported values are gnomonical, stereographic, equidistant,
     /// equisolid_angle, orthographic, custom. For gnomonical (perspective)

--- a/include/sdf/Camera.hh
+++ b/include/sdf/Camera.hh
@@ -296,20 +296,6 @@ namespace sdf
     /// \brief Get the pose of the camer. This is the pose of the camera
     /// as specified in SDF (<camera> <pose> ... </pose></camera>).
     /// \return The pose of the link.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the camera.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new camera pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the camer. This is the pose of the camera
-    /// as specified in SDF (<camera> <pose> ... </pose></camera>).
-    /// \return The pose of the link.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the camera.

--- a/include/sdf/Collision.hh
+++ b/include/sdf/Collision.hh
@@ -139,22 +139,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this collision
-    /// object's pose is expressed. A empty value indicates that the frame is
-    /// the parent link.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this collision
-    /// object's pose is expressed. A empty value indicates that the frame is
-    /// the parent link.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get SemanticPose object of this object to aid in resolving
     /// poses.
     /// \return SemanticPose object for this link.

--- a/include/sdf/Collision.hh
+++ b/include/sdf/Collision.hh
@@ -102,21 +102,6 @@ namespace sdf
     public: void SetSurface(const sdf::Surface &_surface);
 
     /// \brief Get the pose of the collision object. This is the pose of the
-    /// collision as specified in SDF
-    /// (<collision><pose> ... </pose></collision>).
-    /// \return The pose of the collision object.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the collision object.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The pose of the collision object.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the collision object. This is the pose of the
     /// collison as specified in SDF
     /// (<collision><pose> ... </pose></collision>).
     /// \return The pose of the collision object.

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -170,22 +170,6 @@ namespace sdf
     /// Transformations have not been applied to the return value.
     /// \return The pose of the joint. This is the raw pose value, as set in
     /// the SDF file.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the joint.
-    /// \sa const ignition::math::Pose3d &Pose() const;
-    /// \param[in] _pose The pose of the joint.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the joint. This is the pose of the joint
-    /// as specified in SDF (<joint> <pose> ... </pose></joint>).
-    /// Transformations have not been applied to the return value.
-    /// \return The pose of the joint. This is the raw pose value, as set in
-    /// the SDF file.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the joint.

--- a/include/sdf/Joint.hh
+++ b/include/sdf/Joint.hh
@@ -205,22 +205,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this joint's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// child link frame.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this joint's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// child link frame.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get the thread pitch (only valid for screw joints)
     /// \return The thread pitch
     public: double ThreadPitch() const;

--- a/include/sdf/Light.hh
+++ b/include/sdf/Light.hh
@@ -149,22 +149,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this light's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this light's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get SemanticPose object of this object to aid in resolving
     /// poses.
     /// \return SemanticPose object for this link.

--- a/include/sdf/Light.hh
+++ b/include/sdf/Light.hh
@@ -114,22 +114,6 @@ namespace sdf
     /// typically used to express the position and rotation of a light in a
     /// global coordinate frame.
     /// \return The pose of the light.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the light.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new light pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the light. This is the pose of the light
-    /// as specified in SDF (<light> <pose> ... </pose></light>), and is
-    /// typically used to express the position and rotation of a light in a
-    /// global coordinate frame.
-    /// \return The pose of the light.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the light.

--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -228,22 +228,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this link's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// parent model.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this link's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// parent model.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get a pointer to the SDF element that was used during
     /// load.
     /// \return SDF element pointer. The value will be nullptr if Load has

--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -195,20 +195,6 @@ namespace sdf
     /// \brief Get the pose of the link. This is the pose of the link
     /// as specified in SDF (<link> <pose> ... </pose></link>).
     /// \return The pose of the link.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the link.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new link pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the link. This is the pose of the link
-    /// as specified in SDF (<link> <pose> ... </pose></link>).
-    /// \return The pose of the link.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the link.

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -203,22 +203,6 @@ namespace sdf
     /// typically used to express the position and rotation of a model in a
     /// global coordinate frame.
     /// \return The pose of the model.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the model.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new model pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the model. This is the pose of the model
-    /// as specified in SDF (<model> <pose> ... </pose></model>), and is
-    /// typically used to express the position and rotation of a model in a
-    /// global coordinate frame.
-    /// \return The pose of the model.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the model.

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -252,22 +252,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this model's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this model's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get a pointer to the SDF element that was used during
     /// load.
     /// \return SDF element pointer. The value will be nullptr if Load has

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -195,22 +195,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this sensor's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this sensor's
-    /// pose is expressed. A empty value indicates that the frame is the
-    /// global/world coordinate frame.
-    /// \param[in] _frame The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get SemanticPose object of this object to aid in resolving
     /// poses.
     /// \return SemanticPose object for this link.

--- a/include/sdf/Sensor.hh
+++ b/include/sdf/Sensor.hh
@@ -160,22 +160,6 @@ namespace sdf
     /// typically used to express the position and rotation of a sensor in a
     /// global coordinate frame.
     /// \return The pose of the sensor.
-    /// \deprecated See RawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the sensor.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The new sensor pose.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the sensor. This is the pose of the sensor
-    /// as specified in SDF (<sensor> <pose> ... </pose></sensor>), and is
-    /// typically used to express the position and rotation of a sensor in a
-    /// global coordinate frame.
-    /// \return The pose of the sensor.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the sensor.

--- a/include/sdf/Visual.hh
+++ b/include/sdf/Visual.hh
@@ -148,22 +148,6 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get the name of the coordinate frame in which this visual
-    /// object's pose is expressed. A empty value indicates that the frame is
-    /// the parent link.
-    /// \return The name of the pose frame.
-    /// \deprecated See PoseRelativeTo.
-    public: const std::string &PoseFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the name of the coordinate frame in which this visual
-    /// object's pose is expressed. A empty value indicates that the frame is
-    /// the parent link.
-    /// \return The name of the pose frame.
-    /// \deprecated See SetPoseRelativeTo.
-    public: void SetPoseFrame(const std::string &_frame)
-        SDF_DEPRECATED(9.0);
-
     /// \brief Get SemanticPose object of this object to aid in resolving
     /// poses.
     /// \return SemanticPose object for this link.

--- a/include/sdf/Visual.hh
+++ b/include/sdf/Visual.hh
@@ -114,21 +114,6 @@ namespace sdf
     /// visual as specified in SDF
     /// (<visual><pose> ... </pose></visual>).
     /// \return The pose of the visual object.
-    /// \deprecated See SetRawPose.
-    public: const ignition::math::Pose3d &Pose() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set the pose of the visual object.
-    /// \sa const ignition::math::Pose3d &Pose() const
-    /// \param[in] _pose The pose of the visual object.
-    /// \deprecated See SetRawPose.
-    public: void SetPose(const ignition::math::Pose3d &_pose)
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Get the pose of the visual object. This is the pose of the
-    /// visual as specified in SDF
-    /// (<visual><pose> ... </pose></visual>).
-    /// \return The pose of the visual object.
     public: const ignition::math::Pose3d &RawPose() const;
 
     /// \brief Set the pose of the visual object.

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -643,12 +643,6 @@ void Actor::SetName(const std::string &_name)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Actor::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Actor::RawPose() const
 {
   return this->dataPtr->pose;
@@ -658,12 +652,6 @@ const ignition::math::Pose3d &Actor::RawPose() const
 const std::string &Actor::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Actor::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -655,12 +655,6 @@ const ignition::math::Pose3d &Actor::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Actor::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Actor::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -676,12 +670,6 @@ void Actor::SetPose(const ignition::math::Pose3d &_pose)
 void Actor::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Actor::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -697,12 +697,6 @@ const ignition::math::Pose3d &Camera::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Camera::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Camera::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -718,12 +712,6 @@ void Camera::SetPose(const ignition::math::Pose3d &_pose)
 void Camera::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Camera::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -685,12 +685,6 @@ void Camera::SetDistortionCenter(
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Camera::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Camera::RawPose() const
 {
   return this->dataPtr->pose;
@@ -700,12 +694,6 @@ const ignition::math::Pose3d &Camera::RawPose() const
 const std::string &Camera::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Camera::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -176,12 +176,6 @@ void Collision::SetSurface(const sdf::Surface &_surface)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Collision::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Collision::RawPose() const
 {
   return this->dataPtr->pose;
@@ -191,12 +185,6 @@ const ignition::math::Pose3d &Collision::RawPose() const
 const std::string &Collision::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Collision::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Collision.cc
+++ b/src/Collision.cc
@@ -188,12 +188,6 @@ const ignition::math::Pose3d &Collision::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Collision::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Collision::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -209,12 +203,6 @@ void Collision::SetPose(const ignition::math::Pose3d &_pose)
 void Collision::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Collision::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -331,12 +331,6 @@ void Joint::SetAxis(const unsigned int _index, const JointAxis &_axis)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Joint::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Joint::RawPose() const
 {
   return this->dataPtr->pose;
@@ -346,12 +340,6 @@ const ignition::math::Pose3d &Joint::RawPose() const
 const std::string &Joint::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Joint::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Joint.cc
+++ b/src/Joint.cc
@@ -343,12 +343,6 @@ const ignition::math::Pose3d &Joint::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Joint::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Joint::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -364,12 +358,6 @@ void Joint::SetPose(const ignition::math::Pose3d &_pose)
 void Joint::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Joint::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Light.cc
+++ b/src/Light.cc
@@ -286,12 +286,6 @@ void Light::SetName(const std::string &_name) const
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Light::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Light::RawPose() const
 {
   return this->dataPtr->pose;
@@ -301,12 +295,6 @@ const ignition::math::Pose3d &Light::RawPose() const
 const std::string &Light::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Light::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Light.cc
+++ b/src/Light.cc
@@ -298,12 +298,6 @@ const ignition::math::Pose3d &Light::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Light::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Light::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -319,12 +313,6 @@ void Light::SetPose(const ignition::math::Pose3d &_pose)
 void Light::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Light::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -362,12 +362,6 @@ const ignition::math::Pose3d &Link::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Link::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Link::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -383,12 +377,6 @@ void Link::SetPose(const ignition::math::Pose3d &_pose)
 void Link::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Link::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -350,12 +350,6 @@ bool Link::SetInertial(const ignition::math::Inertiald &_inertial)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Link::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Link::RawPose() const
 {
   return this->dataPtr->pose;
@@ -365,12 +359,6 @@ const ignition::math::Pose3d &Link::RawPose() const
 const std::string &Link::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Link::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -565,12 +565,6 @@ const ignition::math::Pose3d &Model::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Model::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Model::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -586,12 +580,6 @@ void Model::SetPose(const ignition::math::Pose3d &_pose)
 void Model::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Model::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -553,12 +553,6 @@ void Model::SetCanonicalLinkName(const std::string &_canonicalLink)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Model::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Model::RawPose() const
 {
   return this->dataPtr->pose;
@@ -568,12 +562,6 @@ const ignition::math::Pose3d &Model::RawPose() const
 const std::string &Model::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Model::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -443,12 +443,6 @@ void Sensor::SetTopic(const std::string &_topic)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Sensor::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Sensor::RawPose() const
 {
   return this->dataPtr->pose;
@@ -458,12 +452,6 @@ const ignition::math::Pose3d &Sensor::RawPose() const
 const std::string &Sensor::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Sensor::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -455,12 +455,6 @@ const ignition::math::Pose3d &Sensor::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Sensor::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Sensor::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -476,12 +470,6 @@ void Sensor::SetPose(const ignition::math::Pose3d &_pose)
 void Sensor::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Sensor::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -245,12 +245,6 @@ const ignition::math::Pose3d &Visual::RawPose() const
 }
 
 /////////////////////////////////////////////////
-const std::string &Visual::PoseFrame() const
-{
-  return this->PoseRelativeTo();
-}
-
-/////////////////////////////////////////////////
 const std::string &Visual::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
@@ -266,12 +260,6 @@ void Visual::SetPose(const ignition::math::Pose3d &_pose)
 void Visual::SetRawPose(const ignition::math::Pose3d &_pose)
 {
   this->dataPtr->pose = _pose;
-}
-
-/////////////////////////////////////////////////
-void Visual::SetPoseFrame(const std::string &_frame)
-{
-  this->SetPoseRelativeTo(_frame);
 }
 
 /////////////////////////////////////////////////

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -233,12 +233,6 @@ void Visual::SetTransparency(float _transparency)
 }
 
 /////////////////////////////////////////////////
-const ignition::math::Pose3d &Visual::Pose() const
-{
-  return this->RawPose();
-}
-
-/////////////////////////////////////////////////
 const ignition::math::Pose3d &Visual::RawPose() const
 {
   return this->dataPtr->pose;
@@ -248,12 +242,6 @@ const ignition::math::Pose3d &Visual::RawPose() const
 const std::string &Visual::PoseRelativeTo() const
 {
   return this->dataPtr->poseRelativeTo;
-}
-
-/////////////////////////////////////////////////
-void Visual::SetPose(const ignition::math::Pose3d &_pose)
-{
-  this->SetRawPose(_pose);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Several `*Pose()` and `*PoseFrame()` functions were deprecated from DOM objects in libsdformat9 by [bitbucket pr 598](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/598) and [bitbucket pr 599](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/599). This removes them and updates the migration guide with the changes from #244 and #276 as well.