### PR TITLE
Set sdf::Root to contain only one model/actor/light

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -23,6 +23,13 @@ but with improved human-readability..
 1. **sdf/Model.hh**:
     + std::pair<const Link *, std::string> CanonicalLinkAndRelativeName() const;
 
+1. **sdf/Root.hh** sdf::Root elements can now only contain one of either Model,
+      Light or Actor since multiple items would conflict with overrides
+      specified in an <include> tag.
+    + const sdf::Model \*Model();
+    + const sdf::Light \*Light();
+    + const sdf::Actor \*Actor();
+
 ### Modifications
 
 1. **sdf/Model.hh**: the following methods now accept nested names relative to
@@ -35,6 +42,21 @@ but with improved human-readability..
     + bool FrameNameExists(const std::string &) const
     + bool JointNameExists(const std::string &) const
     + bool LinkNameExists(const std::string &) const
+
+### Deprecations
+
+1. **src/Root.hh**: The following methods have been deprecated in favor of the
+      new methods. For now the behavior is unchanged, but Root elements should
+      only contain one or none of Model/Light/Actor.
+    + const sdf::Model \*ModelByIndex();
+    + uint64_t ModelCount();
+    + bool ModelNameExists(const std::string &\_name) const;
+    + const sdf::Light \*LightByIndex();
+    + uint64_t LightCount();
+    + bool LightNameExists(const std::string &\_name) const;
+    + const sdf::Actor \*ActorByIndex();
+    + uint64_t ActorCount();
+    + bool ActorNameExists(const std::string &\_name) const;
 
 ## SDFormat 9.x to 10.0
 

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -144,6 +144,13 @@ namespace sdf
         SDF_DEPRECATED(11.0);
 
     /// \brief Get a pointer to the model object if it exists.
+    ///
+    /// If there is more than one model, this will return the first element.
+    /// This method is preferred to ModelByIndex, as its behavior is
+    /// consistent with the planned future API. Having more than one Model, or
+    /// more than one of Model/Actor/Light is now considered deprecated and
+    /// should not be relied upon going forward.
+    ///
     /// \return A pointer to the model, nullptr if it doesn't exist
     public: const sdf::Model *Model() const;
 
@@ -166,6 +173,14 @@ namespace sdf
         SDF_DEPRECATED(11.0);
 
     /// \brief Get a pointer to the light object if it exists.
+    ///
+    /// If there is more than one light, this will return the first element. If
+    /// there is already a model element, this will return null.
+    /// This method is preferred to LightByIndex, as its behavior is
+    /// consistent with the planned future API. Having more than one Light, or
+    /// more than one of Model/Actor/Light is now considered deprecated and
+    /// should not be relied upon going forward.
+    ///
     /// \return A pointer to the light, nullptr if it doesn't exist
     public: const sdf::Light *Light() const;
 
@@ -188,6 +203,14 @@ namespace sdf
         SDF_DEPRECATED(11.0);
 
     /// \brief Get a pointer to the actor object if it exists.
+    ///
+    /// If there is more than one actor, this will return the first element. If
+    /// there is already a model or light element, this will return null.
+    /// This method is preferred to ActorByIndex, as its behavior is
+    /// consistent with the planned future API. Having more than one Actor, or
+    /// more than one of Model/Actor/Light is now considered deprecated and
+    /// should not be relied upon going forward.
+    ///
     /// \return A pointer to the actor, nullptr if it doesn't exist
     public: const sdf::Actor *Actor() const;
 

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -127,51 +127,15 @@ namespace sdf
     /// \brief Get the number of models that are immediate (not nested) children
     /// of this Root object.
     /// \return Number of models contained in this Root object.
-    public: uint64_t ModelCount() const;
-
-    /// \brief Get a model based on an index.
-    /// \param[in] _index Index of the model. The index should be in the
-    /// range [0..ModelCount()).
-    /// \return Pointer to the model. Nullptr if the index does not exist.
-    /// \sa uint64_t ModelCount() const
-    public: const Model *ModelByIndex(const uint64_t _index) const;
-
-    /// \brief Get whether a model name exists.
-    /// \param[in] _name Name of the model to check.
-    /// \return True if there exists a model with the given name.
-    public: bool ModelNameExists(const std::string &_name) const;
+    public: const sdf::Model *Model() const;
 
     /// \brief Get the number of lights.
     /// \return Number of lights contained in this Root object.
-    public: uint64_t LightCount() const;
-
-    /// \brief Get a light based on an index.
-    /// \param[in] _index Index of the light. The index should be in the
-    /// range [0..LightCount()).
-    /// \return Pointer to the light. Nullptr if the index does not exist.
-    /// \sa uint64_t LightCount() const
-    public: const Light *LightByIndex(const uint64_t _index) const;
-
-    /// \brief Get whether a light name exists.
-    /// \param[in] _name Name of the light to check.
-    /// \return True if there exists a light with the given name.
-    public: bool LightNameExists(const std::string &_name) const;
+    public: const sdf::Light *Light() const;
 
     /// \brief Get the number of actors.
     /// \return Number of actors contained in this Root object.
-    public: uint64_t ActorCount() const;
-
-    /// \brief Get an actor based on an index.
-    /// \param[in] _index Index of the actor. The actor should be in the
-    /// range [0..ActorCount()).
-    /// \return Pointer to the actor. Nullptr if the index does not exist.
-    /// \sa uint64_t ActorCount() const
-    public: const Actor *ActorByIndex(const uint64_t _index) const;
-
-    /// \brief Get whether an actor name exists.
-    /// \param[in] _name Name of the actor to check.
-    /// \return True if there exists an actor with the given name.
-    public: bool ActorNameExists(const std::string &_name) const;
+    public: const sdf::Actor *Actor() const;
 
     /// \brief Get a pointer to the SDF element that was generated during
     /// load.

--- a/include/sdf/Root.hh
+++ b/include/sdf/Root.hh
@@ -127,14 +127,68 @@ namespace sdf
     /// \brief Get the number of models that are immediate (not nested) children
     /// of this Root object.
     /// \return Number of models contained in this Root object.
+    public: uint64_t ModelCount() const SDF_DEPRECATED(11.0);
+
+    /// \brief Get a model based on an index.
+    /// \param[in] _index Index of the model. The index should be in the
+    /// range [0..ModelCount()).
+    /// \return Pointer to the model. Nullptr if the index does not exist.
+    /// \sa uint64_t ModelCount() const
+    public: const sdf::Model *ModelByIndex(const uint64_t _index) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get whether a model name exists.
+    /// \param[in] _name Name of the model to check.
+    /// \return True if there exists a model with the given name.
+    public: bool ModelNameExists(const std::string &_name) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get a pointer to the model object if it exists.
+    /// \return A pointer to the model, nullptr if it doesn't exist
     public: const sdf::Model *Model() const;
 
     /// \brief Get the number of lights.
     /// \return Number of lights contained in this Root object.
+    public: uint64_t LightCount() const SDF_DEPRECATED(11.0);
+
+    /// \brief Get a light based on an index.
+    /// \param[in] _index Index of the light. The index should be in the
+    /// range [0..LightCount()).
+    /// \return Pointer to the light. Nullptr if the index does not exist.
+    /// \sa uint64_t LightCount() const
+    public: const sdf::Light *LightByIndex(const uint64_t _index) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get whether a light name exists.
+    /// \param[in] _name Name of the light to check.
+    /// \return True if there exists a light with the given name.
+    public: bool LightNameExists(const std::string &_name) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get a pointer to the light object if it exists.
+    /// \return A pointer to the light, nullptr if it doesn't exist
     public: const sdf::Light *Light() const;
 
     /// \brief Get the number of actors.
     /// \return Number of actors contained in this Root object.
+    public: uint64_t ActorCount() const SDF_DEPRECATED(11.0);
+
+    /// \brief Get an actor based on an index.
+    /// \param[in] _index Index of the actor. The actor should be in the
+    /// range [0..ActorCount()).
+    /// \return Pointer to the actor. Nullptr if the index does not exist.
+    /// \sa uint64_t ActorCount() const
+    public: const sdf::Actor *ActorByIndex(const uint64_t _index) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get whether an actor name exists.
+    /// \param[in] _name Name of the actor to check.
+    /// \return True if there exists an actor with the given name.
+    public: bool ActorNameExists(const std::string &_name) const
+        SDF_DEPRECATED(11.0);
+
+    /// \brief Get a pointer to the actor object if it exists.
+    /// \return A pointer to the actor, nullptr if it doesn't exist
     public: const sdf::Actor *Actor() const;
 
     /// \brief Get a pointer to the SDF element that was generated during

--- a/src/FrameSemantics_TEST.cc
+++ b/src/FrameSemantics_TEST.cc
@@ -48,7 +48,7 @@ TEST(FrameSemantics, buildFrameAttachedToGraph_Model)
   EXPECT_TRUE(errors.empty()) << errors;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
 
   auto ownedGraph = std::make_shared<sdf::FrameAttachedToGraph>();
   sdf::ScopedGraph<sdf::FrameAttachedToGraph> graph(ownedGraph);
@@ -217,7 +217,7 @@ TEST(FrameSemantics, buildPoseRelativeToGraph)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
 
   auto ownedGraph = std::make_shared<sdf::PoseRelativeToGraph>();
   sdf::ScopedGraph<sdf::PoseRelativeToGraph> graph(ownedGraph);
@@ -313,7 +313,7 @@ TEST(NestedFrameSemantics, buildFrameAttachedToGraph_Model)
   EXPECT_TRUE(errors.empty()) << errors;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
 
   auto ownedGraph = std::make_shared<sdf::FrameAttachedToGraph>();
   sdf::ScopedGraph<sdf::FrameAttachedToGraph> graph(ownedGraph);
@@ -592,7 +592,7 @@ TEST(NestedFrameSemantics, ModelWithoutLinksWithNestedStaticModel)
   auto errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty()) << errors;
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   auto ownedModelGraph = std::make_shared<sdf::FrameAttachedToGraph>();

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -52,15 +52,15 @@ class sdf::RootPrivate
 
   /// \brief The models specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Model> models SDF_DEPRECATED(11.0);
+  public: std::vector<sdf::Model> models;
 
   /// \brief The lights specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Light> lights SDF_DEPRECATED(11.0);
+  public: std::vector<sdf::Light> lights;
 
   /// \brief The actors specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Actor> actors SDF_DEPRECATED(11.0);
+  public: std::vector<sdf::Actor> actors;
 
   /// \brief Frame Attached-To Graphs constructed when loading Worlds.
   public: std::vector<sdf::ScopedGraph<FrameAttachedToGraph>>

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -355,15 +355,80 @@ bool Root::WorldNameExists(const std::string &_name) const
 }
 
 /////////////////////////////////////////////////
+uint64_t Root::ModelCount() const
+{
+  return static_cast<uint64_t>(nullptr != this->Model());
+}
+
+/////////////////////////////////////////////////
+const Model *Root::ModelByIndex(const uint64_t _index) const
+{
+  if (0u == _index)
+  {
+    return this->Model();
+  }
+  return nullptr;
+}
+
+/////////////////////////////////////////////////
+bool Root::ModelNameExists(const std::string &_name) const
+{
+  return nullptr != this->Model() && this->Model()->Name() == _name;
+}
+
+/////////////////////////////////////////////////
 const Model *Root::Model() const
 {
   return this->dataPtr->model.get();
+}
+
+uint64_t Root::LightCount() const
+{
+  return static_cast<uint64_t>(nullptr != this->Light());
+}
+
+/////////////////////////////////////////////////
+const Light *Root::LightByIndex(const uint64_t _index) const
+{
+  if (0u == _index)
+  {
+    return this->Light();
+  }
+  return nullptr;
+}
+
+/////////////////////////////////////////////////
+bool Root::LightNameExists(const std::string &_name) const
+{
+  return nullptr != this->Light() && this->Light()->Name() == _name;
 }
 
 /////////////////////////////////////////////////
 const Light *Root::Light() const
 {
   return this->dataPtr->light.get();
+}
+
+/////////////////////////////////////////////////
+uint64_t Root::ActorCount() const
+{
+  return static_cast<uint64_t>(nullptr != this->Actor());
+}
+
+/////////////////////////////////////////////////
+const Actor *Root::ActorByIndex(const uint64_t _index) const
+{
+  if (0u == _index)
+  {
+    return this->Actor();
+  }
+  return nullptr;
+}
+
+/////////////////////////////////////////////////
+bool Root::ActorNameExists(const std::string &_name) const
+{
+  return nullptr != this->Actor() && this->Actor()->Name() == _name;
 }
 
 /////////////////////////////////////////////////

--- a/src/Root.cc
+++ b/src/Root.cc
@@ -52,15 +52,15 @@ class sdf::RootPrivate
 
   /// \brief The models specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Model> models;
+  public: std::vector<sdf::Model> models SDF_DEPRECATED(11.0);
 
   /// \brief The lights specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Light> lights;
+  public: std::vector<sdf::Light> lights SDF_DEPRECATED(11.0);
 
   /// \brief The actors specified under the root SDF element
   /// Deprecated: to be removed in libsdformat12
-  public: std::vector<sdf::Actor> actors;
+  public: std::vector<sdf::Actor> actors SDF_DEPRECATED(11.0);
 
   /// \brief Frame Attached-To Graphs constructed when loading Worlds.
   public: std::vector<sdf::ScopedGraph<FrameAttachedToGraph>>

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -42,6 +42,26 @@ TEST(DOMRoot, Construction)
   EXPECT_EQ(nullptr, root.Model());
   EXPECT_EQ(nullptr, root.Light());
   EXPECT_EQ(nullptr, root.Actor());
+
+  SDF_SUPPRESS_DEPRECATED_BEGIN
+  EXPECT_FALSE(root.ModelNameExists("default"));
+  EXPECT_FALSE(root.ModelNameExists(""));
+  EXPECT_EQ(0u, root.ModelCount());
+  EXPECT_TRUE(root.ModelByIndex(0) == nullptr);
+  EXPECT_TRUE(root.ModelByIndex(1) == nullptr);
+
+  EXPECT_FALSE(root.LightNameExists("default"));
+  EXPECT_FALSE(root.LightNameExists(""));
+  EXPECT_EQ(0u, root.LightCount());
+  EXPECT_TRUE(root.LightByIndex(0) == nullptr);
+  EXPECT_TRUE(root.LightByIndex(1) == nullptr);
+
+  EXPECT_FALSE(root.ActorNameExists("default"));
+  EXPECT_FALSE(root.ActorNameExists(""));
+  EXPECT_EQ(0u, root.ActorCount());
+  EXPECT_TRUE(root.ActorByIndex(0) == nullptr);
+  EXPECT_TRUE(root.ActorByIndex(1) == nullptr);
+  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////

--- a/src/Root_TEST.cc
+++ b/src/Root_TEST.cc
@@ -39,23 +39,9 @@ TEST(DOMRoot, Construction)
   EXPECT_TRUE(root.WorldByIndex(0) == nullptr);
   EXPECT_TRUE(root.WorldByIndex(1) == nullptr);
 
-  EXPECT_FALSE(root.ModelNameExists("default"));
-  EXPECT_FALSE(root.ModelNameExists(""));
-  EXPECT_EQ(0u, root.ModelCount());
-  EXPECT_TRUE(root.ModelByIndex(0) == nullptr);
-  EXPECT_TRUE(root.ModelByIndex(1) == nullptr);
-
-  EXPECT_FALSE(root.LightNameExists("default"));
-  EXPECT_FALSE(root.LightNameExists(""));
-  EXPECT_EQ(0u, root.LightCount());
-  EXPECT_TRUE(root.LightByIndex(0) == nullptr);
-  EXPECT_TRUE(root.LightByIndex(1) == nullptr);
-
-  EXPECT_FALSE(root.ActorNameExists("default"));
-  EXPECT_FALSE(root.ActorNameExists(""));
-  EXPECT_EQ(0u, root.ActorCount());
-  EXPECT_TRUE(root.ActorByIndex(0) == nullptr);
-  EXPECT_TRUE(root.ActorByIndex(1) == nullptr);
+  EXPECT_EQ(nullptr, root.Model());
+  EXPECT_EQ(nullptr, root.Light());
+  EXPECT_EQ(nullptr, root.Actor());
 }
 
 /////////////////////////////////////////////////
@@ -80,10 +66,10 @@ TEST(DOMRoot, MoveAssignmentOperator)
 }
 
 /////////////////////////////////////////////////
-TEST(DOMRoot, StringParse)
+TEST(DOMRoot, StringModelSdfParse)
 {
   std::string sdf = "<?xml version=\"1.0\"?>"
-    " <sdf version=\"1.6\">"
+    " <sdf version=\"1.8\">"
     "   <model name='shapes'>"
     "     <link name='link'>"
     "       <collision name='box_col'>"
@@ -95,9 +81,66 @@ TEST(DOMRoot, StringParse)
     "       </collision>"
     "     </link>"
     "   </model>"
+    " </sdf>";
+
+  sdf::Root root;
+  sdf::Errors errors = root.LoadSdfString(sdf);
+  EXPECT_TRUE(errors.empty());
+  EXPECT_NE(nullptr, root.Element());
+
+  const sdf::Model *model = root.Model();
+  ASSERT_NE(nullptr, model);
+  EXPECT_NE(nullptr, model->Element());
+
+  EXPECT_EQ("shapes", model->Name());
+  EXPECT_EQ(1u, model->LinkCount());
+
+  const sdf::Link *link = model->LinkByIndex(0);
+  ASSERT_NE(nullptr, link);
+  EXPECT_NE(nullptr, link->Element());
+  EXPECT_EQ("link", link->Name());
+  EXPECT_EQ(1u, link->CollisionCount());
+
+  const sdf::Collision *collision = link->CollisionByIndex(0);
+  ASSERT_NE(nullptr, collision);
+  EXPECT_NE(nullptr, collision->Element());
+  EXPECT_EQ("box_col", collision->Name());
+
+  EXPECT_EQ(nullptr, root.Light());
+  EXPECT_EQ(nullptr, root.Actor());
+  EXPECT_EQ(0u, root.WorldCount());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMRoot, StringLightSdfParse)
+{
+  std::string sdf = "<?xml version=\"1.0\"?>"
+    " <sdf version=\"1.8\">"
     "   <light type='directional' name='sun'>"
     "     <direction>-0.5 0.1 -0.9</direction>"
     "   </light>"
+    " </sdf>";
+
+  sdf::Root root;
+  sdf::Errors errors = root.LoadSdfString(sdf);
+  EXPECT_TRUE(errors.empty());
+  EXPECT_NE(nullptr, root.Element());
+
+  const sdf::Light *light = root.Light();
+  ASSERT_NE(nullptr, light);
+  EXPECT_EQ("sun", light->Name());
+  EXPECT_NE(nullptr, light->Element());
+
+  EXPECT_EQ(nullptr, root.Model());
+  EXPECT_EQ(nullptr, root.Actor());
+  EXPECT_EQ(0u, root.WorldCount());
+}
+
+/////////////////////////////////////////////////
+TEST(DOMRoot, StringActorSdfParse)
+{
+  std::string sdf = "<?xml version=\"1.0\"?>"
+    " <sdf version=\"1.8\">"
     "   <actor name='actor_test'>"
     "     <pose>0 0 1.0 0 0 0</pose>"
     "     <skin>"
@@ -120,39 +163,15 @@ TEST(DOMRoot, StringParse)
   sdf::Root root;
   sdf::Errors errors = root.LoadSdfString(sdf);
   EXPECT_TRUE(errors.empty());
-  EXPECT_EQ(1u, root.ModelCount());
-  EXPECT_EQ(1u, root.LightCount());
-  EXPECT_NE(nullptr, root.Element());
 
-  const sdf::Model *model = root.ModelByIndex(0);
-  ASSERT_NE(nullptr, model);
-  EXPECT_NE(nullptr, model->Element());
-
-  EXPECT_EQ("shapes", model->Name());
-  EXPECT_EQ(1u, model->LinkCount());
-
-  const sdf::Link *link = model->LinkByIndex(0);
-  ASSERT_NE(nullptr, link);
-  EXPECT_NE(nullptr, link->Element());
-  EXPECT_EQ("link", link->Name());
-  EXPECT_EQ(1u, link->CollisionCount());
-
-  const sdf::Collision *collision = link->CollisionByIndex(0);
-  ASSERT_NE(nullptr, collision);
-  EXPECT_NE(nullptr, collision->Element());
-  EXPECT_EQ("box_col", collision->Name());
-
-  EXPECT_TRUE(root.LightNameExists("sun"));
-  EXPECT_EQ(1u, root.LightCount());
-  const sdf::Light *light = root.LightByIndex(0);
-  ASSERT_NE(nullptr, light);
-  EXPECT_NE(nullptr, light->Element());
-
-  EXPECT_TRUE(root.ActorNameExists("actor_test"));
-  EXPECT_EQ(1u, root.ActorCount());
-  const sdf::Actor *actor = root.ActorByIndex(0);
+  const sdf::Actor *actor = root.Actor();
   ASSERT_NE(nullptr, actor);
+  EXPECT_EQ("actor_test", actor->Name());
   EXPECT_NE(nullptr, actor->Element());
+
+  EXPECT_EQ(nullptr, root.Model());
+  EXPECT_EQ(nullptr, root.Light());
+  EXPECT_EQ(0u, root.WorldCount());
 }
 
 /////////////////////////////////////////////////

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -187,9 +187,10 @@ extern "C" SDFORMAT_VISIBLE int cmdGraph(
     {
       errors = sdf::buildPoseRelativeToGraph(graph, root.WorldByIndex(0));
     }
-    else if (root.ModelCount() > 0)
+    else if (root.Model() != nullptr)
     {
-      errors = sdf::buildPoseRelativeToGraph(graph, root.ModelByIndex(0));
+      errors =
+        sdf::buildPoseRelativeToGraph(graph, root.Model());
     }
 
     if (!errors.empty())
@@ -206,9 +207,10 @@ extern "C" SDFORMAT_VISIBLE int cmdGraph(
     {
       errors = sdf::buildFrameAttachedToGraph(graph, root.WorldByIndex(0));
     }
-    else if (root.ModelCount() > 0)
+    else if (root.Model() != nullptr)
     {
-      errors = sdf::buildFrameAttachedToGraph(graph, root.ModelByIndex(0));
+      errors =
+        sdf::buildFrameAttachedToGraph(graph, root.Model());
     }
 
     if (!errors.empty())

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1393,10 +1393,9 @@ bool checkCanonicalLinkNames(const sdf::Root *_root)
     return modelResult;
   };
 
-  for (uint64_t m = 0; m < _root->ModelCount(); ++m)
+  if (_root->Model())
   {
-    auto model = _root->ModelByIndex(m);
-    result = checkModelCanonicalLinkName(model) && result;
+    result = checkModelCanonicalLinkName(_root->Model()) && result;
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)
@@ -1530,10 +1529,9 @@ bool checkFrameAttachedToNames(const sdf::Root *_root)
     return worldResult;
   };
 
-  for (uint64_t m = 0; m < _root->ModelCount(); ++m)
+  if (_root->Model())
   {
-    auto model = _root->ModelByIndex(m);
-    result = checkModelFrameAttachedToNames(model) && result;
+    result = checkModelFrameAttachedToNames(_root->Model()) && result;
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)
@@ -1668,10 +1666,9 @@ bool checkFrameAttachedToGraph(const sdf::Root *_root)
     return worldResult;
   };
 
-  for (uint64_t m = 0; m < _root->ModelCount(); ++m)
+  if (_root->Model())
   {
-    auto model = _root->ModelByIndex(m);
-    result = checkModelFrameAttachedToGraph(model) && result;
+    result = checkModelFrameAttachedToGraph(_root->Model()) && result;
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)
@@ -1751,10 +1748,9 @@ bool checkPoseRelativeToGraph(const sdf::Root *_root)
     return worldResult;
   };
 
-  for (uint64_t m = 0; m < _root->ModelCount(); ++m)
+  if (_root->Model())
   {
-    auto model = _root->ModelByIndex(m);
-    result = checkModelPoseRelativeToGraph(model) && result;
+    result = checkModelPoseRelativeToGraph(_root->Model()) && result;
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)
@@ -1879,10 +1875,9 @@ bool checkJointParentChildLinkNames(const sdf::Root *_root)
     return modelResult;
   };
 
-  for (uint64_t m = 0; m < _root->ModelCount(); ++m)
+  if (_root->Model())
   {
-    auto model = _root->ModelByIndex(m);
-    result = checkModelJointParentChildNames(model) && result;
+    result = checkModelJointParentChildNames(_root->Model()) && result;
   }
 
   for (uint64_t w = 0; w < _root->WorldCount(); ++w)

--- a/test/integration/collision_dom.cc
+++ b/test/integration/collision_dom.cc
@@ -71,7 +71,7 @@ TEST(DOMCollision, DoublePendulum)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_TRUE(model != nullptr);
 
   const sdf::Link *baseLink = model->LinkByIndex(0);
@@ -105,7 +105,7 @@ TEST(DOMCollision, LoadModelFramesRelativeToJoint)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_relative_to_joint", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -284,4 +284,3 @@ TEST(DOMCollision, LoadModelFramesRelativeToJoint)
     linkC->CollisionByName("F4")->SemanticPose().Resolve(pose).empty());
   EXPECT_EQ(Pose(-18, 3, 4, 0, -IGN_PI/2, 0), pose);
 }
-

--- a/test/integration/frame.cc
+++ b/test/integration/frame.cc
@@ -423,7 +423,7 @@ TEST(DOMFrame, LoadModelFramesAttachedTo)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_attached_to", model->Name());
   EXPECT_EQ(1u, model->LinkCount());
@@ -525,7 +525,7 @@ TEST(DOMFrame, LoadModelFramesAttachedToJoint)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_attached_to_joint", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -591,7 +591,7 @@ TEST(DOMFrame, LoadModelFramesAttachedToNestedModel)
   EXPECT_TRUE(errors.empty()) << errors;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_attached_to_nested_model", model->Name());
   EXPECT_EQ(1u, model->LinkCount());
@@ -750,7 +750,7 @@ TEST(DOMFrame, LoadModelFramesRelativeTo)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_relative_to", model->Name());
   EXPECT_EQ(1u, model->LinkCount());
@@ -911,7 +911,7 @@ TEST(DOMFrame, LoadModelFramesRelativeToJoint)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_relative_to_joint", model->Name());
   EXPECT_EQ(2u, model->LinkCount());

--- a/test/integration/geometry_dom.cc
+++ b/test/integration/geometry_dom.cc
@@ -49,7 +49,7 @@ TEST(DOMGeometry, Shapes)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *link = model->LinkByIndex(0);

--- a/test/integration/joint_axis_dom.cc
+++ b/test/integration/joint_axis_dom.cc
@@ -42,7 +42,7 @@ TEST(DOMJointAxis, Complete)
   EXPECT_TRUE(errors.empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   // The model should have nine joints.
@@ -132,7 +132,7 @@ TEST(DOMJointAxis, XyzExpressedIn)
   using Vector3 = ignition::math::Vector3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_joint_axis_expressed_in", model->Name());
   EXPECT_EQ(4u, model->LinkCount());
@@ -244,7 +244,7 @@ TEST(DOMJointAxis, XyzNormalization)
   using ignition::math::Vector3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   {

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -72,7 +72,7 @@ TEST(DOMJoint, DoublePendulum)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   // The double pendulum should have two joints.
@@ -127,7 +127,7 @@ TEST(DOMJoint, Complete)
   EXPECT_TRUE(errors.empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   std::vector<ignition::math::Pose3d> jointPoses =
@@ -171,7 +171,7 @@ TEST(DOMJoint, LoadJointParentWorld)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("joint_parent_world", model->Name());
   EXPECT_EQ(1u, model->LinkCount());
@@ -220,8 +220,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
   auto errors = root.Load(testFile);
   for (auto e : errors)
     std::cout << e << std::endl;
-  EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(7u, errors.size());
+  ASSERT_EQ(7u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::JOINT_CHILD_LINK_INVALID);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find(
@@ -247,7 +246,7 @@ TEST(DOMJoint, LoadJointParentFrame)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("joint_parent_frame", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -340,7 +339,7 @@ TEST(DOMJoint, LoadJointChildFrame)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("joint_child_frame", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -433,7 +432,7 @@ TEST(DOMJoint, LoadJointPoseRelativeTo)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_joint_relative_to", model->Name());
   EXPECT_EQ(4u, model->LinkCount());
@@ -621,7 +620,7 @@ TEST(DOMJoint, LoadLinkJointSameName16Valid)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("link_joint_same_name", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -701,7 +700,7 @@ TEST(DOMJoint, LoadURDFJointPoseRelativeTo)
   using Vector3 = ignition::math::Vector3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("provide_feedback_test", model->Name());
   EXPECT_EQ(3u, model->LinkCount());
@@ -782,7 +781,7 @@ TEST(DOMJoint, LoadJointNestedParentChild)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   {

--- a/test/integration/link_dom.cc
+++ b/test/integration/link_dom.cc
@@ -122,7 +122,7 @@ TEST(DOMLink, InertialDoublePendulum)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *baseLink = model->LinkByIndex(0);
@@ -177,7 +177,7 @@ TEST(DOMLink, InertialComplete)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *link = model->LinkByIndex(0);
@@ -215,7 +215,7 @@ TEST(DOMLink, InertialInvalid)
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::LINK_INERTIA_INVALID);
   EXPECT_EQ(errors[0].Message(), "A link named link has invalid inertia.");
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   ASSERT_EQ(1u, model->LinkCount());
@@ -239,7 +239,7 @@ TEST(DOMLink, Sensors)
   EXPECT_TRUE(errors.empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model", model->Name());
 
@@ -591,7 +591,7 @@ TEST(DOMLink, LoadLinkPoseRelativeTo)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_link_relative_to", model->Name());
   EXPECT_EQ(3u, model->LinkCount());

--- a/test/integration/material_pbr.cc
+++ b/test/integration/material_pbr.cc
@@ -34,7 +34,7 @@ TEST(Material, PbrDOM)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   // Get the first link
@@ -541,5 +541,3 @@ TEST(Material, MaterialPBR)
     }
   }
 }
-
-

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -121,7 +121,7 @@ TEST(DOMRoot, LoadDoublePendulum)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("double_pendulum_with_base", model->Name());
   EXPECT_EQ(3u, model->LinkCount());
@@ -157,10 +157,8 @@ TEST(DOMRoot, NestedModel)
   auto errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty()) << errors;
 
-  EXPECT_EQ(1u, root.ModelCount());
-
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("top_level_model", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -216,10 +214,8 @@ TEST(DOMRoot, MultiNestedModel)
   auto errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty());
 
-  EXPECT_EQ(1u, root.ModelCount());
-
   // Get the outer model
-  const sdf::Model *outerModel = root.ModelByIndex(0);
+  const sdf::Model *outerModel = root.Model();
   ASSERT_NE(nullptr, outerModel);
   EXPECT_EQ("outer_model", outerModel->Name());
   EXPECT_EQ(1u, outerModel->LinkCount());
@@ -318,7 +314,7 @@ TEST(DOMLink, NestedModelPoseRelativeTo)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_nested_model_relative_to", model->Name());
   EXPECT_EQ(1u, model->LinkCount());
@@ -399,7 +395,7 @@ TEST(DOMRoot, LoadCanonicalLink)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_canonical_link", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -441,7 +437,7 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("top", model->Name());
   EXPECT_EQ(0u, model->LinkCount());
@@ -494,7 +490,7 @@ TEST(DOMRoot, LoadNestedExplicitCanonicalLink)
   EXPECT_TRUE(root.Load(testFile).empty());
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("top", model->Name());
   EXPECT_EQ(0u, model->LinkCount());
@@ -542,7 +538,7 @@ TEST(DOMRoot, ModelPlacementFrameAttribute)
   sdf::Errors errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty()) << errors;
 
-  auto *model = root.ModelByIndex(0);
+  auto *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   ignition::math::Pose3d pose;
@@ -564,7 +560,7 @@ TEST(DOMRoot, LoadInvalidNestedModelWithoutLinks)
   for (auto e : errors)
     std::cout << e << std::endl;
   EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(7u, errors.size());
+  ASSERT_EQ(7u, errors.size());
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::MODEL_WITHOUT_LINK);
   EXPECT_NE(std::string::npos,
     errors[0].Message().find("A model must have at least one link"));

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -1106,7 +1106,7 @@ TEST(NestedReference, PoseRelativeTo)
 
   using Pose = ignition::math::Pose3d;
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   auto parentSemPose = model->SemanticPose();
@@ -1229,7 +1229,7 @@ TEST(NestedReference, PlacementFrameAttribute)
   sdf::Errors errors = root.Load(testFile);
   EXPECT_TRUE(errors.empty()) << errors;
 
-  auto *model = root.ModelByIndex(0);
+  auto *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   ignition::math::Pose3d pose;
@@ -1325,7 +1325,7 @@ TEST(NestedReference, PlacementFrameElement)
     sdf::Errors errors = root.LoadSdfString(stream.str());
     EXPECT_TRUE(errors.empty()) << errors;
 
-    auto *parentModel = root.ModelByIndex(0);
+    auto *parentModel = root.Model();
     ASSERT_NE(nullptr, parentModel);
     auto *model = parentModel->ModelByIndex(0);
     ASSERT_NE(nullptr, model);
@@ -1356,7 +1356,7 @@ TEST(NestedReference, PlacementFrameElement)
     sdf::Errors errors = root.LoadSdfString(stream.str());
     EXPECT_TRUE(errors.empty()) << errors;
 
-    auto *parentModel = root.ModelByIndex(0);
+    auto *parentModel = root.Model();
     ASSERT_NE(nullptr, parentModel);
     auto *model = parentModel ->ModelByIndex(0);
     ASSERT_NE(nullptr, model);

--- a/test/integration/nested_multiple_elements_error.cc
+++ b/test/integration/nested_multiple_elements_error.cc
@@ -60,16 +60,15 @@ TEST(IncludesTest, NestedMultipleModelsError)
     ASSERT_TRUE(errors.empty());
   }
 
-  ASSERT_EQ(1u, root.ModelCount());
-  const auto * model = root.ModelByIndex(0);
+  const auto * model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("nested_model", model->Name());
 
   ASSERT_EQ(1u, model->LinkCount());
   EXPECT_EQ("link1", model->LinkByIndex(0)->Name());
 
-  EXPECT_EQ(0u, root.ActorCount());
-  EXPECT_EQ(0u, root.LightCount());
+  EXPECT_EQ(nullptr, root.Actor());
+  EXPECT_EQ(nullptr, root.Light());
 }
 
 //////////////////////////////////////////////////
@@ -93,11 +92,10 @@ TEST(IncludesTest, NestedMultipleActorsError)
     ASSERT_TRUE(errors.empty());
   }
 
-  EXPECT_EQ(0u, root.ModelCount());
-  EXPECT_EQ(0u, root.LightCount());
+  EXPECT_EQ(nullptr, root.Model());
+  EXPECT_EQ(nullptr, root.Light());
 
-  ASSERT_EQ(1u, root.ActorCount());
-  const auto * actor = root.ActorByIndex(0);
+  const auto * actor = root.Actor();
   ASSERT_NE(nullptr, actor);
   EXPECT_EQ("nested_actor", actor->Name());
   ASSERT_EQ(1u, actor->LinkCount());
@@ -125,11 +123,10 @@ TEST(IncludesTest, NestedMultipleLightsError)
     ASSERT_TRUE(errors.empty());
   }
 
-  EXPECT_EQ(0u, root.ModelCount());
-  EXPECT_EQ(0u, root.ActorCount());
+  EXPECT_EQ(nullptr, root.Model());
+  EXPECT_EQ(nullptr, root.Actor());
 
-  ASSERT_EQ(1u, root.LightCount());
-  const auto * light = root.LightByIndex(0);
+  const auto * light = root.Light();
   ASSERT_NE(nullptr, light);
   EXPECT_EQ("nested_light", light->Name());
   EXPECT_EQ(ignition::math::Vector3d(1, 0, 0), light->Direction());
@@ -156,11 +153,10 @@ TEST(IncludesTest, NestedMultipleElementsError)
     ASSERT_TRUE(errors.empty());
   }
 
-  EXPECT_EQ(0u, root.LightCount());
-  EXPECT_EQ(0u, root.ActorCount());
+  EXPECT_EQ(nullptr, root.Light());
+  EXPECT_EQ(nullptr, root.Actor());
 
-  ASSERT_EQ(1u, root.ModelCount());
-  const auto * model = root.ModelByIndex(0);
+  const auto * model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("nested_model", model->Name());
 }
@@ -185,9 +181,9 @@ TEST(IncludesTest, NestedMultipleElementsErrorWorld)
     ASSERT_TRUE(errors.empty());
   }
 
-  EXPECT_EQ(0u, root.LightCount());
-  EXPECT_EQ(0u, root.ActorCount());
-  EXPECT_EQ(0u, root.ModelCount());
+  EXPECT_EQ(nullptr, root.Light());
+  EXPECT_EQ(nullptr, root.Actor());
+  EXPECT_EQ(nullptr, root.Model());
 
   ASSERT_EQ(1u, root.WorldCount());
   const auto * world = root.WorldByIndex(0);

--- a/test/integration/root_dom.cc
+++ b/test/integration/root_dom.cc
@@ -91,6 +91,19 @@ TEST(DOMRoot, LoadMultipleModels)
   EXPECT_TRUE(errors.empty()) << errors;
   ASSERT_NE(nullptr, root.Model());
   EXPECT_EQ("robot1", root.Model()->Name());
+
+  SDF_SUPPRESS_DEPRECATED_BEGIN
+  EXPECT_EQ(3u, root.ModelCount());
+
+  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
+  EXPECT_EQ("robot2", root.ModelByIndex(1)->Name());
+  EXPECT_EQ("last_robot", root.ModelByIndex(2)->Name());
+
+  EXPECT_FALSE(root.ModelNameExists("robot"));
+  EXPECT_TRUE(root.ModelNameExists("robot1"));
+  EXPECT_TRUE(root.ModelNameExists("robot2"));
+  EXPECT_TRUE(root.ModelNameExists("last_robot"));
+  SDF_SUPPRESS_DEPRECATED_END
 }
 
 /////////////////////////////////////////////////
@@ -105,4 +118,9 @@ TEST(DOMRoot, LoadDuplicateModels)
   EXPECT_FALSE(errors.empty());
   EXPECT_NE(nullptr, root.Model());
   EXPECT_EQ("robot1", root.Model()->Name());
+
+  SDF_SUPPRESS_DEPRECATED_BEGIN
+  EXPECT_EQ(1u, root.ModelCount());
+  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
+  SDF_SUPPRESS_DEPRECATED_END
 }

--- a/test/integration/root_dom.cc
+++ b/test/integration/root_dom.cc
@@ -102,7 +102,7 @@ TEST(DOMRoot, LoadDuplicateModels)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
-  EXPECT_TRUE(errors.empty()) << errors;
+  EXPECT_FALSE(errors.empty());
   EXPECT_NE(nullptr, root.Model());
   EXPECT_EQ("robot1", root.Model()->Name());
 }

--- a/test/integration/root_dom.cc
+++ b/test/integration/root_dom.cc
@@ -85,17 +85,12 @@ TEST(DOMRoot, LoadMultipleModels)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
+
+  // Currently just warnings are issued in this case, eventually they may become
+  // errors. For now, only the first model is loaded.
   EXPECT_TRUE(errors.empty()) << errors;
-  EXPECT_EQ(3u, root.ModelCount());
-
-  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
-  EXPECT_EQ("robot2", root.ModelByIndex(1)->Name());
-  EXPECT_EQ("last_robot", root.ModelByIndex(2)->Name());
-
-  EXPECT_FALSE(root.ModelNameExists("robot"));
-  EXPECT_TRUE(root.ModelNameExists("robot1"));
-  EXPECT_TRUE(root.ModelNameExists("robot2"));
-  EXPECT_TRUE(root.ModelNameExists("last_robot"));
+  ASSERT_NE(nullptr, root.Model());
+  EXPECT_EQ("robot1", root.Model()->Name());
 }
 
 /////////////////////////////////////////////////
@@ -107,7 +102,7 @@ TEST(DOMRoot, LoadDuplicateModels)
 
   sdf::Root root;
   sdf::Errors errors = root.Load(testFile);
-  EXPECT_FALSE(errors.empty());
-  EXPECT_EQ(1u, root.ModelCount());
-  EXPECT_EQ("robot1", root.ModelByIndex(0)->Name());
+  EXPECT_TRUE(errors.empty()) << errors;
+  EXPECT_NE(nullptr, root.Model());
+  EXPECT_EQ("robot1", root.Model()->Name());
 }

--- a/test/integration/surface_dom.cc
+++ b/test/integration/surface_dom.cc
@@ -39,7 +39,7 @@ TEST(DOMSurface, Shapes)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const auto model = root.ModelByIndex(0);
+  const auto model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const auto link = model->LinkByIndex(0);

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -71,7 +71,7 @@ TEST(DOMVisual, DoublePendulum)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_TRUE(model != nullptr);
 
   const sdf::Link *baseLink = model->LinkByIndex(0);
@@ -104,7 +104,7 @@ TEST(DOMVisual, Material)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *link = model->LinkByIndex(0);
@@ -189,7 +189,7 @@ TEST(DOMVisual, Transparency)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *link = model->LinkByIndex(0);
@@ -215,7 +215,7 @@ TEST(DOMVisual, LoadModelFramesRelativeToJoint)
   using Pose = ignition::math::Pose3d;
 
   // Get the first model
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
   EXPECT_EQ("model_frame_relative_to_joint", model->Name());
   EXPECT_EQ(2u, model->LinkCount());
@@ -406,7 +406,7 @@ TEST(DOMVisual, VisibilityFlags)
   sdf::Root root;
   EXPECT_TRUE(root.Load(testFile).empty());
 
-  const sdf::Model *model = root.ModelByIndex(0);
+  const sdf::Model *model = root.Model();
   ASSERT_NE(nullptr, model);
 
   const sdf::Link *link = model->LinkByIndex(0);


### PR DESCRIPTION
This is a followup PR to #433. This changes sdf::Root to have only one Actor/Light/Model.

This change will introduce a hard break to the root element.
Signed-off-by: Stephen Brawner <brawner@gmail.com>