### PR TITLE
Cherry-pick #414 to sdf9: Enable tests for #202, add macos catalina workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: macOS latest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    env:
+      PACKAGE: sdformat8
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+    - run: brew config
+
+    - name: Install base dependencies
+      run: |
+        brew tap osrf/simulation;
+        brew install --only-dependencies ${PACKAGE};
+
+    - run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/${PACKAGE}/HEAD
+    - run: make
+      working-directory: build
+    - run: make test
+      working-directory: build
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: make install
+      working-directory: build
+      run: |
+        make install;
+        brew link ${PACKAGE};
+    - name: Compile example code
+      working-directory: examples
+      run: |
+        mkdir build;
+        cd build;
+        cmake ..;
+        make;
+        ./simple ../simple.sdf;

--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -132,9 +132,9 @@ TEST(SDF, UpdateElement)
     staticParam->Get(flagCheck);
     EXPECT_EQ(flagCheck, fixture.flag);
     poseParam->Get(poseCheck);
-    // test fails on homebrew see issue 202
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
     EXPECT_EQ(poseCheck, fixture.pose);
 #endif
   }
@@ -419,9 +419,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
 #endif
     }
@@ -437,9 +437,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
 #endif
     }
@@ -481,9 +481,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew see issue 202
+    // test fails on homebrew with Xcode 11 and earlier, see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#ifndef __APPLE__
+#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
       FAIL();
 #endif
     }


### PR DESCRIPTION
Forward port of #414, amended to fix major version number in workflow. Use rebase and merge.