### PR TITLE
Wrap description tags in CDATA

### DIFF
--- a/src/Element.cc
+++ b/src/Element.cc
@@ -255,7 +255,8 @@ void Element::PrintDescription(const std::string &_prefix) const
 
   std::cout << ">\n";
 
-  std::cout << _prefix << "  <description><![CDATA[" << this->dataPtr->description
+  std::cout << _prefix << "  <description><![CDATA["
+            << this->dataPtr->description
             << "]]></description>\n";
 
   Param_V::iterator aiter;
@@ -266,7 +267,8 @@ void Element::PrintDescription(const std::string &_prefix) const
               << (*aiter)->GetKey() << "' type ='" << (*aiter)->GetTypeName()
               << "' default ='" << (*aiter)->GetDefaultAsString()
               << "' required ='" << (*aiter)->GetRequired() << "'>\n";
-    std::cout << _prefix << "    <description><![CDATA[" << (*aiter)->GetDescription()
+    std::cout << _prefix << "    <description><![CDATA["
+              << (*aiter)->GetDescription()
               << "]]></description>\n";
     std::cout << _prefix << "  </attribute>\n";
   }

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -255,8 +255,8 @@ void Element::PrintDescription(const std::string &_prefix) const
 
   std::cout << ">\n";
 
-  std::cout << _prefix << "  <description>" << this->dataPtr->description
-            << "</description>\n";
+  std::cout << _prefix << "  <description><![CDATA[" << this->dataPtr->description
+            << "]]></description>\n";
 
   Param_V::iterator aiter;
   for (aiter = this->dataPtr->attributes.begin();
@@ -266,8 +266,8 @@ void Element::PrintDescription(const std::string &_prefix) const
               << (*aiter)->GetKey() << "' type ='" << (*aiter)->GetTypeName()
               << "' default ='" << (*aiter)->GetDefaultAsString()
               << "' required ='" << (*aiter)->GetRequired() << "'>\n";
-    std::cout << _prefix << "    <description>" << (*aiter)->GetDescription()
-              << "</description>\n";
+    std::cout << _prefix << "    <description><![CDATA[" << (*aiter)->GetDescription()
+              << "]]></description>\n";
     std::cout << _prefix << "  </attribute>\n";
   }
 


### PR DESCRIPTION
closes #375

This PR wraps all `<description>` content in `<![CDATA[]]>`, which was stripped away when full sdf files were generated. All symbols should show up properly on website upon merging.