### PR TITLE
Cherry-pick #301 to sdf10

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,9 @@
 1. Find python3 in cmake, fix cmake warning.
     * [Pull request 328](https://github.com/osrf/sdformat/pull/328)
 
+1. Fix Actor copy operators and increase test coverage.
+    * [Pull request 301](https://github.com/osrf/sdformat/pull/301)
+
 1. Change bitbucket links to GitHub.
     * [Pull request 240](https://github.com/osrf/sdformat/pull/240)
 
@@ -246,6 +249,9 @@
 ## libsdformat 8.0
 
 ### libsdformat 8.X.X (202X-XX-XX)
+
+1. Fix Actor copy operators and increase test coverage.
+    * [Pull request 301](https://github.com/osrf/sdformat/pull/301)
 
 1. Increase output precision of URDF to SDF conversion, output -0 as 0.
     * [BitBucket pull request 675](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/675)

--- a/src/Actor.cc
+++ b/src/Actor.cc
@@ -129,9 +129,8 @@ Animation::~Animation()
 
 //////////////////////////////////////////////////
 Animation::Animation(const Animation &_animation)
-  : dataPtr(new AnimationPrivate)
+  : dataPtr(new AnimationPrivate(*_animation.dataPtr))
 {
-  this->CopyFrom(_animation);
 }
 
 /////////////////////////////////////////////////
@@ -156,6 +155,7 @@ Animation &Animation::operator=(Animation &&_animation)
 /////////////////////////////////////////////////
 void Animation::CopyFrom(const Animation &_animation)
 {
+  // TODO(anyone) Deprecate function
   this->dataPtr->name = _animation.dataPtr->name;
   this->dataPtr->filename = _animation.dataPtr->filename;
   this->dataPtr->scale = _animation.dataPtr->scale;
@@ -269,9 +269,8 @@ Waypoint::~Waypoint()
 
 //////////////////////////////////////////////////
 Waypoint::Waypoint(const Waypoint &_waypoint)
-  : dataPtr(new WaypointPrivate)
+  : dataPtr(new WaypointPrivate(*_waypoint.dataPtr))
 {
-  this->CopyFrom(_waypoint);
 }
 
 /////////////////////////////////////////////////
@@ -296,6 +295,7 @@ Waypoint &Waypoint::operator=(Waypoint &&_waypoint)
 /////////////////////////////////////////////////
 void Waypoint::CopyFrom(const Waypoint &_waypoint)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->time = _waypoint.dataPtr->time;
   this->dataPtr->pose = _waypoint.dataPtr->pose;
 }
@@ -364,9 +364,8 @@ Trajectory::~Trajectory()
 
 //////////////////////////////////////////////////
 Trajectory::Trajectory(const Trajectory &_trajectory)
-  : dataPtr(new TrajectoryPrivate)
+  : dataPtr(new TrajectoryPrivate(*_trajectory.dataPtr))
 {
-  this->CopyFrom(_trajectory);
 }
 
 /////////////////////////////////////////////////
@@ -391,6 +390,7 @@ Trajectory &Trajectory::operator=(Trajectory &&_trajectory)
 /////////////////////////////////////////////////
 void Trajectory::CopyFrom(const Trajectory &_trajectory)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->id = _trajectory.dataPtr->id;
   this->dataPtr->type = _trajectory.dataPtr->type;
   this->dataPtr->tension = _trajectory.dataPtr->tension;
@@ -501,9 +501,8 @@ Actor::~Actor()
 
 //////////////////////////////////////////////////
 Actor::Actor(const Actor &_actor)
-  : dataPtr(new ActorPrivate)
+  : dataPtr(new ActorPrivate(*_actor.dataPtr))
 {
-  this->CopyFrom(_actor);
 }
 
 /////////////////////////////////////////////////
@@ -528,6 +527,7 @@ Actor &Actor::operator=(Actor &&_actor)
 //////////////////////////////////////////////////
 void Actor::CopyFrom(const Actor &_actor)
 {
+  // TODO(anyone) deprecate function
   this->dataPtr->name             = _actor.dataPtr->name;
   this->dataPtr->pose             = _actor.dataPtr->pose;
   this->dataPtr->poseRelativeTo   = _actor.dataPtr->poseRelativeTo;

--- a/test/integration/actor_dom.cc
+++ b/test/integration/actor_dom.cc
@@ -134,5 +134,30 @@ TEST(DOMActor, LoadActors)
   EXPECT_TRUE(actor2->ScriptLoop());
   EXPECT_DOUBLE_EQ(1.0, actor2->ScriptDelayStart());
   EXPECT_TRUE(actor2->ScriptAutoStart());
+
+  EXPECT_EQ(2u, actor2->LinkCount());
+  EXPECT_EQ(1u, actor2->JointCount());
 }
 
+//////////////////////////////////////////////////
+TEST(DOMActor, CopySdfLoadedProperties)
+{
+  // Verify that copying an actor also copies the underlying ElementPtr
+  // Joints and Links
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+
+  ASSERT_NE(nullptr, root.Element());
+
+  const sdf::World *world = root.WorldByIndex(0);
+  const sdf::Actor *actor2 = world->ActorByIndex(1);
+  sdf::Actor actor1(*actor2);
+
+  EXPECT_EQ(actor1.Element().get(), actor2->Element().get());
+  EXPECT_EQ(actor1.LinkCount(), actor2->LinkCount());
+  EXPECT_EQ(actor1.JointCount(), actor2->JointCount());
+}

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -182,6 +182,15 @@
           </waypoint>
         </trajectory>
       </script>
+      <link name="link1">
+      </link>
+      <link name="link2">
+      </link>
+      <joint name="fixed_joint" type="fixed">
+        <pose>0 0 0 1 0 0</pose>
+        <child>link1</child>
+        <parent>link2</parent>
+      </joint>
     </actor>
 
   </world>


### PR DESCRIPTION
Follow-up to #344, cherry-pick to sdf10. Use rebase and merge.

Fix Actor.cc copy operators and restructure tests (#301)

* Simplify and fix copy constructors, restructure tests and increase coverage
* Add joint and link tests
* Add changelog

Signed-off-by: Luca Della Vedova <luca@openrobotics.org>

Co-authored-by: Ian Chen <ichen@osrfoundation.org>
Co-authored-by: Steve Peters <scpeters@openrobotics.org>