### PR TITLE
Link privately to TinyXML2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,7 +167,7 @@ endif()
 
 sdf_add_library(${sdf_target} ${sources})
 target_compile_features(${sdf_target} PUBLIC cxx_std_17)
-target_link_libraries(${sdf_target} PUBLIC
+target_link_libraries(${sdf_target} PRIVATE
   ${IGNITION-MATH_LIBRARIES}
   ${TinyXML2_LIBRARIES})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,9 +173,11 @@ endif()
 
 sdf_add_library(${sdf_target} ${sources})
 target_compile_features(${sdf_target} PUBLIC cxx_std_17)
-target_link_libraries(${sdf_target} PRIVATE
-  ${IGNITION-MATH_LIBRARIES}
-  ${TinyXML2_LIBRARIES})
+target_link_libraries(${sdf_target}
+  PUBLIC
+    ${IGNITION-MATH_LIBRARIES}
+  PRIVATE
+    ${TinyXML2_LIBRARIES})
 
 if (WIN32)
   target_compile_definitions(${sdf_target} PRIVATE URDFDOM_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,8 @@ if (BUILD_SDF_TEST)
   if (NOT WIN32)
     set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS XmlUtils.cc)
     sdf_build_tests(XmlUtils_TEST.cc)
+    target_link_libraries(UNIT_XmlUtils_TEST PRIVATE
+      ${TinyXML2_LIBRARIES})
   endif()
 
   if (NOT WIN32)
@@ -150,6 +152,8 @@ if (BUILD_SDF_TEST)
   if (NOT WIN32)
     set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Converter.cc EmbeddedSdf.cc XmlUtils.cc)
     sdf_build_tests(Converter_TEST.cc)
+    target_link_libraries(UNIT_Converter_TEST PRIVATE
+      ${TinyXML2_LIBRARIES})
   endif()
 
   if (NOT WIN32)
@@ -162,6 +166,8 @@ if (BUILD_SDF_TEST)
       endif()
       target_link_libraries(UNIT_parser_urdf_TEST PRIVATE ${URDF_LIBRARIES})
     endif()
+    target_link_libraries(UNIT_parser_urdf_TEST PRIVATE
+      ${TinyXML2_LIBRARIES})
   endif()
 endif()
 


### PR DESCRIPTION
TinyXML2 is not exposed on SDFormat's public API, so it can be linked to privately.

This fixes compilation of Ignition Physics on Windows, see https://github.com/ignitionrobotics/ign-physics/pull/85/.

Here's `ign-physics3` Windows CI using this branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_physics-pr-win&build=782)](https://build.osrfoundation.org/job/ign_physics-pr-win/782/)