### PR TITLE
Fix supported shader types (normal_map_X_space)

### DIFF
--- a/sdf/1.2/visual.sdf
+++ b/sdf/1.2/visual.sdf
@@ -41,7 +41,7 @@
       <description></description>
 
       <attribute name="type" type="string" default="pixel" required="1">
-        <description>vertex, pixel, normal_map_objectspace, normal_map_tangentspace</description>
+        <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
       </attribute>
 
       <element name="normal_map" type="string" default="__default__" required="0">

--- a/sdf/1.3/visual.sdf
+++ b/sdf/1.3/visual.sdf
@@ -41,7 +41,7 @@
       <description></description>
 
       <attribute name="type" type="string" default="pixel" required="1">
-        <description>vertex, pixel, normal_map_objectspace, normal_map_tangentspace</description>
+        <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
       </attribute>
 
       <element name="normal_map" type="string" default="__default__" required="0">

--- a/sdf/1.4/visual.sdf
+++ b/sdf/1.4/visual.sdf
@@ -41,7 +41,7 @@
       <description></description>
 
       <attribute name="type" type="string" default="pixel" required="1">
-        <description>vertex, pixel, normal_map_objectspace, normal_map_tangentspace</description>
+        <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
       </attribute>
 
       <element name="normal_map" type="string" default="__default__" required="0">

--- a/sdf/1.5/material.sdf
+++ b/sdf/1.5/material.sdf
@@ -17,7 +17,7 @@
   <element name="shader" required="0">
 
     <attribute name="type" type="string" default="pixel" required="1">
-      <description>vertex, pixel, normal_map_objectspace, normal_map_tangentspace</description>
+      <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
     </attribute>
 
     <element name="normal_map" type="string" default="__default__" required="0">

--- a/sdf/1.6/material.sdf
+++ b/sdf/1.6/material.sdf
@@ -17,7 +17,7 @@
   <element name="shader" required="0">
 
     <attribute name="type" type="string" default="pixel" required="1">
-      <description>vertex, pixel, normal_map_objectspace, normal_map_tangentspace</description>
+      <description>vertex, pixel, normal_map_object_space, normal_map_tangent_space</description>
     </attribute>
 
     <element name="normal_map" type="string" default="__default__" required="0">

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -176,7 +176,11 @@ Errors Material::Load(sdf::ElementPtr _sdf)
       this->dataPtr->shader = ShaderType::VERTEX;
     else if (typePair.first == "normal_map_objectspace")
       this->dataPtr->shader = ShaderType::NORMAL_MAP_OBJECTSPACE;
+    else if (typePair.first == "normal_map_object_space")
+      this->dataPtr->shader = ShaderType::NORMAL_MAP_OBJECTSPACE;
     else if (typePair.first == "normal_map_tangentspace")
+      this->dataPtr->shader = ShaderType::NORMAL_MAP_TANGENTSPACE;
+    else if (typePair.first == "normal_map_tangent_space")
       this->dataPtr->shader = ShaderType::NORMAL_MAP_TANGENTSPACE;
     else
     {

--- a/test/sdf/material.sdf
+++ b/test/sdf/material.sdf
@@ -26,7 +26,7 @@
 
       <visual name="visual3">
         <material>
-          <shader type="normal_map_objectspace">
+          <shader type="normal_map_object_space">
             <normal_map>my_normal_map</normal_map>
           </shader>
         </material>

--- a/test/sdf/material_normal_map_missing.sdf
+++ b/test/sdf/material_normal_map_missing.sdf
@@ -4,7 +4,7 @@
     <link name="link">
       <visual name="visual1">
         <material>
-          <shader type="normal_map_tangentspace">
+          <shader type="normal_map_tangent_space">
           </shader>
         </material>
       </visual>


### PR DESCRIPTION
Going over models on the Gazebo model database, I don't see a single model that uses:

* [normal_map_objectspace](https://github.com/osrf/gazebo_models/search?q=normal_map_objectspace&type=code)
* [normal_map_tangentspace](https://github.com/osrf/gazebo_models/search?q=normal_map_tangentspace&type=code)

Instead, there are models using:

* [normal_map_object_space](https://github.com/osrf/gazebo_models/search?q=normal_map_object_space&type=code)
* [normal_map_tangent_space](https://github.com/osrf/gazebo_models/search?q=normal_map_tangent_space&type=code)

I suspect that the documentation has been wrong all along, and when the `sdf::Material` class was created, the error was propagated.

The fix here changes the documentation to the "correct" values, but keeps the "old" values supported to avoid breaking existing code.