### PR TITLE
Root: Fix minor grammar error in error message

### DIFF
--- a/src/Root.cc
+++ b/src/Root.cc
@@ -180,7 +180,7 @@ Errors Root::LoadSdfString(const std::string &_sdf)
   if (!readString(_sdf, sdfParsed, errors))
   {
     errors.push_back(
-        {ErrorCode::STRING_READ, "Unable to SDF string: " + _sdf});
+        {ErrorCode::STRING_READ, "Unable to read SDF string: " + _sdf});
     return errors;
   }
 


### PR DESCRIPTION
When looking at errors in Anzu (internal repository) that consumes Drake (open repository), I was briefly confused by this error message.

Relates https://github.com/RobotLocomotion/drake/pull/14401