### PR TITLE
tests: Ensure removed SDFormat elements raise errors in newer versions

### DIFF
--- a/test/integration/unknown.cc
+++ b/test/integration/unknown.cc
@@ -135,3 +135,54 @@ TEST(UnrecognizedElements, UnrecognizedElementsWithNamespaces)
   const auto errors = root.Load(testFile, config);
   EXPECT_TRUE(errors.empty());
 }
+
+/////////////////////////////////////////////////
+/// Test that elements that aren't part of the version of the spec
+/// cause an error (#327) - e.g. something that was valid in SDFormat 1.6 but
+/// not in SDFormat>=1.7 (https://git.io/JtKKb).
+TEST(UnrecognizedElements, OldElementsInNewSchemas)
+{
+  // This should be valid in 1.6, but not in 1.8 (do to usage of
+  // `use_parent_model_frame`).
+  auto make_model_xml_string = [](std::string version) {
+    return R"(
+<?xml version="1.0" ?>
+<sdf version=")" + version + R"(">
+  <model name="default">
+    <joint name="joint_WA" type="revolute">
+      <parent>world</parent>
+      <child>A</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="A"/>
+  </model>
+</sdf>)";
+  };
+
+  sdf::ParserConfig config;
+  config.SetUnrecognizedElementsPolicy(sdf::EnforcementPolicy::ERR);
+
+  // Valid in 1.6.
+  {
+    sdf::Root root;
+    const auto errors = root.LoadSdfString(
+        make_model_xml_string("1.6"), config);
+    ASSERT_TRUE(errors.empty());
+  }
+
+  // Invalid in >=1.7.
+  {
+    sdf::Root root;
+    const auto errors = root.LoadSdfString(
+        make_model_xml_string("1.8"), config);
+    ASSERT_EQ(errors.size(), 1u);
+    constexpr char expectedMessage[] =
+        "XML Element[use_parent_model_frame], child of element[axis], not "
+        "defined in SDF. Copying[use_parent_model_frame] as children of "
+        "[axis].\n";
+    EXPECT_EQ(errors[0].Message(), expectedMessage);
+  }
+}

--- a/test/integration/unknown.cc
+++ b/test/integration/unknown.cc
@@ -144,7 +144,8 @@ TEST(UnrecognizedElements, OldElementsInNewSchemas)
 {
   // This should be valid in 1.6, but not in 1.8 (do to usage of
   // `use_parent_model_frame`).
-  auto make_model_xml_string = [](std::string version) {
+  auto make_model_xml_string = [](std::string version)
+  {
     return R"(
 <?xml version="1.0" ?>
 <sdf version=")" + version + R"(">


### PR DESCRIPTION
Resolves #327 (explicitly)
Follow-up to #481

Uses model setup from issue:
https://github.com/RobotLocomotion/drake/blob/ab20bf25d9e9c05f861d7b6905cd6ef4dd9950c7/examples/multibody/four_bar/four_bar.sdf#L249

\cc @brawner