### PR TITLE
Add split/join for separating the link name from it's fully qualified name

### DIFF
--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -60,6 +60,8 @@ namespace sdf
   inline namespace SDF_VERSION_NAMESPACE {
   //
 
+  const std::string kSdfScopeDelimiter = "::";
+
   /// \brief Split a string using the delimiter in splitter.
   /// \param[in] str       The string to split.
   /// \param[in] splitter  The delimiter to use.
@@ -228,6 +230,14 @@ namespace sdf
   /// \param[in] _in String to convert to lowercase
   /// \return Lowercase equilvalent of _in.
   std::string SDFORMAT_VISIBLE lowercase(const std::string &_in);
+
+  SDFORMAT_VISIBLE
+  std::pair<std::string, std::string> SplitName(
+      const std::string &_absoluteName);
+
+  SDFORMAT_VISIBLE
+  std::string JoinName(
+      const std::string &_scopeName, const std::string &_localName);
   }
 }
 #endif

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -232,10 +232,19 @@ namespace sdf
   /// \return Lowercase equilvalent of _in.
   std::string SDFORMAT_VISIBLE lowercase(const std::string &_in);
 
+  /// \brief Split a name into a two strings based on the '::' delimeter
+  /// \param[in] _absoluteName The fully qualified absolute name
+  /// \return A pair with the absolute name minus the leaf node name, and the
+  /// leaf name
   SDFORMAT_VISIBLE
   std::pair<std::string, std::string> SplitName(
       const std::string &_absoluteName);
 
+  /// \brief Join two strings with the '::' delimiter.
+  /// This checks for edge cases and is safe to use with any valid names
+  /// \param[in] _scopeName the left-hand-side component
+  /// \param[in] _localName the right-hand-side component
+  /// \return A full string with the names joined by the '::' delimeter.
   SDFORMAT_VISIBLE
   std::string JoinName(
       const std::string &_scopeName, const std::string &_localName);

--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <sdf/sdf_config.h>

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -88,5 +88,31 @@ std::ostream &operator<<(std::ostream &_out, const sdf::Errors &_errs)
   }
   return _out;
 }
+
+// Split a given absolute name into the parent model name and the local name.
+// If the give name is not scoped, this will return an empty string for the
+// parent model name and the given name as the local name.
+std::pair<std::string, std::string> SplitName(
+    const std::string &_absoluteName)
+{
+  const auto pos = _absoluteName.rfind(kSdfScopeDelimiter);
+  if (pos != std::string::npos)
+  {
+    const std::string first = _absoluteName.substr(0, pos);
+    const std::string second =
+        _absoluteName.substr(pos + kSdfScopeDelimiter.size());
+    return {first, second};
+  }
+  return {"", _absoluteName};
+}
+
+// Join an scope name prefix with a local name using the scope delimeter
+std::string JoinName(
+    const std::string &_scopeName, const std::string &_localName)
+{
+  if (_scopeName.empty())
+    return _localName;
+  return _scopeName + kSdfScopeDelimiter + _localName;
+}
 }
 }

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -112,6 +112,9 @@ std::string JoinName(
 {
   if (_scopeName.empty())
     return _localName;
+  if (_localName.empty()) {
+    return _scopeName;
+  }
   return _scopeName + kSdfScopeDelimiter + _localName;
 }
 }

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -111,8 +111,9 @@ static bool EndsWithDelimiter(const std::string &_s)
   if (_s.size() < kSdfScopeDelimiter.size())
     return false;
 
-  const size_t findStartPosition = _s.size() - kSdfScopeDelimiter.size();
-  return _s.substr(findStartPosition) == kSdfScopeDelimiter;
+  const size_t startPosition = _s.size() - kSdfScopeDelimiter.size();
+  return _s.compare(
+    startPosition, kSdfScopeDelimiter.size(), kSdfScopeDelimiter) == 0;
 }
 
 static bool StartsWithDelimiter(const std::string &_s)
@@ -120,7 +121,7 @@ static bool StartsWithDelimiter(const std::string &_s)
   if (_s.size() < kSdfScopeDelimiter.size())
     return false;
 
-  return _s.substr(0, kSdfScopeDelimiter.size()) == kSdfScopeDelimiter;
+  return _s.compare(0, kSdfScopeDelimiter.size(), kSdfScopeDelimiter) == 0;
 }
 
 // Join an scope name prefix with a local name using the scope delimeter

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -106,16 +106,41 @@ std::pair<std::string, std::string> SplitName(
   return {"", _absoluteName};
 }
 
+static bool EndsWithDelimiter(const std::string &_s)
+{
+  if (_s.size() < kSdfScopeDelimiter.size())
+    return false;
+
+  const size_t findStartPosition = _s.size() - kSdfScopeDelimiter.size();
+  return _s.substr(findStartPosition) == kSdfScopeDelimiter;
+}
+
+static bool StartsWithDelimiter(const std::string &_s)
+{
+  if (_s.size() < kSdfScopeDelimiter.size())
+    return false;
+
+  return _s.substr(0, kSdfScopeDelimiter.size()) == kSdfScopeDelimiter;
+}
+
 // Join an scope name prefix with a local name using the scope delimeter
 std::string JoinName(
     const std::string &_scopeName, const std::string &_localName)
 {
   if (_scopeName.empty())
     return _localName;
-  if (_localName.empty()) {
+  if (_localName.empty())
     return _scopeName;
-  }
-  return _scopeName + kSdfScopeDelimiter + _localName;
+
+  const bool scopeNameEndsWithDelimiter = EndsWithDelimiter(_scopeName);
+  const bool localNameStartsWithDelimiter = StartsWithDelimiter(_localName);
+
+  if (scopeNameEndsWithDelimiter && localNameStartsWithDelimiter)
+    return _scopeName + _localName.substr(kSdfScopeDelimiter.size());
+  else if (scopeNameEndsWithDelimiter || localNameStartsWithDelimiter)
+    return _scopeName + _localName;
+  else
+    return _scopeName + kSdfScopeDelimiter + _localName;
 }
 }
 }

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -124,7 +124,7 @@ static bool StartsWithDelimiter(const std::string &_s)
   return _s.compare(0, kSdfScopeDelimiter.size(), kSdfScopeDelimiter) == 0;
 }
 
-// Join an scope name prefix with a local name using the scope delimeter
+// Join a scope name prefix with a local name using the scope delimeter
 std::string JoinName(
     const std::string &_scopeName, const std::string &_localName)
 {

--- a/src/Types_TEST.cc
+++ b/src/Types_TEST.cc
@@ -120,6 +120,85 @@ TEST(Types, ErrorsOutputStream)
   EXPECT_EQ(expected, output.str());
 }
 
+TEST(Types, SplitName)
+{
+  {
+    const auto[basePath, tipName] = sdf::SplitName("a::b");
+    EXPECT_EQ(basePath, "a");
+    EXPECT_EQ(tipName, "b");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("a::b::c");
+    EXPECT_EQ(basePath, "a::b");
+    EXPECT_EQ(tipName, "c");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("b");
+    EXPECT_EQ(basePath, "");
+    EXPECT_EQ(tipName, "b");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("a::b::");
+    EXPECT_EQ(basePath, "a::b");
+    EXPECT_EQ(tipName, "");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("::b");
+    EXPECT_EQ(basePath, "");
+    EXPECT_EQ(tipName, "b");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("");
+    EXPECT_EQ(basePath, "");
+    EXPECT_EQ(tipName, "");
+  }
+  {
+    const auto[basePath, tipName] = sdf::SplitName("a::b::c::d");
+    EXPECT_EQ(basePath, "a::b::c");
+    EXPECT_EQ(tipName, "d");
+  }
+}
+
+TEST(Types, JoinName)
+{
+  {
+    const auto joinedName = sdf::JoinName("a", "b");
+    EXPECT_EQ(joinedName, "a::b");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a::b", "c");
+    EXPECT_EQ(joinedName, "a::b::c");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a", "b::c");
+    EXPECT_EQ(joinedName, "a::b::c");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a::", "b");
+    EXPECT_EQ(joinedName, "a::b");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a", "::b");
+    EXPECT_EQ(joinedName, "a::b");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a::", "::b");
+    EXPECT_EQ(joinedName, "a::b");
+  }
+  {
+    const auto joinedName = sdf::JoinName("", "b");
+    EXPECT_EQ(joinedName, "b");
+  }
+  {
+    const auto joinedName = sdf::JoinName("a", "");
+    EXPECT_EQ(joinedName, "a");
+  }
+  {
+    const auto joinedName = sdf::JoinName("", "");
+    EXPECT_EQ(joinedName, "");
+  }
+}
+
 /////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR adds small functionality for splitting and joining a name based on the '::' separator. It's necessary for https://github.com/ignitionrobotics/ign-gazebo/pull/542