### PR TITLE
Quietly search for urdfdom

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -31,7 +31,7 @@ if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
   pkg_check_modules(URDF urdfdom>=1.0)
 
   if (NOT URDF_FOUND)
-    find_package(urdfdom)
+    find_package(urdfdom QUIET)
     if (urdfdom_FOUND)
       set(URDF_INCLUDE_DIRS ${urdfdom_INCLUDE_DIRS})
       # ${urdfdom_LIBRARIES} already contains absolute library filenames


### PR DESCRIPTION
This is causing CMake warnings downstream, for example in https://github.com/ignitionrobotics/ign-sensors/pull/98

Tested here that this fixes the warning on `ign-sensors` (uses this branch and `release-tools`'s `chapulina/sensors/pr98` branch: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_sensors-ci-pr_any-ubuntu_auto-amd64&build=625)](https://build.osrfoundation.org/job/ignition_sensors-ci-pr_any-ubuntu_auto-amd64/625/)