### PR TITLE
Re-disable tests for #202

### DIFF
--- a/src/SDF_TEST.cc
+++ b/src/SDF_TEST.cc
@@ -132,9 +132,9 @@ TEST(SDF, UpdateElement)
     staticParam->Get(flagCheck);
     EXPECT_EQ(flagCheck, fixture.flag);
     poseParam->Get(poseCheck);
-    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // test fails on homebrew see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
+#ifndef __APPLE__
     EXPECT_EQ(poseCheck, fixture.pose);
 #endif
   }
@@ -419,9 +419,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // test fails on homebrew see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
+#ifndef __APPLE__
       FAIL();
 #endif
     }
@@ -437,9 +437,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // test fails on homebrew see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
+#ifndef __APPLE__
       FAIL();
 #endif
     }
@@ -481,9 +481,9 @@ TEST(SDF, GetAny)
     }
     catch(std::bad_any_cast &/*_e*/)
     {
-    // test fails on homebrew with Xcode 11 and earlier, see issue 202
+    // test fails on homebrew see issue 202
     // https://github.com/osrf/sdformat/issues/202
-#if !(defined(__APPLE__) && defined(__clang_major__) && __clang_major__ < 12)
+#ifndef __APPLE__
       FAIL();
 #endif
     }


### PR DESCRIPTION
This reverts part of "Enable tests for #202 on macOS with Xcode 12+, add catalina workflow (#414)", since those tests have started failing again in the macOS CI action. It keeps the macOS workflow.

* https://github.com/osrf/sdformat/actions?query=workflow%3A%22macOS+latest%22

I don't know what has changed or why, but I've re-opened #202 and am disabling the tests again here.