### PR TITLE
Error when delimiter "::" found in element name in SDFormat 1.8

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -327,6 +327,9 @@ but with improved human-readability..
 
 1. **heightmap.sdf**: sampling now defaults to 1 instead of 2.
 
+1. Element attribute names containing delimiter "::" no longer accepted
+    * [Issue 420](https://github.com/osrf/sdformat/issues/420)
+
 ### Deprecations
 
 1. **joint.sdf** `initial_position` element in `<joint><axis>` and `<joint><axis2>` is deprecated

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -417,10 +417,11 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool recursiveSiblingUniqueNames(sdf::ElementPtr _elem);
 
-  /// \brief Check that all sibling elements do not the delimiter double colons
-  /// '::' in element names which is reserved for forming scopes in SDFormat 1.8
-  /// This checks recursively and should check the files exhaustively rather
-  /// than terminating early when the first name containing '::' is found.
+  /// \brief Check that all sibling elements do not contain the delimiter
+  /// double colons '::' in element names, which is reserved for forming scopes
+  /// in SDFormat 1.8. This checks recursively and should check the files
+  /// exhaustively rather than terminating early when the first name
+  /// containing '::' is found.
   /// \param[in] _elem SDF Element to check recursively.
   /// \return True if all contained element names do not have the delimiter '::'
   SDFORMAT_VISIBLE

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -417,6 +417,15 @@ namespace sdf
   SDFORMAT_VISIBLE
   bool recursiveSiblingUniqueNames(sdf::ElementPtr _elem);
 
+  /// \brief Check that all sibling elements do not the delimiter double colons
+  /// '::' in element names which is reserved for forming scopes in SDFormat 1.8
+  /// This checks recursively and should check the files exhaustively rather
+  /// than terminating early when the first name containing '::' is found.
+  /// \param[in] _elem SDF Element to check recursively.
+  /// \return True if all contained element names do not have the delimiter '::'
+  SDFORMAT_VISIBLE
+  bool recursiveSiblingNoDoubleColonInNames(sdf::ElementPtr _elem);
+
   /// \brief Check whether the element should be validated. If this returns
   /// false, validators such as the unique name and reserve name checkers should
   /// skip this element and its descendants.

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -687,7 +687,8 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
     }
 
     // delimiter '::' in element names not allowed in SDFormat >= 1.8
-    if (std::stof(_sdf->Root()->OriginalVersion()) >= 1.8f
+    ignition::math::SemanticVersion sdfVersion(_sdf->Root()->OriginalVersion());
+    if (sdfVersion >= ignition::math::SemanticVersion(1, 8)
         && !recursiveSiblingNoDoubleColonInNames(_sdf->Root()))
     {
       _errors.push_back({ErrorCode::RESERVED_NAME,
@@ -768,7 +769,8 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
     }
 
     // delimiter '::' in element names not allowed in SDFormat >= 1.8
-    if (std::stof(_sdf->OriginalVersion()) >= 1.8f
+    ignition::math::SemanticVersion sdfVersion(_sdf->OriginalVersion());
+    if (sdfVersion >= ignition::math::SemanticVersion(1, 8)
         && !recursiveSiblingNoDoubleColonInNames(_sdf))
     {
       _errors.push_back({ErrorCode::RESERVED_NAME,

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -354,6 +354,31 @@ TEST(Parser, PlacementFrameMissingPose)
 }
 
 /////////////////////////////////////////////////
+// Delimiter '::' in name should error in SDFormat 1.8 but not in 1.7
+TEST(Parser, DoubleColonNameAttrError)
+{
+  sdf::SDFPtr sdf = InitSDF();
+  std::ostringstream stream;
+  stream << "<?xml version=\"1.0\"?>"
+         << "<sdf version='1.8'>"
+         << "  <model name='test'>"
+         << "    <link name='A::B'/>"
+         << "  </model>"
+         << "</sdf>";
+
+  EXPECT_FALSE(sdf::readString(stream.str(), sdf));
+
+  sdf = InitSDF();
+  stream.str("");
+  stream << "<?xml version=\"1.0\"?>"
+         << "<sdf version='1.7'>"
+         << "  <model name='test::A'/>"
+         << "</sdf>";
+
+  EXPECT_TRUE(sdf::readString(stream.str(), sdf));
+}
+
+/////////////////////////////////////////////////
 /// Fixture for setting up stream redirection
 class ValueConstraintsFixture : public ::testing::Test
 {

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -366,7 +366,10 @@ TEST(Parser, DoubleColonNameAttrError)
          << "  </model>"
          << "</sdf>";
 
-  EXPECT_FALSE(sdf::readString(stream.str(), sdf));
+  sdf::Errors errors;
+  EXPECT_FALSE(sdf::readString(stream.str(), sdf, errors));
+  ASSERT_EQ(errors.size(), 1u);
+  EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::RESERVED_NAME);
 
   sdf = InitSDF();
   stream.str("");
@@ -375,7 +378,9 @@ TEST(Parser, DoubleColonNameAttrError)
          << "  <model name='test::A'/>"
          << "</sdf>";
 
-  EXPECT_TRUE(sdf::readString(stream.str(), sdf));
+  errors.clear();
+  EXPECT_TRUE(sdf::readString(stream.str(), sdf, errors));
+  EXPECT_EQ(errors.size(), 0u);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Closes #420 

## Summary
Error when the `::` delimiter is found in `name` attributes for files that are SDFormat >= 1.8

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**