### PR TITLE
Trim whitespace from uri element text

### DIFF
--- a/src/Material.cc
+++ b/src/Material.cc
@@ -135,6 +135,7 @@ Errors Material::Load(sdf::ElementPtr _sdf)
     std::pair<std::string, bool> uriPair = elem->Get<std::string>("uri", "");
     if (uriPair.first == "__default__")
       uriPair.first = "";
+    uriPair.first = sdf::trim(uriPair.first);
 
     if (!uriPair.second || uriPair.first.empty())
     {

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -915,7 +915,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
 
         if (elemXml->FirstChildElement("uri"))
         {
-          std::string uri = elemXml->FirstChildElement("uri")->GetText();
+          std::string uri =
+              sdf::trim(elemXml->FirstChildElement("uri")->GetText());
           modelPath = sdf::findFile(uri, true, true);
 
           // Test the model path

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -40,6 +40,7 @@ set(tests
   urdf_gazebo_extensions.cc
   urdf_joint_parameters.cc
   visual_dom.cc
+  whitespace.cc
   world_dom.cc
 )
 

--- a/test/integration/whitespace.cc
+++ b/test/integration/whitespace.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "sdf/Actor.hh"
+#include "sdf/Collision.hh"
+#include "sdf/Filesystem.hh"
+#include "sdf/Geometry.hh"
+#include "sdf/Light.hh"
+#include "sdf/Link.hh"
+#include "sdf/Mesh.hh"
+#include "sdf/Model.hh"
+#include "sdf/parser.hh"
+#include "sdf/Root.hh"
+#include "sdf/SDFImpl.hh"
+#include "sdf/Visual.hh"
+#include "sdf/World.hh"
+#include "test_config.h"
+
+const auto g_testPath = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
+const auto g_modelsPath =
+    sdf::filesystem::append(g_testPath, "integration", "model");
+
+/////////////////////////////////////////////////
+std::string findFileCb(const std::string &_input)
+{
+  return sdf::filesystem::append(g_testPath, "integration", "model", _input);
+}
+
+//////////////////////////////////////////////////
+TEST(WhitespaceTest, Whitespace)
+{
+  sdf::setFindCallback(findFileCb);
+
+  const auto worldFile =
+    sdf::filesystem::append(g_testPath, "sdf", "whitespace.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(worldFile);
+  for (auto e : errors)
+    std::cout << e.Message() << std::endl;
+  EXPECT_TRUE(errors.empty());
+
+  ASSERT_NE(nullptr, root.Element());
+  EXPECT_EQ(worldFile, root.Element()->FilePath());
+  EXPECT_EQ("1.6", root.Element()->OriginalVersion());
+}

--- a/test/sdf/whitespace.sdf
+++ b/test/sdf/whitespace.sdf
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>test_model</uri>
+    </include>
+
+    <include>
+      <uri>
+          test_model
+      </uri>
+      <name>override_model_name</name>
+    </include>
+
+    <include>
+      <uri>test_light</uri>
+    </include>
+
+    <include>
+      <uri>
+          test_light
+      </uri>
+      <name>override_light_name</name>
+      <pose>4 5 6 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>test_actor</uri>
+    </include>
+
+    <include>
+      <uri>
+          test_actor
+      </uri>
+      <name>override_actor_name</name>
+    </include>
+
+  </world>
+</sdf>


### PR DESCRIPTION
This copies the whitespace test from #359
but takes a narrower approach by only trimming
whitespace from `<uri>` element text.

Closes #322.

Signed-off-by: Steve Peters <scpeters@openrobotics.org>