### PR TITLE
Move list of debian dependencies to packages.apt

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,0 +1,8 @@
+libignition-cmake2-dev
+libignition-math6-dev
+libignition-tools-dev
+libtinyxml-dev
+liburdfdom-dev
+libxml2-utils
+python-psutil
+ruby-dev

--- a/.github/workflows/linux-ubuntu-bionic.yml
+++ b/.github/workflows/linux-ubuntu-bionic.yml
@@ -16,7 +16,7 @@ jobs:
         sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list';
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743;
         sudo apt-get update;
-        sudo apt -y install cmake build-essential curl g++-8 git mercurial libtinyxml-dev libxml2-utils ruby-dev python-psutil cppcheck;
+        sudo apt -y install cmake build-essential curl g++-8 git cppcheck;
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8;
         # workaround for https://github.com/rubygems/rubygems/issues/3068
         # suggested in https://github.com/rubygems/rubygems/issues/3068#issuecomment-574775885
@@ -32,10 +32,7 @@ jobs:
     - name: Install ignition dependencies
       run: |
         sudo apt -y install \
-            libignition-cmake2-dev \
-            libignition-math6-dev \
-            libignition-tools-dev \
-            liburdfdom-dev;
+            $(sort -u $(find .github -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
     - name: cmake
       run: |
         mkdir build;


### PR DESCRIPTION
This will help keeping the list of dependencies in a single place, which is easier to maintain. Being close to the source code also makes it simple to update when a PR introduces a new dependency.

Our Jenkins CI can start referring to this list instead of [dependencies_archive.sh](https://github.com/ignition-tooling/release-tools/blob/c9a13eecfc578d1157721eb3b003a92ae75c7185/jenkins-scripts/lib/dependencies_archive.sh#L55-L113) (see https://github.com/ignition-tooling/release-tools/pull/317) and other tools, like the [API doc uploader](https://github.com/ignitionrobotics/docs/blob/1e4a23088105e47aa89837203daf8f5ee951ce9a/tools/scripts/build_ign.sh#L18-L19) can also make use of it.

The pattern we've been using is:


* `packages.apt` for dependencies common to all platforms
* `packages-<distro>.apt` for dependencies specific to Ubuntu <distro>

