### PR TITLE
Add camera type aliases to docs

### DIFF
--- a/sdf/1.6/sensor.sdf
+++ b/sdf/1.6/sensor.sdf
@@ -12,7 +12,7 @@
                   altimeter,
                   camera,
                   contact,
-                  depth_camera,
+                  depth_camera, depth,
                   force_torque,
                   gps,
                   gpu_lidar,
@@ -25,9 +25,9 @@
                   ray,
                   rfid,
                   rfidtag,
-                  rgbd_camera,
+                  rgbd_camera, rgbd,
                   sonar,
-                  thermal_camera,
+                  thermal_camera, thermal,
                   wireless_receiver, and
                   wireless_transmitter.
       The "ray" and "gpu_ray" types are equivalent to "lidar" and "gpu_lidar", respectively. It is preferred to use "lidar" and "gpu_lidar" since "ray" and "gpu_ray" will be deprecated. The "ray" and "gpu_ray" types are maintained for legacy support.

--- a/sdf/1.7/sensor.sdf
+++ b/sdf/1.7/sensor.sdf
@@ -12,7 +12,7 @@
                   altimeter,
                   camera,
                   contact,
-                  depth_camera,
+                  depth_camera, depth,
                   force_torque,
                   gps,
                   gpu_lidar,
@@ -25,9 +25,9 @@
                   ray,
                   rfid,
                   rfidtag,
-                  rgbd_camera,
+                  rgbd_camera, rgbd,
                   sonar,
-                  thermal_camera,
+                  thermal_camera, thermal,
                   wireless_receiver, and
                   wireless_transmitter.
       The "ray" and "gpu_ray" types are equivalent to "lidar" and "gpu_lidar", respectively. It is preferred to use "lidar" and "gpu_lidar" since "ray" and "gpu_ray" will be deprecated. The "ray" and "gpu_ray" types are maintained for legacy support.


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
I added aliases of camera types to the SDF docs of `<sensor type="">`. In [code](https://github.com/osrf/sdformat/blob/105bf225ea187a0ea24c9e66de820e9bc8487fc9/src/Sensor.cc#L262), you can see that e.g. both `thermal_camera` and `thermal` are accepted, but the docs mention only `thermal_camera`. As the list in the docs looks pretty much normative and exhaustive, I think it's less confusing if also the aliases are in the list.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**