### PR TITLE
Test included model folders missing model.config

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -746,7 +746,8 @@ std::string getModelFilePath(const std::string &_modelDirPath)
     if (!sdf::filesystem::exists(configFilePath))
     {
       // We didn't find manifest.xml either, output an error and get out.
-      sdferr << "Could not find model.config or manifest.xml for the model\n";
+      sdferr << "Could not find model.config or manifest.xml in ["
+             << _modelDirPath << "]\n";
       return std::string();
     }
     else
@@ -932,6 +933,15 @@ bool readXml(TiXmlElement *_xml, ElementPtr _sdf, Errors &_errors)
 
           // Get the config.xml filename
           filename = getModelFilePath(modelPath);
+
+          if (filename.empty())
+          {
+            _errors.push_back({ErrorCode::URI_LOOKUP,
+                "Unable to resolve uri[" + uri + "] to model path [" +
+                modelPath + "] since it does not contain a model.config " +
+                "file."});
+            continue;
+          }
         }
         else
         {

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -336,7 +336,10 @@ TEST(IncludesTest, IncludeModelMissingConfig)
   sdf::init(sdfParsed);
   sdf::Errors errors;
   ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed, errors));
+
+  ASSERT_GE(1u, errors.size());
   EXPECT_EQ(1u, errors.size());
+  std::cout << errors[0] << std::endl;
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::URI_LOOKUP);
   EXPECT_NE(std::string::npos, errors[0].Message().find(
       "Unable to resolve uri[box_missing_config] to model path")) << errors[0];

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -334,10 +334,18 @@ TEST(IncludesTest, IncludeModelMissingConfig)
 
   sdf::SDFPtr sdfParsed(new sdf::SDF());
   sdf::init(sdfParsed);
-  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+  sdf::Errors errors;
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed, errors));
+  EXPECT_EQ(1u, errors.size());
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::URI_LOOKUP);
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "Unable to resolve uri[box_missing_config] to model path")) << errors[0];
+  EXPECT_NE(std::string::npos, errors[0].Message().find(
+      "box_missing_config] since it does not contain a model.config file"))
+    << errors[0];
 
   sdf::Root root;
-  sdf::Errors errors = root.Load(sdfParsed);
+  errors = root.Load(sdfParsed);
   for (auto e : errors)
     std::cout << e.Message() << std::endl;
   EXPECT_TRUE(errors.empty());

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -318,3 +318,29 @@ TEST(IncludesTest, Includes_15_convert)
   EXPECT_EQ("1.6", modelElem->OriginalVersion());
   EXPECT_EQ("1.6", linkElem->OriginalVersion());
 }
+
+//////////////////////////////////////////////////
+TEST(IncludesTest, IncludeModelMissingConfig)
+{
+  sdf::setFindCallback(findFileCb);
+
+  std::ostringstream stream;
+  stream
+    << "<sdf version='" << SDF_VERSION << "'>"
+    << "<include>"
+    << "  <uri>box_missing_config</uri>"
+    << "</include>"
+    << "</sdf>";
+
+  sdf::SDFPtr sdfParsed(new sdf::SDF());
+  sdf::init(sdfParsed);
+  ASSERT_TRUE(sdf::readString(stream.str(), sdfParsed));
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(sdfParsed);
+  for (auto e : errors)
+    std::cout << e.Message() << std::endl;
+  EXPECT_TRUE(errors.empty());
+
+  EXPECT_EQ(0u, root.ModelCount());
+}

--- a/test/integration/model/box_missing_config/model.sdf
+++ b/test/integration/model/box_missing_config/model.sdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="box">
+    <pose>0 0 0.5 0 0 0</pose>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>1 1 1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>1 1 1</size>
+          </box>
+        </geometry>
+      </visual>
+    </link>
+  </model>
+</sdf>


### PR DESCRIPTION
Currently there is a confusing error message if a file is loaded that finds a folder matching the name of a model to
be included but the folder does not have a model.config file. This improves the first error message and stops further loading
to prevent additional confusing messages. To illustrate this, I've added a model folder `box_missing_config` to `test/integration/model` containing a `model.sdf` but no `model.config` and a test that tries to include a model matching that folder name. Without the change to parser.cc, the test prints the following:

~~~
[ RUN      ] IncludesTest.IncludeModelMissingConfig
Error [parser.cc:749] Could not find model.config or manifest.xml for the model
Error [parser.cc:749] Could not find model.config or manifest.xml for the model
Error [parser.cc:397] File [] doesn't exist.
Error:   Could not find the 'robot' element in the xml file
         at line 80 in /build/urdfdom-YMMa9X/urdfdom-1.0.0/urdf_parser/src/model.cpp
Error [parser_urdf.cc:3193] Unable to call parseURDF on robot model
Error [parser.cc:488] parse as old deprecated model file failed.
Error Code 1 Msg: Unable to read file[]
Error Code 8 Msg: Error reading element <sdf>
/home/scpeters/clone/sdformat/test/integration/includes.cc:337: Failure
Value of: sdf::readString(stream.str(), sdfParsed)
  Actual: false
Expected: true
[  FAILED  ] IncludesTest.IncludeModelMissingConfig (51 ms)
~~~

Note that `box_missing_config` is not listed anywhere, which makes it hard to figure out what is the cause of the problem. It also causes `readString` to fail. After modifying parser.cc, the parser doesn't fail and the test shows the following console output (the second message comes from printing out the errors returned by `Root::Load`):

~~~
[ RUN      ] IncludesTest.IncludeModelMissingConfig
Error [parser.cc:749] Could not find model.config or manifest.xml in [/home/scpeters/clone/sdformat/test/integration/model/box_missing_config]
Error Code 12 Msg: Unable to resolve uri[box_missing_config] to model path [/home/scpeters/clone/sdformat/test/integration/model/box_missing_config] since it does not contain a model.config file.
[       OK ] IncludesTest.IncludeModelMissingConfig (34 ms)
~~~

EDIT: it doesn't actually cause `sdf::readString` to fail, though it does return / print an error depending on which overload is called.