### PR TITLE
Return to previous build directory after testing examples

### DIFF
--- a/.github/ci/after_make_test.sh
+++ b/.github/ci/after_make_test.sh
@@ -6,9 +6,11 @@ set -x
 make install
 
 # Compile examples
+curdir=$PWD
 cd ../examples
 mkdir build;
 cd build;
 cmake ..;
 make;
 ./simple ../simple.sdf;
+cd $curdir


### PR DESCRIPTION
I believe coverage generation is failing right now because the example test changes the directory but doesn't return to the original build directory  (eg. https://github.com/osrf/sdformat/pull/444/checks?check_run_id=1647029579#step:4:4010) 