### PR TITLE
Backport to sdf8: Find python3 in cmake, fix warning

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -84,7 +84,7 @@ endif()
 ################################################
 # Find the Python interpreter for running the
 # check_test_ran.py script
-find_package(PythonInterp QUIET)
+find_package(PythonInterp 3 QUIET)
 
 ################################################
 # Find psutil python package for memory tests

--- a/test/integration/element_memory_leak.cc
+++ b/test/integration/element_memory_leak.cc
@@ -71,7 +71,7 @@ const std::string sdfString(
 
 const std::string getMemInfoPath =
   sdf::filesystem::append(PROJECT_SOURCE_PATH, "tools", "get_mem_info.py");
-const std::string pythonMeminfo("python " + getMemInfoPath);
+const std::string pythonMeminfo("python3 " + getMemInfoPath);
 
 int getMemoryUsage()
 {


### PR DESCRIPTION
Backport #328 to `sdf8`. Use rebase and merge

Find python3 in cmake, fix warning (#328)

* Also use python3 in test
