### PR TITLE
Disable ign tests on Windows (sdf10)

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -101,6 +101,13 @@ macro (check_gcc_visibility)
 endmacro()
 
 ########################################
+# Find ignition cmake2
+# Only for using the testing macros, not really
+# being use to configure the whole project
+find_package(ignition-cmake2 2.3 REQUIRED)
+set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
+
+########################################
 # Find ignition math
 # Set a variable for generating ProjectConfig.cmake
 find_package(ignition-math6 QUIET)
@@ -111,10 +118,3 @@ else()
   set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
   message(STATUS "Looking for ignition-math${IGN_MATH_VER}-config.cmake - found")
 endif()
-
-########################################
-# Find ignition cmake2
-# Only for using the testing macros, not really
-# being use to configure the whole project
-find_package(ignition-cmake2 2.3 REQUIRED)
-set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -111,3 +111,10 @@ else()
   set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
   message(STATUS "Looking for ignition-math${IGN_MATH_VER}-config.cmake - found")
 endif()
+
+########################################
+# Find ignition cmake2
+# Only for using the testing macros, not really
+# being use to configure the whole project
+find_package(ignition-cmake2 2.3 REQUIRED)
+set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,7 +134,7 @@ if (BUILD_SDF_TEST)
 
   sdf_build_tests(${gtest_sources})
 
-  if (IGNITION-TOOLS_BINARY_DIRS)
+  if (TARGET UNIT_ign_TEST)
     # Link the libraries that we always need.
     target_link_libraries("UNIT_ign_TEST"
       PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,14 @@ if (BUILD_SDF_TEST)
 
   sdf_build_tests(${gtest_sources})
 
+  if (IGNITION-TOOLS_BINARY_DIRS)
+    # Link the libraries that we always need.
+    target_link_libraries("UNIT_ign_TEST"
+      PUBLIC
+        ignition-cmake${IGN_CMAKE_VER}::utilities
+    )
+  endif()
+
   if (NOT WIN32)
     set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS Utils.cc)
     sdf_build_tests(Utils_TEST.cc)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <string>
 
+#include <ignition/utilities/ExtraTestMacros.hh>
+
 #include "sdf/parser.hh"
 #include "sdf/SDFImpl.hh"
 #include "sdf/sdf_config.h"
@@ -57,7 +59,7 @@ std::string custom_exec_str(std::string _cmd)
 }
 
 /////////////////////////////////////////////////
-TEST(check, SDF)
+TEST(check, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -642,7 +644,7 @@ TEST(check, SDF)
 }
 
 /////////////////////////////////////////////////
-TEST(check_model_sdf, SDF)
+TEST(check_model_sdf, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/integration/model/box";
@@ -668,7 +670,7 @@ TEST(check_model_sdf, SDF)
 }
 
 /////////////////////////////////////////////////
-TEST(describe, SDF)
+TEST(describe, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   // Get the description
   std::string output =
@@ -680,7 +682,7 @@ TEST(describe, SDF)
 }
 
 /////////////////////////////////////////////////
-TEST(print, SDF)
+TEST(print, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";


### PR DESCRIPTION
Following @scpeters suggestion https://github.com/ignition-tooling/release-tools/pull/365#issuecomment-748378863, the PR disable the run of ign tests on Windows.