### PR TITLE
Support explicitly specified nested canonical links using :: syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,15 @@
 1. Initial version of SDFormat 1.8 specification.
     * [BitBucket pull request 682](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/682)
 
+1. SDFormat 1.8: Support specifying frames as joint child/parent.
+    * [Pull request 304](https://github.com/osrf/sdformat/pull/304)
+
+1. SDFormat 1.8: Add support for `//include/placement_frame` and `//model/@placement_frame`.
+    * [Pull request 324](https://github.com/osrf/sdformat/pull/324)
+
+1. SDFormat 1.8: Support explicit nested canonical links with :: syntax.
+    * [Pull request 353](https://github.com/osrf/sdformat/pull/353)
+
 1. SDFormat 1.8: Deprecate //joint/axis/initial_position.
     * [BitBucket pull request 683](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/683)
 

--- a/Migration.md
+++ b/Migration.md
@@ -20,6 +20,18 @@ but with improved human-readability..
     + Errors ResolveChildLink(std::string&) const
     + Errors ResolveParentLink(std::string&) const
 
+### Modifications
+
+1. **sdf/Model.hh**: the following methods now accept nested names
+      that can begin with a sequence of nested model names separated
+      by `::` and may end with the name of an object of the specified type.
+    + const Frame \*FrameByName(const std::string &) const
+    + const Joint \*JointByName(const std::string &) const
+    + const Link \*LinkByName(const std::string &) const
+    + bool FrameNameExists(const std::string &) const
+    + bool JointNameExists(const std::string &) const
+    + bool LinkNameExists(const std::string &) const
+
 ## SDFormat 9.x to 10.0
 
 ### Modifications

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ TODO(eric.cousineau): Move terminology section to sdf_tutorials?
 
 ## Installation
 
+**Note:** the `master` branch is under development for `libsdformat11` and is
+currently unstable. A release branch (`sdf10`, `sdf9`, etc.) is recommended
+for most users.
+
 Standard installation can be performed in UNIX systems using the following
 steps:
 

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -145,11 +145,15 @@ namespace sdf
 
     /// \brief Get a link based on a name.
     /// \param[in] _name Name of the link.
+    /// To get a link in a nested model, prefix the link name with the
+    /// sequence of nested models containing this link, delimited by "::".
     /// \return Pointer to the link. Nullptr if the name does not exist.
     public: const Link *LinkByName(const std::string &_name) const;
 
     /// \brief Get whether a link name exists.
     /// \param[in] _name Name of the link to check.
+    /// To check for a link in a nested model, prefix the link name with
+    /// the sequence of nested models containing this link, delimited by "::".
     /// \return True if there exists a link with the given name.
     public: bool LinkNameExists(const std::string &_name) const;
 
@@ -166,11 +170,15 @@ namespace sdf
 
     /// \brief Get whether a joint name exists.
     /// \param[in] _name Name of the joint to check.
+    /// To check for a joint in a nested model, prefix the link name with
+    /// the sequence of nested models containing this joint, delimited by "::".
     /// \return True if there exists a joint with the given name.
     public: bool JointNameExists(const std::string &_name) const;
 
     /// \brief Get a joint based on a name.
     /// \param[in] _name Name of the joint.
+    /// To get a joint in a nested model, prefix the joint name with the
+    /// sequence of nested models containing this joint, delimited by "::".
     /// \return Pointer to the joint. Nullptr if a joint with the given name
     ///  does not exist.
     /// \sa bool JointNameExists(const std::string &_name) const
@@ -190,12 +198,16 @@ namespace sdf
 
     /// \brief Get an explicit frame based on a name.
     /// \param[in] _name Name of the explicit frame.
+    /// To get a frame in a nested model, prefix the frame name with the
+    /// sequence of nested models containing this frame, delimited by "::".
     /// \return Pointer to the explicit frame. Nullptr if the name does not
     /// exist.
     public: const Frame *FrameByName(const std::string &_name) const;
 
     /// \brief Get whether an explicit frame name exists.
     /// \param[in] _name Name of the explicit frame to check.
+    /// To check for a frame in a nested model, prefix the frame name with
+    /// the sequence of nested models containing this frame, delimited by "::".
     /// \return True if there exists an explicit frame with the given name.
     public: bool FrameNameExists(const std::string &_name) const;
 
@@ -212,11 +224,15 @@ namespace sdf
 
     /// \brief Get whether a nested model name exists.
     /// \param[in] _name Name of the nested model to check.
+    /// To check for a model nested in other models, prefix the model name
+    /// with the sequence of nested model names, delimited by "::".
     /// \return True if there exists a nested model with the given name.
     public: bool ModelNameExists(const std::string &_name) const;
 
     /// \brief Get a nested model based on a name.
     /// \param[in] _name Name of the nested model.
+    /// To get a model nested in other models, prefix the model name
+    /// with the sequence of nested model names, delimited by "::".
     /// \return Pointer to the model. Nullptr if a model with the given name
     ///  does not exist.
     /// \sa bool ModelNameExists(const std::string &_name) const

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -579,14 +579,7 @@ const Link *Model::LinkByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool Model::LinkNameExists(const std::string &_name) const
 {
-  for (auto const &l : this->dataPtr->links)
-  {
-    if (l.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->LinkByName(_name);
 }
 
 /////////////////////////////////////////////////
@@ -606,19 +599,28 @@ const Joint *Model::JointByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool Model::JointNameExists(const std::string &_name) const
 {
-  for (auto const &j : this->dataPtr->joints)
-  {
-    if (j.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->JointByName(_name);
 }
 
 /////////////////////////////////////////////////
 const Joint *Model::JointByName(const std::string &_name) const
 {
+  auto index = _name.rfind("::");
+  if (index != std::string::npos)
+  {
+    const Model *model = this->ModelByName(_name.substr(0, index));
+    if (nullptr != model)
+    {
+      return model->JointByName(_name.substr(index + 2));
+    }
+
+    // The nested model name preceding the last "::" could not be found.
+    // For now, try to find a link that matches _name exactly.
+    // When "::" are reserved and not allowed in names, then uncomment
+    // the following line to return a nullptr.
+    // return nullptr;
+  }
+
   for (auto const &j : this->dataPtr->joints)
   {
     if (j.Name() == _name)
@@ -646,19 +648,28 @@ const Frame *Model::FrameByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool Model::FrameNameExists(const std::string &_name) const
 {
-  for (auto const &f : this->dataPtr->frames)
-  {
-    if (f.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->FrameByName(_name);
 }
 
 /////////////////////////////////////////////////
 const Frame *Model::FrameByName(const std::string &_name) const
 {
+  auto index = _name.rfind("::");
+  if (index != std::string::npos)
+  {
+    const Model *model = this->ModelByName(_name.substr(0, index));
+    if (nullptr != model)
+    {
+      return model->FrameByName(_name.substr(index + 2));
+    }
+
+    // The nested model name preceding the last "::" could not be found.
+    // For now, try to find a link that matches _name exactly.
+    // When "::" are reserved and not allowed in names, then uncomment
+    // the following line to return a nullptr.
+    // return nullptr;
+  }
+
   for (auto const &f : this->dataPtr->frames)
   {
     if (f.Name() == _name)
@@ -686,27 +697,30 @@ const Model *Model::ModelByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool Model::ModelNameExists(const std::string &_name) const
 {
-  for (auto const &m : this->dataPtr->models)
-  {
-    if (m.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->ModelByName(_name);
 }
 
 /////////////////////////////////////////////////
 const Model *Model::ModelByName(const std::string &_name) const
 {
+  auto index = _name.find("::");
+  const std::string nextModelName = _name.substr(0, index);
+  const Model *nextModel = nullptr;
+
   for (auto const &m : this->dataPtr->models)
   {
-    if (m.Name() == _name)
+    if (m.Name() == nextModelName)
     {
-      return &m;
+      nextModel = &m;
+      break;
     }
   }
-  return nullptr;
+
+  if (nullptr != nextModel && index != std::string::npos)
+  {
+    return nextModel->ModelByName(_name.substr(index + 2));
+  }
+  return nextModel;
 }
 
 /////////////////////////////////////////////////
@@ -832,6 +846,22 @@ sdf::SemanticPose Model::SemanticPose() const
 /////////////////////////////////////////////////
 const Link *Model::LinkByName(const std::string &_name) const
 {
+  auto index = _name.rfind("::");
+  if (index != std::string::npos)
+  {
+    const Model *model = this->ModelByName(_name.substr(0, index));
+    if (nullptr != model)
+    {
+      return model->LinkByName(_name.substr(index + 2));
+    }
+
+    // The nested model name preceding the last "::" could not be found.
+    // For now, try to find a link that matches _name exactly.
+    // When "::" are reserved and not allowed in names, then uncomment
+    // the following line to return a nullptr.
+    // return nullptr;
+  }
+
   for (auto const &l : this->dataPtr->links)
   {
     if (l.Name() == _name)

--- a/src/Model_TEST.cc
+++ b/src/Model_TEST.cc
@@ -52,32 +52,56 @@ TEST(DOMModel, Construction)
   EXPECT_EQ(nullptr, model.ModelByIndex(1));
   EXPECT_EQ(nullptr, model.ModelByName(""));
   EXPECT_EQ(nullptr, model.ModelByName("default"));
+  EXPECT_EQ(nullptr, model.ModelByName("a::b"));
+  EXPECT_EQ(nullptr, model.ModelByName("a::b::c"));
+  EXPECT_EQ(nullptr, model.ModelByName("::::"));
   EXPECT_FALSE(model.ModelNameExists(""));
   EXPECT_FALSE(model.ModelNameExists("default"));
+  EXPECT_FALSE(model.ModelNameExists("a::b"));
+  EXPECT_FALSE(model.ModelNameExists("a::b::c"));
+  EXPECT_FALSE(model.ModelNameExists("::::"));
 
   EXPECT_EQ(0u, model.LinkCount());
   EXPECT_EQ(nullptr, model.LinkByIndex(0));
   EXPECT_EQ(nullptr, model.LinkByIndex(1));
   EXPECT_EQ(nullptr, model.LinkByName(""));
   EXPECT_EQ(nullptr, model.LinkByName("default"));
+  EXPECT_EQ(nullptr, model.LinkByName("a::b"));
+  EXPECT_EQ(nullptr, model.LinkByName("a::b::c"));
+  EXPECT_EQ(nullptr, model.LinkByName("::::"));
   EXPECT_FALSE(model.LinkNameExists(""));
   EXPECT_FALSE(model.LinkNameExists("default"));
+  EXPECT_FALSE(model.LinkNameExists("a::b"));
+  EXPECT_FALSE(model.LinkNameExists("a::b::c"));
+  EXPECT_FALSE(model.LinkNameExists("::::"));
 
   EXPECT_EQ(0u, model.JointCount());
   EXPECT_EQ(nullptr, model.JointByIndex(0));
   EXPECT_EQ(nullptr, model.JointByIndex(1));
   EXPECT_EQ(nullptr, model.JointByName(""));
   EXPECT_EQ(nullptr, model.JointByName("default"));
+  EXPECT_EQ(nullptr, model.JointByName("a::b"));
+  EXPECT_EQ(nullptr, model.JointByName("a::b::c"));
+  EXPECT_EQ(nullptr, model.JointByName("::::"));
   EXPECT_FALSE(model.JointNameExists(""));
   EXPECT_FALSE(model.JointNameExists("default"));
+  EXPECT_FALSE(model.JointNameExists("a::b"));
+  EXPECT_FALSE(model.JointNameExists("a::b::c"));
+  EXPECT_FALSE(model.JointNameExists("::::"));
 
   EXPECT_EQ(0u, model.FrameCount());
   EXPECT_EQ(nullptr, model.FrameByIndex(0));
   EXPECT_EQ(nullptr, model.FrameByIndex(1));
   EXPECT_EQ(nullptr, model.FrameByName(""));
   EXPECT_EQ(nullptr, model.FrameByName("default"));
+  EXPECT_EQ(nullptr, model.FrameByName("a::b"));
+  EXPECT_EQ(nullptr, model.FrameByName("a::b::c"));
+  EXPECT_EQ(nullptr, model.FrameByName("::::"));
   EXPECT_FALSE(model.FrameNameExists(""));
   EXPECT_FALSE(model.FrameNameExists("default"));
+  EXPECT_FALSE(model.FrameNameExists("a::b"));
+  EXPECT_FALSE(model.FrameNameExists("a::b::c"));
+  EXPECT_FALSE(model.FrameNameExists("::::"));
 
   EXPECT_TRUE(model.CanonicalLinkName().empty());
   EXPECT_EQ(nullptr, model.CanonicalLink());

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -372,14 +372,21 @@ TEST(check, SDF)
   // that is explicitly specified by //model/@canonical_link using ::
   // syntax.
   {
-    std::string path = pathBase +"/nested_invalid_explicit_canonical_link.sdf";
+    std::string path = pathBase +"/nested_explicit_canonical_link.sdf";
 
-    // Check nested_invalid_explicit_canonical_link.sdf
+    // Check nested_explicit_canonical_link.sdf
     std::string output =
       custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
-    EXPECT_NE(output.find("Error: canonical_link with name[nested::link] not "
-                          "found in model with name[top]."),
-              std::string::npos) << output;
+    EXPECT_EQ("Valid.\n", output) << output;
+  }
+
+  // Check an SDF file with a model that a nested model without a link.
+  {
+    std::string path = pathBase +"/nested_without_links_invalid.sdf";
+
+    // Check nested_without_links_invalid.sdf
+    std::string output =
+      custom_exec_str(g_ignCommand + " sdf -k " + path + g_sdfVersion);
     EXPECT_NE(output.find("Error: A model must have at least one link."),
               std::string::npos) << output;
   }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1322,6 +1322,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF, Errors &_errors)
   while (elem)
   {
     if ((elem->GetName() == "link") ||
+        (elem->GetName() == "model") ||
         (elem->GetName() == "joint") ||
         (elem->GetName() == "frame"))
     {
@@ -1330,7 +1331,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF, Errors &_errors)
       replace[elemName] = newName;
     }
 
-    if ((elem->GetName() == "link"))
+    if ((elem->GetName() == "link") || (elem->GetName() == "model"))
     {
       // Add a pose element even if the element doesn't originally have one
       auto elemPose = elem->GetElement("pose");

--- a/test/integration/model/test_model_with_frames/model.sdf
+++ b/test/integration/model/test_model_with_frames/model.sdf
@@ -59,5 +59,11 @@
       <parent>L3</parent>
       <child>L4</child>
     </joint>
+    <model name="M2">
+      <pose relative_to="F1">1 0 0 0 0 0</pose>
+      <link name="L5">
+        <pose>1 0 0 0 0 0</pose>
+      </link>
+    </model>
   </model>
 </sdf>

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -197,6 +197,112 @@ TEST(DOMRoot, NestedModel)
 
   EXPECT_EQ(0u, nestedModel->JointCount());
   EXPECT_EQ(0u, nestedModel->FrameCount());
+
+  // get nested link from parent model
+  const std::string linkNestedName = "nested_model::nested_link01";
+  EXPECT_TRUE(model->LinkNameExists(linkNestedName));
+  const sdf::Link *nestedLink01 = model->LinkByName(linkNestedName);
+  EXPECT_NE(nullptr, nestedLink01);
+}
+
+/////////////////////////////////////////////////
+TEST(DOMRoot, MultiNestedModel)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "model_multi_nested_model.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+
+  EXPECT_EQ(1u, root.ModelCount());
+
+  // Get the outer model
+  const sdf::Model *outerModel = root.ModelByIndex(0);
+  ASSERT_NE(nullptr, outerModel);
+  EXPECT_EQ("outer_model", outerModel->Name());
+  EXPECT_EQ(1u, outerModel->LinkCount());
+  EXPECT_NE(nullptr, outerModel->LinkByIndex(0));
+  EXPECT_EQ(nullptr, outerModel->LinkByIndex(1));
+
+  EXPECT_TRUE(outerModel->LinkNameExists("outer_link"));
+
+  EXPECT_EQ(1u, outerModel->JointCount());
+  EXPECT_TRUE(outerModel->JointNameExists("outer_joint"));
+
+  EXPECT_EQ(1u, outerModel->FrameCount());
+  EXPECT_TRUE(outerModel->FrameNameExists("outer_frame"));
+
+  EXPECT_EQ(1u, outerModel->ModelCount());
+  EXPECT_NE(nullptr, outerModel->ModelByIndex(0));
+  EXPECT_EQ(nullptr, outerModel->ModelByIndex(1));
+
+  EXPECT_TRUE(outerModel->ModelNameExists("mid_model"));
+
+  // Get the middle model
+  const sdf::Model *midModel = outerModel->ModelByIndex(0);
+  ASSERT_NE(nullptr, midModel);
+  EXPECT_EQ("mid_model", midModel->Name());
+  EXPECT_EQ(1u, midModel->LinkCount());
+  EXPECT_NE(nullptr, midModel->LinkByIndex(0));
+  EXPECT_EQ(nullptr, midModel->LinkByIndex(1));
+
+  EXPECT_TRUE(midModel->LinkNameExists("mid_link"));
+
+  EXPECT_EQ(1u, midModel->JointCount());
+  EXPECT_TRUE(midModel->JointNameExists("mid_joint"));
+
+  EXPECT_EQ(1u, midModel->FrameCount());
+  EXPECT_TRUE(midModel->FrameNameExists("mid_frame"));
+
+  EXPECT_EQ(1u, midModel->ModelCount());
+  EXPECT_NE(nullptr, midModel->ModelByIndex(0));
+  EXPECT_EQ(nullptr, midModel->ModelByIndex(1));
+
+  EXPECT_TRUE(midModel->ModelNameExists("inner_model"));
+
+  // Get the inner model
+  const sdf::Model *innerModel = midModel->ModelByIndex(0);
+  ASSERT_NE(nullptr, innerModel);
+  EXPECT_EQ("inner_model", innerModel->Name());
+  EXPECT_EQ(1u, innerModel->LinkCount());
+  EXPECT_NE(nullptr, innerModel->LinkByIndex(0));
+  EXPECT_EQ(nullptr, innerModel->LinkByIndex(1));
+
+  EXPECT_TRUE(innerModel->LinkNameExists("inner_link"));
+
+  EXPECT_EQ(1u, innerModel->JointCount());
+  EXPECT_TRUE(innerModel->JointNameExists("inner_joint"));
+
+  EXPECT_EQ(1u, innerModel->FrameCount());
+  EXPECT_TRUE(innerModel->FrameNameExists("inner_frame"));
+
+  EXPECT_EQ(0u, innerModel->ModelCount());
+
+  // test nested names from outer model
+  const std::string innerModelNestedName = "mid_model::inner_model";
+  EXPECT_TRUE(outerModel->ModelNameExists(innerModelNestedName));
+  EXPECT_EQ(innerModel, outerModel->ModelByName(innerModelNestedName));
+
+  const std::string innerLinkNestedName = innerModelNestedName + "::inner_link";
+  EXPECT_TRUE(outerModel->LinkNameExists(innerLinkNestedName));
+  EXPECT_EQ(innerModel->LinkByIndex(0),
+            outerModel->LinkByName(innerLinkNestedName));
+  EXPECT_NE(nullptr, outerModel->LinkByName(innerLinkNestedName));
+
+  std::string innerJointNestedName = innerModelNestedName + "::inner_joint";
+  EXPECT_TRUE(outerModel->JointNameExists(innerJointNestedName));
+  EXPECT_EQ(innerModel->JointByIndex(0),
+            outerModel->JointByName(innerJointNestedName));
+  EXPECT_NE(nullptr, outerModel->JointByName(innerJointNestedName));
+
+  std::string innerFrameNestedName = innerModelNestedName + "::inner_frame";
+  EXPECT_TRUE(outerModel->FrameNameExists(innerFrameNestedName));
+  EXPECT_EQ(innerModel->FrameByIndex(0),
+            outerModel->FrameByName(innerFrameNestedName));
+  EXPECT_NE(nullptr, outerModel->FrameByName(innerFrameNestedName));
 }
 
 /////////////////////////////////////////////////
@@ -375,5 +481,83 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
   EXPECT_TRUE(
       shallowModel->FrameByName("F")->ResolveAttachedToBody(body).empty());
   EXPECT_EQ("deep::deeper::deepest::deepest_link", body);
+}
+
+/////////////////////////////////////////////////
+TEST(DOMRoot, LoadNestedExplicitCanonicalLink)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "nested_explicit_canonical_link.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  EXPECT_TRUE(root.Load(testFile).empty());
+
+  // Get the first model
+  const sdf::Model *model = root.ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ("top", model->Name());
+  EXPECT_EQ(0u, model->LinkCount());
+  EXPECT_EQ(nullptr, model->LinkByIndex(0));
+
+  EXPECT_EQ(0u, model->JointCount());
+  EXPECT_EQ(nullptr, model->JointByIndex(0));
+
+  EXPECT_EQ(1u, model->FrameCount());
+  EXPECT_NE(nullptr, model->FrameByIndex(0));
+  EXPECT_EQ(nullptr, model->FrameByIndex(1));
+
+  EXPECT_EQ(1u, model->ModelCount());
+  EXPECT_TRUE(model->ModelNameExists("nested"));
+  EXPECT_NE(nullptr, model->ModelByIndex(0));
+  EXPECT_EQ(model->ModelByName("nested"), model->ModelByIndex(0));
+  EXPECT_EQ(nullptr, model->ModelByIndex(1));
+
+  // expect implicit canonical link
+  EXPECT_EQ("nested::link2", model->CanonicalLinkName());
+
+  // frame F is attached to __model__ and resolves to canonical link,
+  // which is "nested::link2"
+  std::string body;
+  EXPECT_TRUE(model->FrameByName("F")->ResolveAttachedToBody(body).empty());
+  EXPECT_EQ("nested::link2", body);
+
+  EXPECT_NE(nullptr, model->CanonicalLink());
+  EXPECT_EQ(model->LinkByName("nested::link2"), model->CanonicalLink());
+  EXPECT_EQ(model->ModelByName("nested")->LinkByName("link2"),
+            model->CanonicalLink());
+  // this reports the local name, not the nested name "nested::link2"
+  EXPECT_EQ("link2", model->CanonicalLink()->Name());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMJoint, LoadInvalidNestedModelWithoutLinks)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+        "nested_without_links_invalid.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  for (auto e : errors)
+    std::cout << e << std::endl;
+  EXPECT_FALSE(errors.empty());
+  EXPECT_EQ(10u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::MODEL_WITHOUT_LINK);
+  EXPECT_NE(std::string::npos,
+    errors[0].Message().find("A model must have at least one link"));
+  EXPECT_EQ(errors[1].Code(), sdf::ErrorCode::MODEL_WITHOUT_LINK);
+  EXPECT_NE(std::string::npos,
+    errors[1].Message().find("A model must have at least one link"));
+  // errors[2]
+  // errors[3]
+  // errors[4]
+  // errors[5]
+  // errors[6]
+  // errors[7]
+  // errors[8]
+  // errors[9]
 }
 

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -618,6 +618,82 @@ TEST(NestedModel, NestedModelWithFramesDirectComparison)
 }
 
 //////////////////////////////////////////////////
+// Test DOM APIs with partially flattened model
+TEST(NestedModel, PartiallyFlattened)
+{
+  const std::string testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+      "nested_model_with_frames_expected.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty());
+
+  EXPECT_EQ(1u, root.WorldCount());
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+
+  // Get the outer model
+  const sdf::Model *outerModel = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, outerModel);
+  EXPECT_EQ("ParentModel", outerModel->Name());
+  EXPECT_EQ(4u, outerModel->LinkCount());
+  EXPECT_NE(nullptr, outerModel->LinkByIndex(0));
+  EXPECT_NE(nullptr, outerModel->LinkByIndex(1));
+  EXPECT_NE(nullptr, outerModel->LinkByIndex(2));
+  EXPECT_NE(nullptr, outerModel->LinkByIndex(3));
+  EXPECT_EQ(nullptr, outerModel->LinkByIndex(4));
+
+  EXPECT_TRUE(outerModel->LinkNameExists("M1::L1"));
+  EXPECT_TRUE(outerModel->LinkNameExists("M1::L2"));
+  EXPECT_TRUE(outerModel->LinkNameExists("M1::L3"));
+  EXPECT_TRUE(outerModel->LinkNameExists("M1::L4"));
+
+  EXPECT_EQ(3u, outerModel->JointCount());
+  EXPECT_TRUE(outerModel->JointNameExists("M1::J1"));
+  EXPECT_TRUE(outerModel->JointNameExists("M1::J2"));
+  EXPECT_TRUE(outerModel->JointNameExists("M1::J3"));
+
+  EXPECT_EQ(3u, outerModel->FrameCount());
+  EXPECT_TRUE(outerModel->FrameNameExists("M1::__model__"));
+  EXPECT_TRUE(outerModel->FrameNameExists("M1::F1"));
+  EXPECT_TRUE(outerModel->FrameNameExists("M1::F2"));
+
+  EXPECT_EQ(1u, outerModel->ModelCount());
+  EXPECT_NE(nullptr, outerModel->ModelByIndex(0));
+  EXPECT_EQ(nullptr, outerModel->ModelByIndex(1));
+
+  // Get the middle model
+  const sdf::Model *midModel = outerModel->ModelByIndex(0);
+  ASSERT_NE(nullptr, midModel);
+  EXPECT_EQ("M1::M2", midModel->Name());
+  // TODO: the following expectations should be true, but ModelNameExists
+  // and ModelByName do not support names containing "::".
+  // EXPECT_TRUE(outerModel->ModelNameExists("M1::M2"));
+  // EXPECT_EQ(midModel, outerModel->ModelByName("M1::M2"));
+
+  EXPECT_EQ(1u, midModel->LinkCount());
+  EXPECT_NE(nullptr, midModel->LinkByIndex(0));
+  EXPECT_EQ(nullptr, midModel->LinkByIndex(1));
+
+  EXPECT_TRUE(midModel->LinkNameExists("L5"));
+
+  EXPECT_EQ(0u, midModel->JointCount());
+
+  EXPECT_EQ(0u, midModel->FrameCount());
+
+  EXPECT_EQ(0u, midModel->ModelCount());
+
+  // test nested names from outer model
+  // TODO: the following expectations also fail due to the limitations of
+  // ModelNameExists and ModelByName not supporting names containing "::".
+  // const std::string midLinkNestedName = "M1::M2::L5";
+  // EXPECT_TRUE(outerModel->LinkNameExists(midLinkNestedName));
+  // EXPECT_NE(nullptr, outerModel->LinkByName(midLinkNestedName));
+}
+
+//////////////////////////////////////////////////
 // Test parsing models that have two levels of nesting with child models
 // containg frames nested via <include>.
 // Compare parsed SDF with expected string

--- a/test/integration/nested_model_with_frames_expected.sdf
+++ b/test/integration/nested_model_with_frames_expected.sdf
@@ -63,6 +63,12 @@
         <parent>M1::L3</parent>
         <child>M1::L4</child>
       </joint>
+      <model name='M1::M2'>
+        <pose relative_to='M1::F1'>1 0 0 0 -0 0</pose>
+        <link name='L5'>
+          <pose>1 0 0 0 -0 0</pose>
+        </link>
+      </model>
     </model>
   </world>
 </sdf>

--- a/test/integration/two_level_nested_model_with_frames_expected.sdf
+++ b/test/integration/two_level_nested_model_with_frames_expected.sdf
@@ -66,6 +66,12 @@
         <parent>M1::test_model_with_frames::L3</parent>
         <child>M1::test_model_with_frames::L4</child>
       </joint>
+      <model name='M1::test_model_with_frames::M2'>
+        <pose relative_to='M1::test_model_with_frames::F1'>1 0 0 0 -0 0</pose>
+        <link name='L5'>
+          <pose>1 0 0 0 -0 0</pose>
+        </link>
+      </model>
     </model>
   </world>
 </sdf>

--- a/test/sdf/model_multi_nested_model.sdf
+++ b/test/sdf/model_multi_nested_model.sdf
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<sdf version='1.7'>
+  <model name="outer_model">
+    <link name="outer_link"/>
+    <joint name="outer_joint" type="fixed">
+      <parent>world</parent>
+      <child>outer_link</child>
+    </joint>
+    <frame name="outer_frame"/>
+    <model name="mid_model">
+      <pose>1 0 0 0 1.5707963267948966 0</pose>
+      <link name="mid_link"/>
+      <joint name="mid_joint" type="fixed">
+        <parent>world</parent>
+        <child>mid_link</child>
+      </joint>
+      <frame name="mid_frame"/>
+      <model name="inner_model">
+        <link name="inner_link"/>
+        <joint name="inner_joint" type="fixed">
+          <parent>world</parent>
+          <child>inner_link</child>
+        </joint>
+        <frame name="inner_frame"/>
+      </model>
+    </model>
+  </model>
+</sdf>

--- a/test/sdf/nested_explicit_canonical_link.sdf
+++ b/test/sdf/nested_explicit_canonical_link.sdf
@@ -1,0 +1,9 @@
+<sdf version='1.8'>
+  <model name="top" canonical_link="nested::link2">
+    <frame name="F"/>
+    <model name="nested">
+      <link name="link1"/>
+      <link name="link2"/>
+    </model>
+  </model>
+</sdf>

--- a/test/sdf/nested_without_links_invalid.sdf
+++ b/test/sdf/nested_without_links_invalid.sdf
@@ -1,8 +1,6 @@
 <sdf version='1.7'>
-  <model name="top" canonical_link="nested::link">
-    <model name="nested">
-      <link name="link"/>
-    </model>
+  <model name="nested_without_links_invalid">
+    <link name="link"/>
     <model name="nested_without_links1">
       <model name="nested_without_links2">
         <model name="nested_without_links3">


### PR DESCRIPTION
This is a partial step towards resolution of #342.

Support for implicit nested canonical links (i.e. when `//model/@canonical_link` is empty) was added in #341, but explicitly specifying a nested link using `::` syntax (like `<model name="M" canonical_link="nested_model::nested_link">`) was not supported. This adds support for `::` syntax in the `Model::*ByName` and `Model::*NameExists` functions, which is enough to support explicit specification of nested canonical links using `::` syntax.

I split the `test/sdf/nested_invalid_explicit_canonical_link.sdf` test file into two parts, since it was demonstrating two different types of failures:

* test/sdf/nested_explicit_canonical_link.sdf: now a valid file in 1.8
* test/sdf/nested_without_links_invalid.sdf: still not supported

In this implementation, if `::` is detected in the name passed to `Model::*ByName` and `Model::*NameExists`, those functions will interpret all instances of `::` as separators between nested models and attempt to find a hierarchy of nested models that precedes the last instance of `::`. If such a nested model cannot be found, it checks for an object that matches the full name (including instances of `::`). I expect this behavior to be changed before we finish libsdformat11, but it is needed for now since included models are flattened by `addNestedModel` during parsing (see #284), so that some link, joint, and frame names may contain `::`. I left some comments in `Model::*ByName` about how to change this behavior when `::` become reserved and not allowed in frame names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/osrf/sdformat/355)
<!-- Reviewable:end -->
