### PR TITLE
sdformat.pc.in: requires ignition-utils1

### DIFF
--- a/cmake/sdformat_pc.in
+++ b/cmake/sdformat_pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: SDF
 Description: Robot Modeling Language (SDF)
 Version: @SDF_VERSION_FULL@
-Requires: ignition-math@IGN_MATH_VER@
+Requires: ignition-math@IGN_MATH_VER@, ignition-utils@IGN_UTILS_VER@
 Libs: -L${libdir} -lsdformat@SDF_MAJOR_VERSION@
 CFlags: -I${includedir}/sdformat-@SDF_VERSION@ -std=c++17


### PR DESCRIPTION
We updated the cmake config file in #474, but forgot to update the pkg-config file. This caused the sdformat 11.0.0~pre2 bottle build to fail: https://github.com/osrf/homebrew-simulation/pull/1326

~~~
==> pkg-config sdformat11
==> /usr/bin/clang test.cpp -std=c++17 -I/usr/local/lib/pkgconfig/../..//include/sdformat-11.0 -I/usr/local/Cellar/ignition-math6/6.8.0~pre2/include/ignition/math6 -I/usr/local/lib/pkgconfig/../..//include/ignition/cmake2 -L/usr/local/Cellar/sdformat11/11.0.0~pre2/lib -lsdformat11 -lc++ -o test
In file included from test.cpp:2:
In file included from /usr/local/lib/pkgconfig/../..//include/sdformat-11.0/sdf/sdf.hh:2:
/usr/local/lib/pkgconfig/../..//include/sdformat-11.0/sdf/Actor.hh:24:10: fatal error: 'ignition/utils/ImplPtr.hh' file not found
#include <ignition/utils/ImplPtr.hh>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
~~~

https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/263/label=osx_catalina/console