### PR TITLE
Add <double_sided> to material spec

### DIFF
--- a/include/sdf/Material.hh
+++ b/include/sdf/Material.hh
@@ -133,6 +133,15 @@ namespace sdf
     /// \param[in] _lighting False disables dynamic lighting.
     public: void SetLighting(const bool _lighting);
 
+    /// \brief Get whether double sided material is enabled. The default
+    /// value is false.
+    /// \return False if double sided material should be disabled.
+    public: bool DoubleSided() const;
+
+    /// \brief Set whether double sided material is enabled.
+    /// \param[in] _lighting False disables double sided material.
+    public: void SetDoubleSided(bool _doubleSided);
+
     /// \brief Get a pointer to the SDF element that was used during
     /// load.
     /// \return SDF element pointer. The value will be nullptr if Load has

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -45,6 +45,11 @@
     <description>The emissive color of a material specified by set of four numbers representing red/green/blue, each in the range of [0,1].</description>
   </element>
 
+  <element name="double_sided" type="bool" default="false" required="0">
+    <description>If true, the mesh that this material is applied to will be rendered as double sided</description>
+  </element>
+
+
   <element name="pbr" required="0">
     <description>Physically Based Rendering (PBR) material. There are two PBR workflows: metal and specular. While both workflows and their parameters can be specified at the same time, typically only one of them will be used (depending on the underlying renderer capability). It is also recommended to use the same workflow for all materials in the world.</description>
 

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -222,7 +222,7 @@ Errors Material::Load(sdf::ElementPtr _sdf)
   this->dataPtr->lighting = _sdf->Get<bool>("lighting",
       this->dataPtr->lighting).first;
 
-  this->dataPtr->doubleSided = _sdf->Get<bool>("doubleSided",
+  this->dataPtr->doubleSided = _sdf->Get<bool>("double_sided",
       this->dataPtr->doubleSided).first;
 
   // load pbr param

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -42,6 +42,9 @@ class sdf::MaterialPrivate
   /// \brief Lighting enabled?
   public: bool lighting = true;
 
+  /// \brief Double sided material
+  public: bool doubleSided = false;
+
   /// \brief Ambient color
   public: ignition::math::Color ambient {0, 0, 0, 1};
 
@@ -86,6 +89,7 @@ Material::Material(const Material &_material)
   this->dataPtr->shader = _material.dataPtr->shader;
   this->dataPtr->normalMap = _material.dataPtr->normalMap;
   this->dataPtr->lighting = _material.dataPtr->lighting;
+  this->dataPtr->doubleSided = _material.dataPtr->doubleSided;
   this->dataPtr->ambient = _material.dataPtr->ambient;
   this->dataPtr->diffuse = _material.dataPtr->diffuse;
   this->dataPtr->specular = _material.dataPtr->specular;
@@ -215,6 +219,12 @@ Errors Material::Load(sdf::ElementPtr _sdf)
   this->dataPtr->emissive = _sdf->Get<ignition::math::Color>("emissive",
       this->dataPtr->emissive).first;
 
+  this->dataPtr->lighting = _sdf->Get<bool>("lighting",
+      this->dataPtr->lighting).first;
+
+  this->dataPtr->doubleSided = _sdf->Get<bool>("doubleSided",
+      this->dataPtr->doubleSided).first;
+
   // load pbr param
   if (_sdf->HasElement("pbr"))
   {
@@ -284,6 +294,18 @@ bool Material::Lighting() const
 void Material::SetLighting(const bool _lighting)
 {
   this->dataPtr->lighting = _lighting;
+}
+
+//////////////////////////////////////////////////
+bool Material::DoubleSided() const
+{
+  return this->dataPtr->doubleSided;
+}
+
+//////////////////////////////////////////////////
+void Material::SetDoubleSided(const bool _doubleSided)
+{
+  this->dataPtr->doubleSided = _doubleSided;
 }
 
 //////////////////////////////////////////////////

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -30,6 +30,7 @@ TEST(DOMMaterial, Construction)
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Specular());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Emissive());
   EXPECT_TRUE(material.Lighting());
+  EXPECT_FALSE(material.DoubleSided());
   EXPECT_EQ(nullptr, material.Element());
   EXPECT_EQ("", material.ScriptUri());
   EXPECT_EQ("", material.ScriptName());
@@ -48,6 +49,7 @@ TEST(DOMMaterial, MoveConstructor)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
@@ -62,6 +64,7 @@ TEST(DOMMaterial, MoveConstructor)
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
+  EXPECT_TRUE(material2.DoubleSided());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -79,6 +82,7 @@ TEST(DOMMaterial, CopyConstructor)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
@@ -93,6 +97,7 @@ TEST(DOMMaterial, CopyConstructor)
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
+  EXPECT_TRUE(material2.DoubleSided());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -110,6 +115,7 @@ TEST(DOMMaterial, AssignmentOperator)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
@@ -125,6 +131,7 @@ TEST(DOMMaterial, AssignmentOperator)
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
+  EXPECT_TRUE(material2.DoubleSided());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -142,6 +149,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
   material.SetShader(sdf::ShaderType::VERTEX);
@@ -156,6 +164,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f),
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
+  EXPECT_TRUE(material2.DoubleSided());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -206,6 +215,10 @@ TEST(DOMMaterial, Set)
   material.SetLighting(false);
   EXPECT_FALSE(material.Lighting());
 
+  EXPECT_FALSE(material.DoubleSided());
+  material.SetDoubleSided(true);
+  EXPECT_TRUE(material.DoubleSided());
+
   EXPECT_EQ("", material.ScriptUri());
   material.SetScriptUri("uri");
   EXPECT_EQ("uri", material.ScriptUri());
@@ -243,6 +256,7 @@ TEST(DOMMaterial, Set)
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f), moved.Specular());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f), moved.Emissive());
   EXPECT_FALSE(moved.Lighting());
+  EXPECT_TRUE(moved.DoubleSided());
   EXPECT_EQ("uri", moved.ScriptUri());
   EXPECT_EQ("name", moved.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, moved.Shader());

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -120,6 +120,8 @@ TEST(DOMVisual, Material)
   EXPECT_EQ(ignition::math::Color(0.2f, 0.5f, 0.1f, 1.0f), mat->Diffuse());
   EXPECT_EQ(ignition::math::Color(0.7f, 0.3f, 0.5f, 0.9f), mat->Specular());
   EXPECT_EQ(ignition::math::Color(1.0f, 0.0f, 0.2f, 1.0f), mat->Emissive());
+  EXPECT_FALSE(mat->Lighting());
+  EXPECT_TRUE(mat->DoubleSided());
   EXPECT_EQ(sdf::ShaderType::VERTEX, mat->Shader());
   EXPECT_EQ("myuri", mat->ScriptUri());
   EXPECT_EQ("myname", mat->ScriptName());

--- a/test/sdf/material.sdf
+++ b/test/sdf/material.sdf
@@ -8,6 +8,8 @@
           <diffuse>0.2 0.5 0.1 1.0</diffuse>
           <specular>0.7 0.3 0.5 0.9</specular>
           <emissive>1.0 0.0 0.2 1.0</emissive>
+          <lighting>false</lighting>
+          <double_sided>true</double_sided>
           <shader type="vertex">
           </shader>
           <script>


### PR DESCRIPTION
Add new SDF parameter for configuring a material's double sided property. If set to true, the mesh will be rendered as double sided,  i.e. every polygon of a mesh will be visible from both the front and back sides. The default value is false.