### PR TITLE
Add tinyxml2 as the config name for find_package

### DIFF
--- a/cmake/Modules/FindTinyXML2.cmake
+++ b/cmake/Modules/FindTinyXML2.cmake
@@ -10,7 +10,7 @@
 # TinyXML2_LIBRARIES
 
 # try to find the CMake config file for TinyXML2 first
-find_package(TinyXML2 CONFIG QUIET)
+find_package(TinyXML2 CONFIG NAMES tinyxml2 QUIET)
 if(TinyXML2_FOUND)
   message(STATUS "Found TinyXML2 via Config file: ${TinyXML2_DIR}")
   if(NOT TINYXML2_LIBRARY)


### PR DESCRIPTION
This will look for a file named `tinyxml2Config.cmake` instead of `TinyXML2Config.cmake`. This new name matches the Conan package name. If there's a use case in which we need a `TinyXML2Config.cmake` file, we can add it to the name list.