### PR TITLE
Find python3 in cmake, fix warning

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -84,7 +84,7 @@ endif()
 ################################################
 # Find the Python interpreter for running the
 # check_test_ran.py script
-find_package(PythonInterp QUIET)
+find_package(PythonInterp 3 QUIET)
 
 ################################################
 # Find psutil python package for memory tests

--- a/test/integration/element_memory_leak.cc
+++ b/test/integration/element_memory_leak.cc
@@ -71,7 +71,7 @@ const std::string sdfString(
 
 const std::string getMemInfoPath =
   sdf::filesystem::append(PROJECT_SOURCE_PATH, "tools", "get_mem_info.py");
-const std::string pythonMeminfo("python " + getMemInfoPath);
+const std::string pythonMeminfo("python3 " + getMemInfoPath);
 
 int getMemoryUsage()
 {


### PR DESCRIPTION
There are some cmake warnings now reported by jenkins since we upgraded one of the jenkins plugins:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat-ci-sdformat9-bionic-amd64&build=31)](https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/31/) https://build.osrfoundation.org/job/sdformat-ci-sdformat9-bionic-amd64/31/

~~~
CMake Warning at CMakeLists.txt:226 (message):
  -- 	Python psutil package not found.  Memory leak tests will be skipped
~~~

The issue is that we are installing the python3 version of `psutil`, so we need to find the `python3` interpreter in cmake.