### PR TITLE
Fix temperature gradient default value in Atmosphere DOM

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -16,7 +16,7 @@ but with improved human-readability..
 
 ### Modifications
 
-1. Fixed Atmosphere DOM class's temperature default value. Changed it from from -0.065 to -0.0065.
+1. Fixed Atmosphere DOM class's temperature default value. Changed from -0.065 to -0.0065.
     * [Pull request 482](https://github.com/osrf/sdformat/pull/482)
 
 ## SDFormat 9.x to 10.0

--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,13 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## SDFormat 10.2.0 to 10.x.x
+
+### Modifications
+
+1. Fixed Atmosphere DOM class's temperature default value. Changed it from from -0.065 to -0.0065.
+    * [Pull request 482](https://github.com/osrf/sdformat/pull/482)
+
 ## SDFormat 9.x to 10.0
 
 ### Modifications

--- a/src/Atmosphere.cc
+++ b/src/Atmosphere.cc
@@ -32,7 +32,7 @@ class sdf::AtmospherePrivate
 
   /// \brief Temperature gradient with respect to increasing altitude at sea
   /// level in units of K/m.
-  public: double temperatureGradient {-0.065};
+  public: double temperatureGradient {-0.0065};
 
   /// \brief Pressure at sea level in pascals.
   public: double pressure {101325};

--- a/src/Atmosphere_TEST.cc
+++ b/src/Atmosphere_TEST.cc
@@ -25,7 +25,7 @@ TEST(DOMAtmosphere, Construction)
   sdf::Atmosphere atmosphere;
   EXPECT_EQ(sdf::AtmosphereType::ADIABATIC, atmosphere.Type());
   EXPECT_DOUBLE_EQ(288.15, atmosphere.Temperature().Kelvin());
-  EXPECT_DOUBLE_EQ(-0.065, atmosphere.TemperatureGradient());
+  EXPECT_DOUBLE_EQ(-0.0065, atmosphere.TemperatureGradient());
   EXPECT_DOUBLE_EQ(101325, atmosphere.Pressure());
 }
 


### PR DESCRIPTION
The default value in the Atmosphere SDF DOM was off by a factor of 10, see [default value in atmosphere.sdf spec](https://github.com/osrf/sdformat/blob/master/sdf/1.7/atmosphere.sdf#L17). I believe the one in the spec is correct according to [wikipedia](https://en.wikipedia.org/wiki/Atmospheric_temperature): `Temperatures in the atmosphere decrease with height at an average rate of 6.5°C/km.` 

This could be a behavior change so I could retarget to `master` if needed

Signed-off-by: Ian Chen <ichen@osrfoundation.org>