### PR TITLE
Add collection labeler action

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Collection Labeler
+
+on: pull_request
+
+jobs:
+  pr_collection_labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add collection labels
+      if: github.event.action == 'opened'
+      uses: ignition-tooling/pr-collection-labeler@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tested here: https://github.com/chapulina/sdformat/pull/1

This action will automatically label pull requests that target branches used by Gazebo collections according to the target branch. For sdformat, this currently means:

* `sdf8`: blueprint
* `sdf9`: citadel
* `sdf10`: dome
