### PR TITLE
Store material file path information

### DIFF
--- a/include/sdf/Material.hh
+++ b/include/sdf/Material.hh
@@ -186,6 +186,14 @@ namespace sdf
     /// \return Pointer to the PBR material. Null if it does not exist.
     public: Pbr *PbrMaterial() const;
 
+    /// \brief The path to the file where this element was loaded from.
+    /// \return Full path to the file on disk.
+    public: const std::string &FilePath() const;
+
+    /// \brief Set the path to the file where this element was loaded from.
+    /// \paramp[in] _filePath Full path to the file on disk.
+    public: void SetFilePath(const std::string &_filePath);
+
     /// \brief Private data pointer.
     private: MaterialPrivate *dataPtr = nullptr;
   };

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -59,6 +59,9 @@ class sdf::MaterialPrivate
 
   /// \brief The SDF element pointer used during load.
   public: sdf::ElementPtr sdf;
+
+  /// \brief The path to the file where this material was defined.
+  public: std::string filePath = "";
 };
 
 /////////////////////////////////////////////////
@@ -88,6 +91,7 @@ Material::Material(const Material &_material)
   this->dataPtr->specular = _material.dataPtr->specular;
   this->dataPtr->emissive = _material.dataPtr->emissive;
   this->dataPtr->sdf = _material.dataPtr->sdf;
+  this->dataPtr->filePath = _material.dataPtr->filePath;
   if (_material.dataPtr->pbr)
     this->dataPtr->pbr = std::make_unique<Pbr>(*_material.dataPtr->pbr);
 }
@@ -117,6 +121,8 @@ Errors Material::Load(sdf::ElementPtr _sdf)
   Errors errors;
 
   this->dataPtr->sdf = _sdf;
+
+  this->dataPtr->filePath = _sdf->FilePath();
 
   // Check that the provided SDF element is a <material>
   // This is an error that cannot be recovered, so return an error.
@@ -340,4 +346,16 @@ void Material::SetPbrMaterial(const Pbr &_pbr)
 Pbr *Material::PbrMaterial() const
 {
   return this->dataPtr->pbr.get();
+}
+
+//////////////////////////////////////////////////
+const std::string &Material::FilePath() const
+{
+  return this->dataPtr->filePath;
+}
+
+//////////////////////////////////////////////////
+void Material::SetFilePath(const std::string &_filePath)
+{
+  this->dataPtr->filePath = _filePath;
 }

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -36,6 +36,7 @@ TEST(DOMMaterial, Construction)
   EXPECT_EQ(sdf::ShaderType::PIXEL, material.Shader());
   EXPECT_EQ("", material.NormalMap());
   EXPECT_EQ(nullptr, material.PbrMaterial());
+  EXPECT_EQ("", material.FilePath());
 }
 
 /////////////////////////////////////////////////
@@ -51,6 +52,7 @@ TEST(DOMMaterial, MoveConstructor)
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
   material.SetNormalMap("blueberry");
+  material.SetFilePath("/tmp/path");
 
   sdf::Material material2(std::move(material));
   EXPECT_EQ(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f), material2.Ambient());
@@ -65,6 +67,7 @@ TEST(DOMMaterial, MoveConstructor)
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
   EXPECT_EQ("blueberry", material2.NormalMap());
   EXPECT_EQ(nullptr, material2.PbrMaterial());
+  EXPECT_EQ("/tmp/path", material2.FilePath());
 }
 
 /////////////////////////////////////////////////
@@ -80,6 +83,7 @@ TEST(DOMMaterial, CopyConstructor)
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
   material.SetNormalMap("blueberry");
+  material.SetFilePath("/tmp/other");
 
   sdf::Material material2(material);
   EXPECT_EQ(ignition::math::Color(0.1f, 0.2f, 0.3f, 0.5f), material2.Ambient());
@@ -94,6 +98,7 @@ TEST(DOMMaterial, CopyConstructor)
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
   EXPECT_EQ("blueberry", material2.NormalMap());
   EXPECT_EQ(nullptr, material2.PbrMaterial());
+  EXPECT_EQ("/tmp/other", material2.FilePath());
 }
 
 /////////////////////////////////////////////////
@@ -109,6 +114,7 @@ TEST(DOMMaterial, AssignmentOperator)
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
   material.SetNormalMap("blueberry");
+  material.SetFilePath("/tmp/another");
 
   sdf::Material material2;
   material2 = material;
@@ -124,6 +130,7 @@ TEST(DOMMaterial, AssignmentOperator)
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
   EXPECT_EQ("blueberry", material2.NormalMap());
   EXPECT_EQ(nullptr, material2.PbrMaterial());
+  EXPECT_EQ("/tmp/another", material2.FilePath());
 }
 
 /////////////////////////////////////////////////
@@ -215,6 +222,10 @@ TEST(DOMMaterial, Set)
   material.SetNormalMap("map");
   EXPECT_EQ("map", material.NormalMap());
 
+  EXPECT_EQ("", material.FilePath());
+  material.SetFilePath("/my/path");
+  EXPECT_EQ("/my/path", material.FilePath());
+
   // set pbr material
   sdf::Pbr pbr;
   sdf::PbrWorkflow workflow;
@@ -238,6 +249,7 @@ TEST(DOMMaterial, Set)
   EXPECT_EQ("map", moved.NormalMap());
   EXPECT_EQ(workflow,
       *moved.PbrMaterial()->Workflow(sdf::PbrWorkflowType::METAL));
+  EXPECT_EQ("/my/path", moved.FilePath());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Storing the file path of material is required to fix https://github.com/ignitionrobotics/ign-gazebo/issues/286.

This follows the same pattern as `Mesh::FilePath`.

Signed-off-by: Nate Koenig <nate@openrobotics.org>