### PR TITLE
Return positive infinity instead of -1 for boundless positive values

### DIFF
--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -197,13 +197,13 @@ namespace sdf
     public: double Effort() const;
 
     /// \brief Set the value for enforcing the maximum joint effort applied.
-    /// Limit is not enforced if value is negative.
+    /// Limit is not enforced if value is infinity.
     /// \param[in] _effort Effort limit.
     /// \sa double Effort() const
     public: void SetEffort(double _effort);
 
     /// \brief Get the value for enforcing the maximum joint velocity. The
-    /// default value is -1.
+    /// default value is infinity.
     /// \return The value for enforcing the maximum joint velocity.
     /// \sa void SetVelocity(const double _velocity) const
     public: double MaxVelocity() const;

--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -190,27 +190,31 @@ namespace sdf
     /// \sa double Upper() const
     public: void SetUpper(const double _upper) const;
 
-    /// \brief Get the value for enforcing the maximum joint effort applied.
-    /// Limit is not enforced if value is negative. The default value is -1.
-    /// \return Effort limit.
+    /// \brief Get the value for enforcing the maximum absolute joint effort
+    /// that can be applied.
+    /// The limit is not enforced if the value is infinity.
+    /// The default value is infinity.
+    /// \return Symmetric effort limit.
     /// \sa void SetEffort(double _effort)
     public: double Effort() const;
 
-    /// \brief Set the value for enforcing the maximum joint effort applied.
-    /// Limit is not enforced if value is infinity.
-    /// \param[in] _effort Effort limit.
+    /// \brief Set the value for enforcing the maximum absolute joint effort
+    /// that can be applied.
+    /// The limit is not enforced if the value is infinity.
+    /// \param[in] _effort Symmetric effort limit.
     /// \sa double Effort() const
     public: void SetEffort(double _effort);
 
-    /// \brief Get the value for enforcing the maximum joint velocity. The
-    /// default value is infinity.
-    /// \return The value for enforcing the maximum joint velocity.
+    /// \brief Get the value for enforcing the maximum absolute joint velocity.
+    /// The default value is infinity.
+    /// \return The value for enforcing the maximum absolute joint velocity.
     /// \sa void SetVelocity(const double _velocity) const
     public: double MaxVelocity() const;
 
-    /// \brief Set the value for enforcing the maximum joint velocity.
-    /// \param[in] _velocity The value for enforcing the maximum joint velocity.
-    /// \sa double Velocity() const
+    /// \brief Set the value for enforcing the maximum absolute joint velocity.
+    /// \param[in] _velocity The value for enforcing the maximum absolute
+    /// joint velocity.
+    /// \sa double MaxVelocity() const
     public: void SetMaxVelocity(const double _velocity) const;
 
     /// \brief Get the joint stop stiffness. The default value is 1e8.

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -24,6 +24,7 @@
 #include "sdf/Error.hh"
 #include "sdf/JointAxis.hh"
 #include "FrameSemantics.hh"
+#include "Utils.hh"
 
 using namespace sdf;
 
@@ -312,7 +313,7 @@ void JointAxis::SetUpper(const double _upper) const
 /////////////////////////////////////////////////
 double JointAxis::Effort() const
 {
-  return this->dataPtr->effort;
+  return infiniteIfNegative(this->dataPtr->effort);
 }
 
 /////////////////////////////////////////////////
@@ -324,7 +325,7 @@ void JointAxis::SetEffort(double _effort)
 /////////////////////////////////////////////////
 double JointAxis::MaxVelocity() const
 {
-  return this->dataPtr->maxVelocity;
+  return infiniteIfNegative(this->dataPtr->maxVelocity);
 }
 
 /////////////////////////////////////////////////

--- a/src/JointAxis_TEST.cc
+++ b/src/JointAxis_TEST.cc
@@ -32,8 +32,8 @@ TEST(DOMJointAxis, Construction)
   EXPECT_DOUBLE_EQ(0.0, axis.SpringStiffness());
   EXPECT_DOUBLE_EQ(-1e16, axis.Lower());
   EXPECT_DOUBLE_EQ(1e16, axis.Upper());
-  EXPECT_DOUBLE_EQ(-1, axis.Effort());
-  EXPECT_DOUBLE_EQ(-1, axis.MaxVelocity());
+  EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), axis.Effort());
+  EXPECT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), axis.MaxVelocity());
   EXPECT_DOUBLE_EQ(1e8, axis.Stiffness());
   EXPECT_DOUBLE_EQ(1.0, axis.Dissipation());
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -74,5 +74,14 @@ bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
   // on the pose element value.
   return posePair.second;
 }
+
+/////////////////////////////////////////////////
+double infiniteIfNegative(const double _value)
+{
+  if (_value < 0.0)
+    return std::numeric_limits<double>::infinity();
+
+  return _value;
+}
 }
 }

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -55,6 +55,13 @@ namespace sdf
   bool loadPose(sdf::ElementPtr _sdf, ignition::math::Pose3d &_pose,
                 std::string &_frame);
 
+  /// \brief If the value is negative, convert it to positive infinity.
+  /// Otherwise, return the original value.
+  /// \param[in] _value The value to convert, if necessary.
+  /// \return Infinity if the input value is negative, otherwise the original
+  /// value.
+  double infiniteIfNegative(double _value);
+
   /// \brief Load all objects of a specific sdf element type. No error
   /// is returned if an element is not present. This function assumes that
   /// an element has a "name" attribute that must be unique.

--- a/test/sdf/joint_axis_infinite_limits.sdf
+++ b/test/sdf/joint_axis_infinite_limits.sdf
@@ -1,0 +1,58 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="joint_axis_infinite_limits">
+    <link name="link1"/>
+    <link name="link2"/>
+    <link name="link3"/>
+    <link name="link4"/>
+    <link name="link5"/>
+
+    <joint name="default_joint_limits" type="revolute">
+      <child>link1</child>
+      <parent>link2</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+      </axis>
+    </joint>
+    <joint name="finite_joint_limits" type="revolute">
+      <child>link3</child>
+      <parent>link4</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-1.5</lower>
+          <upper>1.5</upper>
+          <velocity>2.5</velocity>
+          <effort>5.5</effort>
+        </limit>
+      </axis>
+    </joint>
+    <joint name="infinite_joint_limits_inf" type="revolute">
+      <child>link4</child>
+      <parent>link5</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-inf</lower>
+          <upper>inf</upper>
+          <velocity>inf</velocity>
+          <effort>inf</effort>
+        </limit>
+      </axis>
+    </joint>
+    <joint name="infinite_joint_limits_neg" type="revolute">
+      <child>link5</child>
+      <parent>link6</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-inf</lower>
+          <upper>inf</upper>
+          <velocity>-1</velocity>
+          <effort>-1</effort>
+        </limit>
+      </axis>
+    </joint>
+  </model>
+</sdf>
+


### PR DESCRIPTION
Targeted at `sdf10`, this is a resubmission of #249, which itself was a revival of [bitbucket PR 458](https://osrf-migration.github.io/sdformat-gh-pages/#!/osrf/sdformat/pull-requests/458) per #231. I've added tests in 148d782. cc @mxgrey 

## Original description:

SDFormat has a convention of using -1 to represent positive infinity. If users of the DOM API are not careful and cognizant of this convention, it can result in confusing bugs that are hard to track down. My dartsim plugin was exhibiting subtle non-physical behavior after loading structures from SDF, because it had effort and velocity limits of +1 (minimum) and -1 (maximum).

This PR is a suggested tweak to the API behavior so that the API returns positive infinity instead of -1 to represent boundlessly positive values. Hopefully this might save other SDF users from long, confusing debugging sessions.

However, this does deviate from the exact convention of the SDF document specification, so I’d understand if this PR is declined.