### PR TITLE
Decrease far clip lower bound

### DIFF
--- a/sdf/1.6/camera.sdf
+++ b/sdf/1.6/camera.sdf
@@ -29,7 +29,7 @@
       <description>Near clipping plane</description>
     </element>
 
-    <element name="far" type="double" default="100" min="10.0" required="1">
+    <element name="far" type="double" default="100" min="0.1" required="1">
       <description>Far clipping plane</description>
     </element>
   </element> <!-- End Clip -->

--- a/sdf/1.7/camera.sdf
+++ b/sdf/1.7/camera.sdf
@@ -29,7 +29,7 @@
       <description>Near clipping plane</description>
     </element>
 
-    <element name="far" type="double" default="100" min="10.0" required="1">
+    <element name="far" type="double" default="100" min="0.1" required="1">
       <description>Far clipping plane</description>
     </element>
   </element> <!-- End Clip -->


### PR DESCRIPTION
A far clip plane for a camera can be less than 10m. I'm setting the minimum value to match the value for the depth_camera.

Signed-off-by: Nate Koenig <nate@openrobotics.org>