### PR TITLE
Make labeler work with PRs from forks

### DIFF
--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Collection Labeler
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   pr_collection_labeler:


### PR DESCRIPTION
Resolves https://github.com/ignition-tooling/pr-collection-labeler/issues/4

GitHub [recently](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) added the `pull_request_target` event, which makes this much easier. Unfortunately, this can't be fixed on the action itself, and needs to be done for each branch using it :cry: 

I tested that this makes the labeler work with forks here: https://github.com/ignitionrobotics/testing/pull/14