### PR TITLE
Fix lidar resolution description about interpolation

### DIFF
--- a/sdf/1.6/lidar.sdf
+++ b/sdf/1.6/lidar.sdf
@@ -11,7 +11,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="1">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">
@@ -31,7 +31,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="0">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">

--- a/sdf/1.7/lidar.sdf
+++ b/sdf/1.7/lidar.sdf
@@ -11,7 +11,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="1">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">
@@ -31,7 +31,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="0">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">

--- a/sdf/1.8/lidar.sdf
+++ b/sdf/1.8/lidar.sdf
@@ -11,7 +11,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="1">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">
@@ -31,7 +31,7 @@
       </element>
 
       <element name="resolution" type="double" default="1" required="0">
-        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged.</description>
+        <description>This number is multiplied by samples to determine the number of range data points returned. If resolution is not equal to one, range data is interpolated.</description>
       </element>
 
       <element name="min_angle" type="double" default="0" required="1">


### PR DESCRIPTION
# 🦟 Bug fix

Fixes description about when interpolation is done in `<lidar><scan><horizontal | vertical><resolution>`.

## Summary

The current description says "If resolution is less than one, range data is interpolated. If resolution is greater than one, range data is averaged."

But in the actual `RaySensor` implementation in both Gazebo 9 and 11, interpolation is done whenever resolution != 1. `interp` is set to `true` whenever `rayCount != rangeCount` (in SDF parameters' terms, that is `samples != samples * resolution`):
https://github.com/osrf/gazebo/blob/d94e2e0b6754a929c11dec4dff2131cfd291478e/gazebo/sensors/RaySensor.cc#L412-L413

This PR updates the description to match the implementation.

## Checklist
- [ ] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

@iche033 

**Note to maintainers**: Remember to use **Squash-Merge**