### PR TITLE
Parse rpyOffset as radians

### DIFF
--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -3467,7 +3467,7 @@ void ReduceSDFExtensionPluginFrameReplace(
         TiXmlNode* rpyKey = (*_blobIt)->FirstChild("rpyOffset");
         if (rpyKey)
         {
-          urdf::Vector3 rpy = ParseVector3(rpyKey, M_PI/180.0);
+          urdf::Vector3 rpy = ParseVector3(rpyKey);
           _reductionTransform.Rot() =
             ignition::math::Quaterniond::EulerToQuaternion(rpy.x, rpy.y, rpy.z);
           // remove xyzOffset and rpyOffset


### PR DESCRIPTION
During fixed joint reduction, the `xyzOffset` and `rpyOffset` plugin parameters are modified. It was found that the `rpyOffset` is actually parsed as degrees instead of radians.

This created a problem when you have chained fixed joints - in the first joint reduction, the code writes out the new `rpyOffset` vector in radians, but in the second fixed joint reduction, the code parses it back as degrees.

Looking at [plugins in gazebo_ros_pkgs](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_plugins/src/gazebo_ros_imu.cpp#L116), this parameter should be in radians



Signed-off-by: Ian Chen <ichen@osrfoundation.org>