### PR TITLE
JointAxis: remove UseParentModelFrame methods

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -34,11 +34,15 @@ but with improved human-readability..
 1. + Removed the `parser_urdf.hh` header file and its `URDF2SDF` class
    + [Pull request 276](https://github.com/osrf/sdformat/pull/276)
 
-1. + Removed the deprecated `Pose()`, `SetPose(), and `*PoseFrame()` API's in all DOM classes:
+1. + Removed the deprecated `Pose()`, `SetPose(), and `*PoseFrame()` APIs in all DOM classes:
    + const ignition::math::Pose3d &Pose()
    + void SetPose(const ignition::math::Pose3d &)
    + const std::string &PoseFrame()
    + void SetPoseFrame(const std::string &)
+
+1. + Removed deprecated functions from **sdf/JointAxis.hh**:
+   + bool UseParentModelFrame()
+   + void SetUseParentModelFrame(bool)
 
 ### Additions
 

--- a/include/sdf/JointAxis.hh
+++ b/include/sdf/JointAxis.hh
@@ -84,8 +84,9 @@ namespace sdf
     public: void SetInitialPosition(const double _pos);
 
     /// \brief Get the x,y,z components of the axis unit vector.
-    /// The axis is expressed in the joint frame unless UseParentModelFrame
-    /// is true. The vector should be normalized.
+    /// The axis is expressed in the frame named in XyzExpressedIn() and
+    /// defaults to the joint frame if that method returns an empty string.
+    /// The vector should be normalized.
     /// The default value is ignition::math::Vector3d::UnitZ which equals
     /// (0, 0, 1).
     /// \return The x,y,z components of the axis unit vector.
@@ -98,22 +99,6 @@ namespace sdf
     /// \return Errors will have an entry if the norm of the xyz vector is 0.
     public: [[nodiscard]] sdf::Errors SetXyz(
                 const ignition::math::Vector3d &_xyz);
-
-    /// \brief Get whether to interpret the axis xyz value in the parent model
-    /// frame instead of joint frame. The default value is false.
-    /// \return True to interpret the axis xyz value in the parent model
-    /// frame, false to use the joint frame.
-    /// \sa void SetUseParentModelFrame(const bool _parentModelFrame)
-    public: bool UseParentModelFrame() const
-        SDF_DEPRECATED(9.0);
-
-    /// \brief Set whether to interpret the axis xyz value in the parent model
-    /// instead of the joint frame.
-    /// \param[in] _parentModelFrame True to interpret the axis xyz value in
-    /// the parent model frame, false to use the joint frame.
-    /// \sa bool UseParentModelFrame() const
-    public: void SetUseParentModelFrame(const bool _parentModelFrame)
-        SDF_DEPRECATED(9.0);
 
     /// \brief Get the physical velocity dependent viscous damping coefficient
     /// of the joint axis. The default value is zero (0.0).

--- a/src/JointAxis.cc
+++ b/src/JointAxis.cc
@@ -229,17 +229,6 @@ sdf::Errors JointAxis::SetXyz(const ignition::math::Vector3d &_xyz)
 }
 
 /////////////////////////////////////////////////
-bool JointAxis::UseParentModelFrame() const
-{
-  return this->dataPtr->useParentModelFrame;
-}
-/////////////////////////////////////////////////
-void JointAxis::SetUseParentModelFrame(const bool _parentModelFrame)
-{
-  this->dataPtr->useParentModelFrame = _parentModelFrame;
-}
-
-/////////////////////////////////////////////////
 double JointAxis::Damping() const
 {
   return this->dataPtr->damping;


### PR DESCRIPTION
These methods were deprecated in `libsdformat9`, so remove them from `libsdformat10`.