### PR TITLE
Merge 10 -> 11 and disable more ign tests on windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -59,6 +59,17 @@
 
 ### libsdformat 10.X.X (202X-XX-XX)
 
+### libsdformat 10.2.0 (2021-01-12)
+
+1. Disable ign test on Windows
+    + [Pull request 456](https://github.com/osrf/sdformat/pull/456)
+
+1. Add Heightmap class
+    + [Pull request 388](https://github.com/osrf/sdformat/pull/388)
+
+1. Added `render_order` to material
+    + [Pull request 446](https://github.com/osrf/sdformat/pull/446)
+
 ### libsdformat 10.1.0 (2020-12-15)
 
 1. Fix supported shader types (`normal_map_X_space`)
@@ -143,7 +154,7 @@
 
 ### libsdformat 9.X.X (202X-XX-XX)
 
-### SDFormat 9.3.0 (2020-XX-XX)
+### libsdformat 9.3.0 (2020-09-07)
 
 1. Store material file path information.
     + [Pull request 349](https://github.com/osrf/sdformat/pull/349)
@@ -374,7 +385,7 @@
 
 ### libsdformat 8.X.X (202X-XX-XX)
 
-### SDFormat 8.9.0 (2020-09-04)
+### libsdformat 8.9.0 (2020-09-04)
 
 1. Find python3 in cmake, fix warning
     * [Pull request 328](https://github.com/osrf/sdformat/pull/328)

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -812,7 +812,7 @@ TEST(check, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(check_shapes_sdf, SDF)
+TEST(check_shapes_sdf, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 {
   std::string pathBase = PROJECT_SOURCE_PATH;
   pathBase += "/test/sdf";
@@ -903,7 +903,7 @@ TEST(print, IGN_UTILS_TEST_DISABLED_ON_WIN32(SDF))
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, WorldPoseRelativeTo)
+TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldPoseRelativeTo))
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
 
@@ -954,7 +954,7 @@ TEST(GraphCmd, WorldPoseRelativeTo)
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, ModelPoseRelativeTo)
+TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelPoseRelativeTo))
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/model_relative_to_nested_reference.sdf";
@@ -1030,7 +1030,7 @@ TEST(GraphCmd, ModelPoseRelativeTo)
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, WorldFrameAttachedTo)
+TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(WorldFrameAttachedTo))
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/world_nested_frame_attached_to.sdf";
@@ -1076,7 +1076,7 @@ TEST(GraphCmd, WorldFrameAttachedTo)
 }
 
 /////////////////////////////////////////////////
-TEST(GraphCmd, ModelFrameAttachedTo)
+TEST(GraphCmd, IGN_UTILS_TEST_DISABLED_ON_WIN32(ModelFrameAttachedTo))
 {
   const std::string pathBase = std::string(PROJECT_SOURCE_PATH) + "/test/sdf";
   const std::string path = pathBase + "/model_nested_frame_attached_to.sdf";


### PR DESCRIPTION
This merges forward the Changelog updates from `sdf10` in #461 and #465 and disables some parts of `UNIT_ign_TEST` that were not disabled when #456 was merged forward.