### PR TITLE
Store include info in Element

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -493,7 +493,7 @@ namespace sdf
 
     /// \brief The <include> element that was used to load this entity. For
     /// example, given the following SDFormat:
-    /// <sdf version = '1.8'>
+    /// <sdf version='1.8'>
     ///   <world name='default'>
     ///     <include>
     ///       <uri>model_uri</uri>
@@ -501,7 +501,7 @@ namespace sdf
     ///     </include>
     ///   </world>
     /// </sdf>
-    /// The ElementPtr associated with the model loaded from 'model_uri' will
+    /// The ElementPtr associated with the model loaded from `model_uri` will
     /// have the includeElement set to
     ///     <include>
     ///       <uri>model_uri</uri>

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -385,8 +385,9 @@ namespace sdf
     public: std::string GetInclude() const SDF_DEPRECATED(11.0);
 
     /// \brief Set the <include> element that was used to load this element.
-    /// This set by the parser on the first element of the included object (eg.
-    /// Model, Actor, Light, etc). It is not passed down to children elements.
+    /// This is set by the parser on the first element of the included object
+    /// (eg. Model, Actor, Light, etc). It is not passed down to children
+    /// elements.
     /// \param[in] _includeELem The <include> Element
     public: void SetIncludeElement(sdf::ElementPtr _includeElem);
 

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -378,11 +378,23 @@ namespace sdf
 
     /// \brief Set the include filename to the passed in filename.
     /// \param[in] _filename the filename to set the include filename to.
-    public: void SetInclude(const std::string &_filename);
+    public: void SetInclude(const std::string &_filename) SDF_DEPRECATED(11.0);
 
     /// \brief Get the include filename.
     /// \return The include filename.
-    public: std::string GetInclude() const;
+    public: std::string GetInclude() const SDF_DEPRECATED(11.0);
+
+    /// \brief Set the <include> element that was used to load this element.
+    /// This set by the parser on the first element of the included object (eg.
+    /// Model, Actor, Light, etc). It is not passed down to children elements.
+    /// \param[in] _includeELem The <include> Element
+    public: void SetIncludeElement(sdf::ElementPtr _includeElem);
+
+    /// \brief Get the <include> element that was used to load this element.
+    /// \return The Element pointer to the <include> element, if this element
+    /// was loaded from an included file. Otherwise, nullptr. This is also
+    /// nullptr for Elements that cannot be included.
+    public: sdf::ElementPtr GetIncludeElement() const;
 
     /// \brief Set the path to the SDF document where this element came from.
     /// \param[in] _path Full path to SDF document.
@@ -478,6 +490,28 @@ namespace sdf
 
     // The possible child elements
     public: ElementPtr_V elementDescriptions;
+
+    /// \brief The <include> element that was used to load this entity. For
+    /// example, given the following SDFormat:
+    /// <sdf version = '1.8'>
+    ///   <world name='default'>
+    ///     <include>
+    ///       <uri>model_uri</uri>
+    ///       <pose>1 2 3 0 0 0</pose>
+    ///     </include>
+    ///   </world>
+    /// </sdf>
+    /// The ElementPtr associated with the model loaded from 'model_uri' will
+    /// have the includeElement set to
+    ///     <include>
+    ///       <uri>model_uri</uri>
+    ///       <pose>1 2 3 0 0 0</pose>
+    ///     </include>
+    ///
+    /// This can be used to retrieve additional information available under the
+    /// <include> tag after the entity has been loaded. An example use case for
+    /// this is when saving a loaded world back to SDFormat.
+    public: ElementPtr includeElement;
 
     /// name of the include file that was used to create this element
     public: std::string includeFilename;

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -195,6 +195,11 @@ ElementPtr Element::Clone() const
     clone->dataPtr->value = this->dataPtr->value->Clone();
   }
 
+  if (this->dataPtr->includeElement)
+  {
+    clone->dataPtr->includeElement = this->dataPtr->includeElement->Clone();
+  }
+
   return clone;
 }
 
@@ -249,6 +254,18 @@ void Element::Copy(const ElementPtr _elem)
     elem->Copy(*iter);
     elem->SetParent(shared_from_this());
     this->dataPtr->elements.push_back(elem);
+  }
+
+  if (_elem->dataPtr->includeElement)
+  {
+    if (!this->dataPtr->includeElement)
+    {
+      this->dataPtr->includeElement = _elem->dataPtr->includeElement->Clone();
+    }
+    else
+    {
+      this->dataPtr->includeElement->Copy(_elem->dataPtr->includeElement);
+    }
   }
 }
 
@@ -910,6 +927,18 @@ void Element::SetInclude(const std::string &_filename)
 std::string Element::GetInclude() const
 {
   return this->dataPtr->includeFilename;
+}
+
+/////////////////////////////////////////////////
+void Element::SetIncludeElement(sdf::ElementPtr _includeElem)
+{
+  this->dataPtr->includeElement = _includeElem;
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr Element::GetIncludeElement() const
+{
+  return this->dataPtr->includeElement;
 }
 
 /////////////////////////////////////////////////

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -47,20 +47,6 @@
 namespace sdf
 {
 inline namespace SDF_VERSION_NAMESPACE {
-
-sdf::ElementPtr getIncludeDescription(sdf::ElementPtr _root)
-{
-  for (uint64_t i = 0; i < _root->GetElementDescriptionCount(); ++i)
-  {
-    auto desc = _root->GetElementDescription(i);
-    if ("include" == desc->GetName())
-    {
-      return desc;
-    }
-  }
-  return nullptr;
-}
-
 //////////////////////////////////////////////////
 /// \brief Internal helper for readFile, which populates the SDF values
 /// from a file

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -1371,3 +1371,87 @@ TEST(NestedReference, PlacementFrameElement)
     EXPECT_EQ(placementPose, pose.Inverse());
   }
 }
+
+/////////////////////////////////////////////////
+TEST(NestedModel, IncludeElements)
+{
+  const std::string modelRootPath = sdf::filesystem::append(
+      PROJECT_SOURCE_PATH, "test", "integration", "model");
+
+  sdf::setFindCallback(
+      [&](const std::string &_file)
+      {
+        return sdf::filesystem::append(modelRootPath, _file);
+      });
+
+  auto checkIncludeElem = [](sdf::ElementPtr _includeElem,
+                              const std::string &_uri, const std::string &_name)
+  {
+    ASSERT_NE(nullptr, _includeElem);
+    ASSERT_TRUE(_includeElem->HasElement("uri"));
+    EXPECT_EQ(_uri, _includeElem->Get<std::string>("uri"));
+
+    ASSERT_TRUE(_includeElem->HasElement("name"));
+    EXPECT_EQ(_name, _includeElem->Get<std::string>("name"));
+
+    ASSERT_TRUE(_includeElem->HasElement("pose"));
+    EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 0),
+        _includeElem->Get<ignition::math::Pose3d>("pose"));
+
+    ASSERT_TRUE(_includeElem->HasElement("placement_frame"));
+    EXPECT_EQ("link", _includeElem->Get<std::string>("placement_frame"));
+
+    ASSERT_TRUE(_includeElem->HasElement("plugin"));
+    auto pluginElem = _includeElem->GetElement("plugin");
+    ASSERT_TRUE(pluginElem->HasAttribute("name"));
+    EXPECT_EQ("test_plugin", pluginElem->Get<std::string>("name"));
+    ASSERT_TRUE(pluginElem->HasAttribute("filename"));
+    EXPECT_EQ("test_plugin_file", pluginElem->Get<std::string>("filename"));
+  };
+
+  // Test with //world/include
+  {
+    std::ostringstream stream;
+    stream << R"(
+    <sdf version='1.8'>
+      <world name='default'>
+        <include>
+          <uri>box</uri>
+          <name>test_box</name>
+          <pose>1 2 3 0 0 0</pose>
+          <placement_frame>link</placement_frame>
+          <plugin name="test_plugin" filename="test_plugin_file"/>
+        </include>
+        <model name="test2">
+          <include>
+            <uri>test_model</uri>
+            <name>test_model</name>
+            <pose>1 2 3 0 0 0</pose>
+            <placement_frame>link</placement_frame>
+            <plugin name="test_plugin" filename="test_plugin_file"/>
+          </include>
+        </model>
+      </world>
+    </sdf>)";
+    sdf::Root root;
+    sdf::Errors errors = root.LoadSdfString(stream.str());
+    EXPECT_TRUE(errors.empty()) << errors;
+
+    auto *world = root.WorldByIndex(0);
+    ASSERT_NE(nullptr, world);
+    auto *box = world->ModelByIndex(0);
+    ASSERT_NE(nullptr, box);
+
+    checkIncludeElem(
+        box->Element()->GetIncludeElement(), "box", "test_box");
+
+    auto *test2 = world->ModelByIndex(1);
+    ASSERT_NE(nullptr, test2);
+    EXPECT_EQ(nullptr, test2->Element()->GetIncludeElement());
+
+    auto *testModel2 = test2->ModelByIndex(0);
+    ASSERT_NE(nullptr, testModel2);
+    checkIncludeElem(
+        testModel2->Element()->GetIncludeElement(), "test_model", "test_model");
+  }
+}

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -1403,7 +1403,8 @@ TEST(NestedModel, IncludeElements)
   const std::string modelRootPath = sdf::filesystem::append(
       PROJECT_SOURCE_PATH, "test", "integration", "model");
 
-  sdf::setFindCallback(
+  sdf::ParserConfig config;
+  config.SetFindCallback(
       [&](const std::string &_file)
       {
         return sdf::filesystem::append(modelRootPath, _file);
@@ -1445,21 +1446,21 @@ TEST(NestedModel, IncludeElements)
           <name>test_box</name>
           <pose>1 2 3 0 0 0</pose>
           <placement_frame>link</placement_frame>
-          <plugin name="test_plugin" filename="test_plugin_file"/>
+          <plugin name='test_plugin' filename='test_plugin_file'/>
         </include>
-        <model name="test2">
+        <model name='test2'>
           <include>
             <uri>test_model</uri>
             <name>test_model</name>
             <pose>1 2 3 0 0 0</pose>
             <placement_frame>link</placement_frame>
-            <plugin name="test_plugin" filename="test_plugin_file"/>
+            <plugin name='test_plugin' filename='test_plugin_file'/>
           </include>
         </model>
       </world>
     </sdf>)";
     sdf::Root root;
-    sdf::Errors errors = root.LoadSdfString(stream.str());
+    sdf::Errors errors = root.LoadSdfString(stream.str(), config);
     EXPECT_TRUE(errors.empty()) << errors;
 
     auto *world = root.WorldByIndex(0);


### PR DESCRIPTION
# 🎉 New feature

Closes #401 

## Summary
This stores the contents of `<include>` inside the Element loaded from the included file.
For example, given the following SDFormat:
```xml
<sdf version = '1.8'>
  <world name='default'>
    <include>
      <uri>model_uri</uri>
      <pose>1 2 3 0 0 0</pose>
    </include>
  </world>
</sdf>
```

The `ElementPtr` associated with the model loaded from 'model_uri' will
have its `includeElement` set to

```xml
    <include>
      <uri>model_uri</uri>
      <pose>1 2 3 0 0 0</pose>
    </include>
```
This can be used to retrieve additional information available under the <include> tag after the entity has been loaded (eg. `<name>`, `<pose>`, `<plugin>`, etc.). An example use case for this is when saving a loaded world back to SDFormat in such a way that the `<include>` tags are left intact.

This also deprecates the functions `Element::SetInclude` and `Element::GetInclude` since they were never used. Based on the code  in `Element::ToString`: https://github.com/osrf/sdformat/blob/54d9018599ce6605cee13d372c7dc51f0c0fcd2d/src/Element.cc#L528-L537
I think these functions were added a long time ago when the syntax for including files was `<include filename="path">`, which is not valid SDFormat anymore.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
