### PR TITLE
Prefix nested model names when flattening

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1305,6 +1305,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF, Errors &_errors)
   while (elem)
   {
     if ((elem->GetName() == "link") ||
+        (elem->GetName() == "model") ||
         (elem->GetName() == "joint") ||
         (elem->GetName() == "frame"))
     {
@@ -1313,7 +1314,7 @@ void addNestedModel(ElementPtr _sdf, ElementPtr _includeSDF, Errors &_errors)
       replace[elemName] = newName;
     }
 
-    if ((elem->GetName() == "link"))
+    if ((elem->GetName() == "link") || (elem->GetName() == "model"))
     {
       // Add a pose element even if the element doesn't originally have one
       auto elemPose = elem->GetElement("pose");

--- a/test/integration/model/test_model_with_frames/model.sdf
+++ b/test/integration/model/test_model_with_frames/model.sdf
@@ -59,5 +59,11 @@
       <parent>L3</parent>
       <child>L4</child>
     </joint>
+    <model name="M2">
+      <pose relative_to="F1">1 0 0 0 0 0</pose>
+      <link name="L5">
+        <pose>1 0 0 0 0 0</pose>
+      </link>
+    </model>
   </model>
 </sdf>

--- a/test/integration/nested_model_with_frames_expected.sdf
+++ b/test/integration/nested_model_with_frames_expected.sdf
@@ -63,6 +63,12 @@
         <parent>M1::L3</parent>
         <child>M1::L4</child>
       </joint>
+      <model name='M1::M2'>
+        <pose relative_to='M1::F1'>1 0 0 0 -0 0</pose>
+        <link name='L5'>
+          <pose>1 0 0 0 -0 0</pose>
+        </link>
+      </model>
     </model>
   </world>
 </sdf>

--- a/test/integration/two_level_nested_model_with_frames_expected.sdf
+++ b/test/integration/two_level_nested_model_with_frames_expected.sdf
@@ -66,6 +66,12 @@
         <parent>M1::test_model_with_frames::L3</parent>
         <child>M1::test_model_with_frames::L4</child>
       </joint>
+      <model name='M1::test_model_with_frames::M2'>
+        <pose relative_to='M1::test_model_with_frames::F1'>1 0 0 0 -0 0</pose>
+        <link name='L5'>
+          <pose>1 0 0 0 -0 0</pose>
+        </link>
+      </model>
     </model>
   </world>
 </sdf>


### PR DESCRIPTION
Currently the [addNestedModel function in parser.cc](https://github.com/osrf/sdformat/blob/sdformat10_10.0.0/src/parser.cc#L1253) prefixes link, joint, and frame names with the flattened model name delimited by "::". This applies the same prefix to the names of nested models within the flattened model as well. Motivated by https://github.com/osrf/sdformat/pull/355#pullrequestreview-485492932