### PR TITLE
Added render_order to material

### DIFF
--- a/include/sdf/Material.hh
+++ b/include/sdf/Material.hh
@@ -124,6 +124,14 @@ namespace sdf
     /// \param[in] _color Emissive color.
     public: void SetEmissive(const ignition::math::Color &_color) const;
 
+    /// \brief Get render order
+    /// \return Render order
+    public: float RenderOrder() const;
+
+    /// \brief Set render order
+    /// \param[in] _renderOrder render order
+    public: void SetRenderOrder(const float _renderOrder);
+
     /// \brief Get whether dynamic lighting is enabled. The default
     /// value is true.
     /// \return False if dynamic lighting should be disabled.

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -25,6 +25,10 @@
     </element>
   </element>
 
+  <element name="render_order" type="double" default="0.0" required="0">
+    <description>Set render order for coplanar polygons</description>
+  </element>
+
   <element name="lighting" type="bool" default="true" required="0">
     <description>If false, dynamic lighting will be disabled</description>
   </element>

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -25,7 +25,7 @@
     </element>
   </element>
 
-  <element name="render_order" type="double" default="0.0" required="0">
+  <element name="render_order" type="float" default="0.0" required="0">
     <description>Set render order for coplanar polygons. The higher value will be rendered on top of the other coplanar polygons</description>
   </element>
 

--- a/sdf/1.7/material.sdf
+++ b/sdf/1.7/material.sdf
@@ -26,7 +26,7 @@
   </element>
 
   <element name="render_order" type="double" default="0.0" required="0">
-    <description>Set render order for coplanar polygons</description>
+    <description>Set render order for coplanar polygons. The higher value will be rendered on top of the other coplanar polygons</description>
   </element>
 
   <element name="lighting" type="bool" default="true" required="0">

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -57,6 +57,9 @@ class sdf::MaterialPrivate
   /// \brief Emissive color
   public: ignition::math::Color emissive {0, 0, 0, 1};
 
+  /// \brief Render order
+  public: float renderOrder = 0;
+
   /// \brief Physically Based Rendering (PBR) properties
   public: std::unique_ptr<Pbr> pbr;
 
@@ -89,6 +92,7 @@ Material::Material(const Material &_material)
   this->dataPtr->shader = _material.dataPtr->shader;
   this->dataPtr->normalMap = _material.dataPtr->normalMap;
   this->dataPtr->lighting = _material.dataPtr->lighting;
+  this->dataPtr->renderOrder = _material.dataPtr->renderOrder;
   this->dataPtr->doubleSided = _material.dataPtr->doubleSided;
   this->dataPtr->ambient = _material.dataPtr->ambient;
   this->dataPtr->diffuse = _material.dataPtr->diffuse;
@@ -207,6 +211,9 @@ Errors Material::Load(sdf::ElementPtr _sdf)
     }
   }
 
+  this->dataPtr->renderOrder = _sdf->Get<float>("render_order",
+      this->dataPtr->renderOrder).first;
+
   this->dataPtr->ambient = _sdf->Get<ignition::math::Color>("ambient",
       this->dataPtr->ambient).first;
 
@@ -282,6 +289,18 @@ ignition::math::Color Material::Emissive() const
 void Material::SetEmissive(const ignition::math::Color &_color) const
 {
   this->dataPtr->emissive = _color;
+}
+
+//////////////////////////////////////////////////
+float Material::RenderOrder() const
+{
+  return this->dataPtr->renderOrder;
+}
+
+//////////////////////////////////////////////////
+void Material::SetRenderOrder(const float _renderOrder)
+{
+  this->dataPtr->renderOrder = _renderOrder;
 }
 
 //////////////////////////////////////////////////

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -30,6 +30,7 @@ TEST(DOMMaterial, Construction)
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Specular());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Emissive());
   EXPECT_TRUE(material.Lighting());
+  EXPECT_EQ(0, material.RenderOrder());
   EXPECT_FALSE(material.DoubleSided());
   EXPECT_EQ(nullptr, material.Element());
   EXPECT_EQ("", material.ScriptUri());
@@ -49,6 +50,7 @@ TEST(DOMMaterial, MoveConstructor)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetRenderOrder(2);
   material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
@@ -65,6 +67,7 @@ TEST(DOMMaterial, MoveConstructor)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
+  EXPECT_EQ(2, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -82,6 +85,7 @@ TEST(DOMMaterial, CopyConstructor)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetRenderOrder(4);
   material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
@@ -98,6 +102,7 @@ TEST(DOMMaterial, CopyConstructor)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
+  EXPECT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -115,6 +120,7 @@ TEST(DOMMaterial, AssignmentOperator)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetRenderOrder(4);
   material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
@@ -132,6 +138,7 @@ TEST(DOMMaterial, AssignmentOperator)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
+  EXPECT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -149,6 +156,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
   material.SetSpecular(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f));
   material.SetEmissive(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f));
   material.SetLighting(false);
+  material.SetRenderOrder(4);
   material.SetDoubleSided(true);
   material.SetScriptUri("banana");
   material.SetScriptName("orange");
@@ -165,6 +173,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
+  EXPECT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -215,6 +224,10 @@ TEST(DOMMaterial, Set)
   material.SetLighting(false);
   EXPECT_FALSE(material.Lighting());
 
+  EXPECT_EQ(0, material.RenderOrder());
+  material.SetRenderOrder(5);
+  EXPECT_EQ(5, material.RenderOrder());
+
   EXPECT_FALSE(material.DoubleSided());
   material.SetDoubleSided(true);
   EXPECT_TRUE(material.DoubleSided());
@@ -256,6 +269,7 @@ TEST(DOMMaterial, Set)
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f), moved.Specular());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f), moved.Emissive());
   EXPECT_FALSE(moved.Lighting());
+  EXPECT_EQ(5, moved.RenderOrder());
   EXPECT_TRUE(moved.DoubleSided());
   EXPECT_EQ("uri", moved.ScriptUri());
   EXPECT_EQ("name", moved.ScriptName());

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -30,7 +30,7 @@ TEST(DOMMaterial, Construction)
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Specular());
   EXPECT_EQ(ignition::math::Color(0, 0, 0, 1), material.Emissive());
   EXPECT_TRUE(material.Lighting());
-  EXPECT_EQ(0, material.RenderOrder());
+  EXPECT_FLOAT_EQ(0, material.RenderOrder());
   EXPECT_FALSE(material.DoubleSided());
   EXPECT_EQ(nullptr, material.Element());
   EXPECT_EQ("", material.ScriptUri());
@@ -67,7 +67,7 @@ TEST(DOMMaterial, MoveConstructor)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
-  EXPECT_EQ(2, material2.RenderOrder());
+  EXPECT_FLOAT_EQ(2.0, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -102,7 +102,7 @@ TEST(DOMMaterial, CopyConstructor)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
-  EXPECT_EQ(4, material2.RenderOrder());
+  EXPECT_FLOAT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -138,7 +138,7 @@ TEST(DOMMaterial, AssignmentOperator)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
-  EXPECT_EQ(4, material2.RenderOrder());
+  EXPECT_FLOAT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -173,7 +173,7 @@ TEST(DOMMaterial, MoveAssignmentOperator)
       material2.Emissive());
   EXPECT_FALSE(material2.Lighting());
   EXPECT_TRUE(material2.DoubleSided());
-  EXPECT_EQ(4, material2.RenderOrder());
+  EXPECT_FLOAT_EQ(4, material2.RenderOrder());
   EXPECT_EQ("banana", material2.ScriptUri());
   EXPECT_EQ("orange", material2.ScriptName());
   EXPECT_EQ(sdf::ShaderType::VERTEX, material2.Shader());
@@ -224,9 +224,9 @@ TEST(DOMMaterial, Set)
   material.SetLighting(false);
   EXPECT_FALSE(material.Lighting());
 
-  EXPECT_EQ(0, material.RenderOrder());
+  EXPECT_FLOAT_EQ(0, material.RenderOrder());
   material.SetRenderOrder(5);
-  EXPECT_EQ(5, material.RenderOrder());
+  EXPECT_FLOAT_EQ(5, material.RenderOrder());
 
   EXPECT_FALSE(material.DoubleSided());
   material.SetDoubleSided(true);
@@ -269,7 +269,7 @@ TEST(DOMMaterial, Set)
   EXPECT_EQ(ignition::math::Color(0.3f, 0.4f, 0.5f, 0.7f), moved.Specular());
   EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 0.8f), moved.Emissive());
   EXPECT_FALSE(moved.Lighting());
-  EXPECT_EQ(5, moved.RenderOrder());
+  EXPECT_FLOAT_EQ(5, moved.RenderOrder());
   EXPECT_TRUE(moved.DoubleSided());
   EXPECT_EQ("uri", moved.ScriptUri());
   EXPECT_EQ("name", moved.ScriptName());

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -122,7 +122,7 @@ TEST(DOMVisual, Material)
   EXPECT_EQ(ignition::math::Color(1.0f, 0.0f, 0.2f, 1.0f), mat->Emissive());
   EXPECT_FALSE(mat->Lighting());
   EXPECT_TRUE(mat->DoubleSided());
-  EXPECT_FLOAT_EQ(5.1, mat->RenderOrder());
+  EXPECT_FLOAT_EQ(5.1f, mat->RenderOrder());
   EXPECT_EQ(sdf::ShaderType::VERTEX, mat->Shader());
   EXPECT_EQ("myuri", mat->ScriptUri());
   EXPECT_EQ("myname", mat->ScriptName());

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -122,6 +122,7 @@ TEST(DOMVisual, Material)
   EXPECT_EQ(ignition::math::Color(1.0f, 0.0f, 0.2f, 1.0f), mat->Emissive());
   EXPECT_FALSE(mat->Lighting());
   EXPECT_TRUE(mat->DoubleSided());
+  EXPECT_FLOAT_EQ(5.1, mat->RenderOrder());
   EXPECT_EQ(sdf::ShaderType::VERTEX, mat->Shader());
   EXPECT_EQ("myuri", mat->ScriptUri());
   EXPECT_EQ("myname", mat->ScriptName());

--- a/test/sdf/material.sdf
+++ b/test/sdf/material.sdf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<sdf version="1.6">
+<sdf version="1.7">
   <model name="model">
     <link name="link">
       <visual name="visual1">
@@ -9,6 +9,7 @@
           <specular>0.7 0.3 0.5 0.9</specular>
           <emissive>1.0 0.0 0.2 1.0</emissive>
           <lighting>false</lighting>
+          <render_order>5.1</render_order>
           <double_sided>true</double_sided>
           <shader type="vertex">
           </shader>


### PR DESCRIPTION
This PR is part of the effort to avoid z-fighting between coplanar meshes. 

Related with https://github.com/ignitionrobotics/ign-rendering/pull/188

Signed-off-by: ahcorde <ahcorde@gmail.com>