### PR TITLE
Enable tests for #202 on macOS with Xcode 12+, add catalina workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: macOS latest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    env:
+      PACKAGE: sdformat8
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew config
+
+    - name: Install base dependencies
+      run: |
+        brew tap osrf/simulation;
+        brew install --only-dependencies ${PACKAGE};
+
+    - run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+    - run: make
+      working-directory: build
+    - run: make test
+      working-directory: build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: make install
+      working-directory: build
+      run: |
+        make install;
+        brew link ${PACKAGE};
+    - name: Compile example code
+      working-directory: examples
+      run: |
+        mkdir build;
+        cd build;
+        cmake ..;
+        make;
+        ./simple ../simple.sdf;

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -132,11 +132,7 @@ TEST(SDF, UpdateElement)
     staticParam->Get(flagCheck);
     EXPECT_EQ(flagCheck, fixture.flag);
     poseParam->Get(poseCheck);
-    // test fails on homebrew see issue 202
-    // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
     EXPECT_EQ(poseCheck, fixture.pose);
-#endif
   }
 }
 
@@ -419,11 +415,7 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
-    // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
       FAIL();
-#endif
     }
   }
 
@@ -437,11 +429,7 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
-    // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
       FAIL();
-#endif
     }
   }
 
@@ -481,11 +469,7 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
-    // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
       FAIL();
-#endif
     }
   }
 

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -132,7 +132,11 @@ TEST(SDF, UpdateElement)
     staticParam->Get(flagCheck);
     EXPECT_EQ(flagCheck, fixture.flag);
     poseParam->Get(poseCheck);
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // https://github.com/osrf/sdformat/issues/202
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
     EXPECT_EQ(poseCheck, fixture.pose);
+#endif
   }
 }
 
@@ -415,7 +419,11 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // https://github.com/osrf/sdformat/issues/202
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
+#endif
     }
   }
 
@@ -429,7 +437,11 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // https://github.com/osrf/sdformat/issues/202
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
+#endif
     }
   }
 
@@ -469,7 +481,11 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // https://github.com/osrf/sdformat/issues/202
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
+#endif
     }
   }
 


### PR DESCRIPTION
I believe the clang bug causing #202 has been fixed in Xcode 12+, which is available on macOS 10.15 Catalina. This re-enables those disabled tests for Xcode 12+ and adds a GitHub workflow for macOS Catalina to confirm the fix.