### PR TITLE
Define PATH_MAX for Debian Hurd system

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -55,6 +55,11 @@
 
 #include "sdf/Filesystem.hh"
 
+/* PATH_MAX is undefined on GNU Hurd */
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 namespace sdf
 {
 inline namespace SDF_VERSION_NAMESPACE {

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -25,6 +25,11 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+/* PATH_MAX is undefined on GNU Hurd */
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 /////////////////////////////////////////////////
 bool create_and_switch_to_temp_dir(std::string &_new_temp_path)
 {


### PR DESCRIPTION
The Hurd operativy system does not fully follow the POSIX standard and does not define the PATH_MAX variable, see bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892231. I just following how[ other projects](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824005) patched this by defining if it does not exists.