### PR TITLE
Make sdf::Model::CanonicalLinkAndRelativeName public

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -20,6 +20,9 @@ but with improved human-readability..
     + Errors ResolveChildLink(std::string&) const
     + Errors ResolveParentLink(std::string&) const
 
+1. **sdf/Model.hh**:
+    + std::pair<const Link *, std::string> CanonicalLinkAndRelativeName() const;
+
 ### Modifications
 
 1. **sdf/Model.hh**: the following methods now accept nested names relative to

--- a/include/sdf/Model.hh
+++ b/include/sdf/Model.hh
@@ -314,6 +314,13 @@ namespace sdf
     /// \param[in] _name Name of the placement frame.
     public: void SetPlacementFrameName(const std::string &_name);
 
+    /// \brief Get the model's canonical link and the nested name of the link
+    /// relative to the current model, delimited by "::".
+    /// \return An immutable pointer to the canonical link and the nested
+    /// name of the link relative to the current model.
+    public: std::pair<const Link *, std::string> CanonicalLinkAndRelativeName()
+        const;
+
     /// \brief Give the scoped PoseRelativeToGraph to be used for resolving
     /// poses. This is private and is intended to be called by Root::Load or
     /// World::SetPoseRelativeToGraph if this is a standalone model and
@@ -330,23 +337,11 @@ namespace sdf
     private: void SetFrameAttachedToGraph(
         sdf::ScopedGraph<FrameAttachedToGraph> _graph);
 
-    /// \brief Get the model's canonical link and the nested name of the link
-    /// relative to the current model, delimited by "::".
-    /// \return An immutable pointer to the canonical link and the nested
-    /// name of the link relative to the current model.
-    private: std::pair<const Link *, std::string> CanonicalLinkAndRelativeName()
-        const;
-
     /// \brief Allow Root::Load, World::SetPoseRelativeToGraph, or
     /// World::SetFrameAttachedToGraph to call SetPoseRelativeToGraph and
     /// SetFrameAttachedToGraph
     friend class Root;
     friend class World;
-
-    /// \brief Allow helper function in FrameSemantics.cc to call
-    /// CanonicalLinkAndRelativeName.
-    friend std::pair<const Link *, std::string>
-        modelCanonicalLinkAndRelativeName(const Model *);
 
     /// \brief Private data pointer.
     private: ModelPrivate *dataPtr = nullptr;


### PR DESCRIPTION
This member function is the only way to obtain the relative name of the canonical link when the link is implicitly nested, i.e, the `//model/@canonical_link` attribute is empty and the canonical link resolves to a link nested in a child model. While `sdf::Model::CanonicalLink` can be used to resolve the link, the returned `sdf::Link*` can only provide the local (non-relative) name of the link.

When constructing models, a downstream application may first recursively construct internal representations of all the links of a model before creating an internal representation of a model. When doing so, the application would need to identify one of the internal links as the canonical link and associate it with the internal representation of the model. In order to use `sdf::Model::CanonicalLink` for this task, it becomes necessary to track the mapping between `sdf::Link*` and the internal links of the application. Whereas if the relative name of the canonical link is available via `sdf::Model::CanonicalLinkAndRelativeName`, the application can query its internal list of links by the the relative name. It's reasonable to assume that the mapping from name to internal link is maintained by any application that consumes libsdformat so using `sdf::Model::CanonicalLinkAndRelativeName` avoids extra overhead.
