### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ else (build_errors)
   set(sdf_version_output "cmake/${sdf_target}-config-version.cmake")
   set(sdf_config_install_dir "${LIB_INSTALL_DIR}/cmake/${PROJECT_NAME_LOWER}/")
 
+  include(CMakePackageConfigHelpers)
   #--------------------------------------
   # Configure and install the config file
   configure_package_config_file(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,7 @@ sdf_add_library(${sdf_target} ${sources})
 target_compile_features(${sdf_target} PUBLIC cxx_std_17)
 target_link_libraries(${sdf_target}
   PUBLIC
-    ${IGNITION-MATH_LIBRARIES}
+    ignition-math${IGN_MATH_VER}::ignition-math${IGN_MATH_VER}
   PRIVATE
     ${TinyXML2_LIBRARIES})
 
@@ -185,7 +185,6 @@ endif()
 
 target_include_directories(${sdf_target}
   PUBLIC
-    ${IGNITION-MATH_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}/..>
 )


### PR DESCRIPTION
When trying to build from Conan, not including `CMakePackageConfigHelpers` ends in an error saying that it can't find `configure_package_config_file`. I'm not exactly sure why it's actually working without it.

Also, use modern CMake target for `ignition-math`.