### PR TITLE
Add Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sdformat #
+# sdformat
 
 SDFormat is an XML file format that describes environments, objects, and robots
 in a manner suitable for robotic applications. SDFormat is capable of representing
@@ -13,76 +13,113 @@ allows conversion from previous versions.
 * libsdformat - The C++ parsing code contained within this repository,
   which can be used to read SDFormat files and return a C++ interface.
 
+[http://sdformat.org/](http://sdformat.org/)
+
 Test coverage:
 
 [![codecov](https://codecov.io/bb/osrf/sdformat/branch/default/graph/badge.svg)](https://codecov.io/bb/osrf/sdformat)
 
+# Installation
 
-## Installation ##
+We recommend following the Binary Installation instructions to get up and running as quickly and painlessly as possible.
 
-### UNIX
+The Source Installation instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
+
+## Binary Installation
+
+### Ubuntu
+
+On Ubuntu systems, `apt-get` can be used to install `ignition-tools`:
+```
+sudo apt install libsdformat<#>-dev libsdformat<#>
+```
+
+Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
+which version you need, or leave it empty for version 1.
+
+### Windows
+
+Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
+Miniconda suffices.
+
+Create if necessary, and activate a Conda environment:
+```
+conda create -n ign-ws
+conda activate ign-ws
+```
+
+Install `sdformat`:
+```
+conda install libsdformat --channel conda-forge
+```
+
+## Source Installation
+
+## UNIX
+
+#### Build from Source
 
 Standard installation can be performed in UNIX systems using the following
 steps:
-
 ```
-mkdir build/
-cd build/
+mkdir build
+cd build
 cmake ..
 sudo make install
 ```
 
 sdformat supported cmake parameters at configuring time:
- - USE_INTERNAL_URDF (bool) [default False]
+ - `USE_INTERNAL_URDF` (`bool`) [default `False`]
    Use an internal copy of urdfdom 1.0.0 instead of look for one
    installed in the system
- - USE_UPSTREAM_CFLAGS (bool) [default True]
+ - `USE_UPSTREAM_CFLAGS` (`bool`) [default `True`]
    Use the sdformat team compilation flags instead of the common set defined
    by cmake.
 
-### Windows
+## Uninstallation
+
+To uninstall the software installed with the previous steps:
+```
+cd build
+sudo make uninstall
+```
+
+## Windows
+
+### Prerequisites
+
+Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
+Miniconda suffices.
 
 Create if necessary, and activate a Conda environment:
-
 ```
 conda create -n ign-ws
 conda activate ign-ws
 ```
 
 Install prerequisites:
-
 ```
 conda install urdfdom --channel conda-forge
 ```
 
 Install Ignition dependencies:
-
 ```
 conda install libignition-tools1 --channel conda-forge
 ```
 
-Configure and build:
+### Build from Source
 
-```
-mkdir build
-cd build
-cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
-cmake --build . --config Release
-```
+This assumes you have created and activated a Conda environment while installing the Prerequisites.
 
-Install:
+1. Configure and build
+  ```
+  mkdir build
+  cd build
+  cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+  cmake --build . --config Release
+  ```
 
-```
-cmake --install . --config Release
-```
-
-## Uninstallation ##
-
-### UNIX
-
-To uninstall the software installed with the previous steps:
-
-```
-cd build/
-sudo make uninstall
-```
+2. Install
+  ```
+  cmake --install . --config Release
+  ```

--- a/README.md
+++ b/README.md
@@ -20,13 +20,17 @@ Test coverage:
 
 ## Installation ##
 
+### UNIX
+
 Standard installation can be performed in UNIX systems using the following
 steps:
 
- - mkdir build/
- - cd build/
- - cmake ..
- - sudo make install
+```
+mkdir build/
+cd build/
+cmake ..
+sudo make install
+```
 
 sdformat supported cmake parameters at configuring time:
  - USE_INTERNAL_URDF (bool) [default False]
@@ -36,8 +40,42 @@ sdformat supported cmake parameters at configuring time:
    Use the sdformat team compilation flags instead of the common set defined
    by cmake.
 
+### Windows
+
+Install prerequisites:
+
+```
+conda install urdfdom --channel conda-forge
+```
+
+Install Ignition dependencies:
+
+```
+conda install libignition-tools1 --channel conda-forge
+```
+
+Configure and build:
+
+```
+mkdir build
+cd build
+cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+cmake --build . --config Release
+```
+
+Install:
+
+```
+cmake --install . --config Release
+```
+
 ## Uninstallation ##
 
+### UNIX
+
 To uninstall the software installed with the previous steps:
- - cd build/
- - sudo make uninstall
+
+```
+cd build/
+sudo make uninstall
+```

--- a/README.md
+++ b/README.md
@@ -102,9 +102,16 @@ Install prerequisites:
 conda install urdfdom --channel conda-forge
 ```
 
-Install Ignition dependencies (optional):
+Install Ignition dependencies:
+
+You can view lists of dependencies:
 ```
-conda install libignition-tools1 --channel conda-forge
+conda search libsdformat --channel conda-forge --info
+```
+
+Install dependencies, replacing `<#>` with the desired versions:
+```
+conda install libignition-math<#> libignition-tools<#> --channel conda-forge
 ```
 
 ### Build from Source

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Install `sdformat`:
 conda install libsdformat --channel conda-forge
 ```
 
+You can view all the versions with
+```
+conda search libsdformat --channel conda-forge
+```
+
+and install a specific minor version with
+```
+conda install libsdformat=9.3.0 --channel conda-forge
+```
+
 ## Source Installation
 
 ## UNIX

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ sdformat supported cmake parameters at configuring time:
 
 ### Windows
 
+Create if necessary, and activate a Conda environment:
+
+```
+conda create -n ign-ws
+conda activate ign-ws
+```
+
 Install prerequisites:
 
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Source Installation instructions should be used if you need the very latest 
 
 ### Ubuntu
 
-On Ubuntu systems, `apt-get` can be used to install `ignition-tools`:
+On Ubuntu systems, `apt-get` can be used to install `sdformat`:
 ```
 sudo apt install libsdformat<#>-dev libsdformat<#>
 ```
@@ -102,7 +102,7 @@ Install prerequisites:
 conda install urdfdom --channel conda-forge
 ```
 
-Install Ignition dependencies:
+Install Ignition dependencies (optional):
 ```
 conda install libignition-tools1 --channel conda-forge
 ```


### PR DESCRIPTION
Retarget of #451 to sdf9 for Citadel via cherry-pick.
Plus standardize tutorial to be uniform with ign-common.

Copy of description:

Partially addresses https://github.com/ignitionrobotics/docs/issues/117

Is `ignition-tools` an optional dependency? I saw a warning in CMake but didn’t see it in CMakeLists.txt.

@JShep1 @chapulina 