### PR TITLE
Support implicit nested canonical links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 1. Support nested models in DOM and frame semantics.
     * [Pull request 316](https://github.com/osrf/sdformat/pull/316)
+    + [Pull request 341](https://github.com/osrf/sdformat/pull/341)
 
 1. Find python3 in cmake, fix cmake warning.
     * [Pull request 328](https://github.com/osrf/sdformat/pull/328)

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,21 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## SDFormat 9.0 to 9.3
+
+### Additions
+
+1. **sdf/Model.hh**
+    + uint64\_t ModelCount() const
+    + const Model \*ModelByIndex(const uint64\_t) const
+    + const Model \*ModelByName(const std::string &) const
+    + bool ModelNameExists(const std::string &) const
+
+### Modifications
+
+1. Permit models without links if they contain a nested canonical link.
+    + [pull request 341](https://github.com/osrf/sdformat/pull/341)
+
 ## SDFormat 8.x to 9.0
 
 ### Additions
@@ -45,10 +60,6 @@ but with improved human-readability..
     + const Frame \*FrameByIndex(const uint64\_t) const
     + const Frame \*FrameByName(const std::string &) const
     + bool FrameNameExists(const std::string &) const
-    + uint64\_t ModelCount() const
-    + const Model \*ModelByIndex(const uint64\_t) const
-    + const Model \*ModelByName(const std::string &) const
-    + bool ModelNameExists(const std::string &) const
     + sdf::SemanticPose SemanticPose() const
 
 1. **sdf/SDFImpl.hh**

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <ignition/math/Pose3.hh>
 #include "sdf/Element.hh"
 #include "sdf/SemanticPose.hh"
@@ -254,12 +255,14 @@ namespace sdf
     public: const Link *CanonicalLink() const;
 
     /// \brief Get the name of the model's canonical link. An empty value
-    /// indicates that the first link in the model is the canonical link.
+    /// indicates that the first link in the model or the first link found
+    /// in a depth first search of nested models is the canonical link.
     /// \return The name of the canonical link.
     public: const std::string &CanonicalLinkName() const;
 
     /// \brief Set the name of the model's canonical link. An empty value
-    /// indicates that the first link in the model is the canonical link.
+    /// indicates that the first link in the model or the first link found
+    /// in a depth first search of nested models is the canonical link.
     /// \param[in] _canonicalLink The name of the canonical link.
     public: void SetCanonicalLinkName(const std::string &_canonicalLink);
 
@@ -310,8 +313,20 @@ namespace sdf
     private: sdf::Errors SetPoseRelativeToGraph(
         std::weak_ptr<const PoseRelativeToGraph> _graph);
 
+    /// \brief Get the model's canonical link and the nested name of the link
+    /// relative to the current model, delimited by "::".
+    /// \return An immutable pointer to the canonical link and the nested
+    /// name of the link relative to the current model.
+    private: std::pair<const Link *, std::string> CanonicalLinkAndRelativeName()
+        const;
+
     /// \brief Allow World::Load to call SetPoseRelativeToGraph.
     friend class World;
+
+    /// \brief Allow helper function in FrameSemantics.cc to call
+    /// CanonicalLinkAndRelativeName.
+    friend std::pair<const Link *, std::string>
+        modelCanonicalLinkAndRelativeName(const Model *);
 
     /// \brief Private data pointer.
     private: ModelPrivate *dataPtr = nullptr;

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -296,6 +296,30 @@ TEST(check, SDF)
     EXPECT_EQ("Valid.\n", output) << output;
   }
 
+  // Check an SDF file with a model that has a nested canonical link.
+  {
+    std::string path = pathBase +"/nested_canonical_link.sdf";
+
+    // Check nested_canonical_link.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with a model that has a nested canonical link
+  // that is explicitly specified by //model/@canonical_link using ::
+  // syntax.
+  {
+    std::string path = pathBase +"/nested_invalid_explicit_canonical_link.sdf";
+
+    // Check nested_invalid_explicit_canonical_link.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
+    EXPECT_NE(output.find("Error: canonical_link with name[nested::link] not "
+                          "found in model with name[top]."),
+              std::string::npos) << output;
+  }
+
   // Check an invalid SDF file that uses reserved names.
   {
     std::string path = pathBase +"/model_invalid_reserved_names.sdf";

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -318,6 +318,8 @@ TEST(check, SDF)
     EXPECT_NE(output.find("Error: canonical_link with name[nested::link] not "
                           "found in model with name[top]."),
               std::string::npos) << output;
+    EXPECT_NE(output.find("Error: A model must have at least one link."),
+              std::string::npos) << output;
   }
 
   // Check an invalid SDF file that uses reserved names.

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -342,12 +342,6 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
   EXPECT_EQ(0u, model->LinkCount());
   EXPECT_EQ(nullptr, model->LinkByIndex(0));
 
-  EXPECT_TRUE(model->CanonicalLinkName().empty());
-
-  ASSERT_NE(nullptr, model->CanonicalLink());
-  // this reports the local name, not the nested name "nested::link2"
-  EXPECT_EQ("link2", model->CanonicalLink()->Name());
-
   EXPECT_EQ(0u, model->JointCount());
   EXPECT_EQ(nullptr, model->JointByIndex(0));
 
@@ -355,17 +349,26 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
   EXPECT_NE(nullptr, model->FrameByIndex(0));
   EXPECT_EQ(nullptr, model->FrameByIndex(1));
 
+  EXPECT_EQ(2u, model->ModelCount());
+  EXPECT_TRUE(model->ModelNameExists("nested"));
+  EXPECT_TRUE(model->ModelNameExists("shallow"));
+  EXPECT_EQ(model->ModelByName("nested"), model->ModelByIndex(0));
+  EXPECT_EQ(model->ModelByName("shallow"), model->ModelByIndex(1));
+  EXPECT_EQ(nullptr, model->ModelByIndex(2));
+
+  // expect implicit canonical link
+  EXPECT_TRUE(model->CanonicalLinkName().empty());
+
+  // frame F is attached to __model__ and resolves to canonical link,
+  // which is "nested::link2"
   std::string body;
   EXPECT_TRUE(model->FrameByName("F")->ResolveAttachedToBody(body).empty());
   EXPECT_EQ("nested::link2", body);
 
-  EXPECT_EQ(2u, model->ModelCount());
-  EXPECT_NE(nullptr, model->ModelByIndex(0));
-  EXPECT_NE(nullptr, model->ModelByIndex(1));
-  EXPECT_EQ(nullptr, model->ModelByIndex(2));
-
-  EXPECT_TRUE(model->ModelNameExists("nested"));
-  EXPECT_TRUE(model->ModelNameExists("shallow"));
+  EXPECT_EQ(model->ModelByName("nested")->LinkByName("link2"),
+            model->CanonicalLink());
+  // this reports the local name, not the nested name "nested::link2"
+  EXPECT_EQ("link2", model->CanonicalLink()->Name());
 
   const sdf::Model *shallowModel = model->ModelByName("shallow");
   EXPECT_EQ(1u, shallowModel->FrameCount());

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -345,8 +345,8 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
   EXPECT_TRUE(model->CanonicalLinkName().empty());
 
   ASSERT_NE(nullptr, model->CanonicalLink());
-  // this reports the local name, not the nested name "nested::link"
-  EXPECT_EQ("link", model->CanonicalLink()->Name());
+  // this reports the local name, not the nested name "nested::link2"
+  EXPECT_EQ("link2", model->CanonicalLink()->Name());
 
   EXPECT_EQ(0u, model->JointCount());
   EXPECT_EQ(nullptr, model->JointByIndex(0));
@@ -357,6 +357,20 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
 
   std::string body;
   EXPECT_TRUE(model->FrameByName("F")->ResolveAttachedToBody(body).empty());
-  EXPECT_EQ("nested::link", body);
+  EXPECT_EQ("nested::link2", body);
+
+  EXPECT_EQ(2u, model->ModelCount());
+  EXPECT_NE(nullptr, model->ModelByIndex(0));
+  EXPECT_NE(nullptr, model->ModelByIndex(1));
+  EXPECT_EQ(nullptr, model->ModelByIndex(2));
+
+  EXPECT_TRUE(model->ModelNameExists("nested"));
+  EXPECT_TRUE(model->ModelNameExists("shallow"));
+
+  const sdf::Model *shallowModel = model->ModelByName("shallow");
+  EXPECT_EQ(1u, shallowModel->FrameCount());
+  EXPECT_TRUE(
+      shallowModel->FrameByName("F")->ResolveAttachedToBody(body).empty());
+  EXPECT_EQ("deep::deeper::deepest::deepest_link", body);
 }
 

--- a/test/sdf/model_canonical_link.sdf
+++ b/test/sdf/model_canonical_link.sdf
@@ -7,5 +7,6 @@
     <link name="link2">
       <pose>0 2 0 0 0 0</pose>
     </link>
+    <frame name="F" attached_to="__model__"/>
   </model>
 </sdf>

--- a/test/sdf/nested_canonical_link.sdf
+++ b/test/sdf/nested_canonical_link.sdf
@@ -1,0 +1,8 @@
+<sdf version='1.7'>
+  <model name="top">
+    <frame name="F"/>
+    <model name="nested">
+      <link name="link"/>
+    </model>
+  </model>
+</sdf>

--- a/test/sdf/nested_canonical_link.sdf
+++ b/test/sdf/nested_canonical_link.sdf
@@ -1,8 +1,19 @@
 <sdf version='1.7'>
   <model name="top">
     <frame name="F"/>
-    <model name="nested">
-      <link name="link"/>
+    <model name="nested" canonical_link="link2">
+      <link name="link1"/>
+      <link name="link2"/>
+    </model>
+    <model name="shallow">
+      <frame name="F"/>
+      <model name="deep">
+        <model name="deeper">
+          <model name="deepest">
+            <link name="deepest_link"/>
+          </model>
+        </model>
+      </model>
     </model>
   </model>
 </sdf>

--- a/test/sdf/nested_invalid_explicit_canonical_link.sdf
+++ b/test/sdf/nested_invalid_explicit_canonical_link.sdf
@@ -1,0 +1,7 @@
+<sdf version='1.7'>
+  <model name="top" canonical_link="nested::link">
+    <model name="nested">
+      <link name="link"/>
+    </model>
+  </model>
+</sdf>

--- a/test/sdf/nested_invalid_explicit_canonical_link.sdf
+++ b/test/sdf/nested_invalid_explicit_canonical_link.sdf
@@ -3,5 +3,12 @@
     <model name="nested">
       <link name="link"/>
     </model>
+    <model name="nested_without_links1">
+      <model name="nested_without_links2">
+        <model name="nested_without_links3">
+          <frame name="F"/>
+        </model>
+      </model>
+    </model>
   </model>
 </sdf>


### PR DESCRIPTION
This is a follow-up to #283 to support some models without direct child links if they contain a nested model with nested links like the following:

~~~
<model name="top">
  <model name="nested">
    <link name="link"/>
  </model>
</model>
~~~

Nested canonical links can be used implicitly, but not explicitly since the `::` syntax for referencing across model boundaries will not be supported until SDFormat 1.8.

The `FrameAttachedToGraph` does need to store the relative name of a nested canonical link using `::` syntax, so a private helper function `Model::CanonicalLinkAndRelativeName` is added that computes this relative name. This helper function is called by `Model::CanonicalLink` to avoid code duplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdformat/341)
<!-- Reviewable:end -->
