### PR TITLE
Add nested model support for World's `*ByName` and `*NameExists` functions

### DIFF
--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -132,11 +132,17 @@ namespace sdf
 
     /// \brief Get a model based on a name.
     /// \param[in] _name Name of the model.
-    /// \return Pointer to the model. Nullptr if the name does not exist.
+    /// To get a model nested in other models, prefix the model name
+    /// with the sequence of nested model names, delimited by "::".
+    /// \return Pointer to the model. Nullptr if a model with the given name
+    /// does not exist.
+    /// \sa bool ModelNameExists(const std::string &_name) const
     public: const Model *ModelByName(const std::string &_name) const;
 
     /// \brief Get whether a model name exists.
     /// \param[in] _name Name of the model to check.
+    /// To check for a model nested in other models, prefix the model name with
+    /// the sequence of nested models containing this frame, delimited by "::".
     /// \return True if there exists a model with the given name.
     public: bool ModelNameExists(const std::string &_name) const;
 

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -145,7 +145,7 @@ namespace sdf
     /// \brief Get whether a model name exists.
     /// \param[in] _name Name of the model to check.
     /// To check for a model nested in other models, prefix the model name with
-    /// the sequence of nested models containing this frame, delimited by "::".
+    /// the sequence of nested models containing this model, delimited by "::".
     /// \return True if there exists a model with the given name.
     public: bool ModelNameExists(const std::string &_name) const;
 

--- a/include/sdf/World.hh
+++ b/include/sdf/World.hh
@@ -120,12 +120,15 @@ namespace sdf
 
     /// \brief Get the number of models that are immediate (not nested) children
     /// of this World object.
+    /// \remark ModelByName() can find nested models that are not immediate
+    /// children of this World object.
     /// \return Number of models contained in this World object.
     public: uint64_t ModelCount() const;
 
-    /// \brief Get an immediate (not nested) child model based on an index.
-    /// \param[in] _index Index of the model. The index should be in the
-    /// range [0..ModelCount()).
+    /// \brief Get an immediate (not recursively nested) child model based on an
+    /// index.
+    /// \param[in] _index Index of the model. The index should be in the range
+    /// [0..ModelCount()).
     /// \return Pointer to the model. Nullptr if the index does not exist.
     /// \sa uint64_t ModelCount() const
     public: const Model *ModelByIndex(const uint64_t _index) const;
@@ -164,6 +167,8 @@ namespace sdf
 
     /// \brief Get the number of explicit frames that are immediate (not nested)
     /// children of this World object.
+    /// \remark FrameByName() can find explicit frames that are not immediate
+    /// children of this World object.
     /// \return Number of explicit frames contained in this World object.
     public: uint64_t FrameCount() const;
 
@@ -178,12 +183,16 @@ namespace sdf
 
     /// \brief Get an explicit frame based on a name.
     /// \param[in] _name Name of the explicit frame.
+    /// To get a frame in a nested model, prefix the frame name with the
+    /// sequence of nested models containing this frame, delimited by "::".
     /// \return Pointer to the explicit frame. Nullptr if the name does not
     /// exist.
     public: const Frame *FrameByName(const std::string &_name) const;
 
     /// \brief Get whether an explicit frame name exists.
     /// \param[in] _name Name of the explicit frame to check.
+    /// To check for a frame in a nested model, prefix the frame name with
+    /// the sequence of nested models containing this frame, delimited by "::".
     /// \return True if there exists an explicit frame with the given name.
     public: bool FrameNameExists(const std::string &_name) const;
 

--- a/src/World.cc
+++ b/src/World.cc
@@ -344,14 +344,24 @@ bool World::ModelNameExists(const std::string &_name) const
 /////////////////////////////////////////////////
 const Model *World::ModelByName(const std::string &_name) const
 {
+  auto index = _name.find("::");
+  const std::string nextModelName = _name.substr(0, index);
+  const Model *nextModel = nullptr;
+
   for (auto const &m : this->dataPtr->models)
   {
-    if (m.Name() == _name)
+    if (m.Name() == nextModelName)
     {
-      return &m;
+      nextModel = &m;
+      break;
     }
   }
-  return nullptr;
+
+  if (nullptr != nextModel && index != std::string::npos)
+  {
+    return nextModel->ModelByName(_name.substr(index + 2));
+  }
+  return nextModel;
 }
 
 /////////////////////////////////////////////////

--- a/src/World.cc
+++ b/src/World.cc
@@ -331,14 +331,7 @@ const Model *World::ModelByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool World::ModelNameExists(const std::string &_name) const
 {
-  for (auto const &m : this->dataPtr->models)
-  {
-    if (m.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->ModelByName(_name);
 }
 
 /////////////////////////////////////////////////
@@ -423,19 +416,28 @@ const Frame *World::FrameByIndex(const uint64_t _index) const
 /////////////////////////////////////////////////
 bool World::FrameNameExists(const std::string &_name) const
 {
-  for (auto const &f : this->dataPtr->frames)
-  {
-    if (f.Name() == _name)
-    {
-      return true;
-    }
-  }
-  return false;
+  return nullptr != this->FrameByName(_name);
 }
 
 /////////////////////////////////////////////////
 const Frame *World::FrameByName(const std::string &_name) const
 {
+  auto index = _name.rfind("::");
+  if (index != std::string::npos)
+  {
+    const Model *model = this->ModelByName(_name.substr(0, index));
+    if (nullptr != model)
+    {
+      return model->FrameByName(_name.substr(index + 2));
+    }
+
+    // The nested model name preceding the last "::" could not be found.
+    // For now, try to find a link that matches _name exactly.
+    // When "::" are reserved and not allowed in names, then uncomment
+    // the following line to return a nullptr.
+    // return nullptr;
+  }
+
   for (auto const &f : this->dataPtr->frames)
   {
     if (f.Name() == _name)

--- a/src/World_TEST.cc
+++ b/src/World_TEST.cc
@@ -37,8 +37,14 @@ TEST(DOMWorld, Construction)
   EXPECT_EQ(nullptr, world.ModelByIndex(1));
   EXPECT_FALSE(world.ModelNameExists(""));
   EXPECT_FALSE(world.ModelNameExists("default"));
+  EXPECT_FALSE(world.ModelNameExists("a::b"));
+  EXPECT_FALSE(world.ModelNameExists("a::b::c"));
+  EXPECT_FALSE(world.ModelNameExists("::::"));
   EXPECT_EQ(nullptr, world.ModelByName(""));
   EXPECT_EQ(nullptr, world.ModelByName("default"));
+  EXPECT_EQ(nullptr, world.ModelByName("a::b"));
+  EXPECT_EQ(nullptr, world.ModelByName("a::b::c"));
+  EXPECT_EQ(nullptr, world.ModelByName("::::"));
 
   EXPECT_EQ(0u, world.FrameCount());
   EXPECT_EQ(nullptr, world.FrameByIndex(0));

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -196,6 +196,18 @@ TEST(DOMRoot, NestedModel)
   EXPECT_TRUE(model->LinkNameExists(linkNestedName));
   const sdf::Link *nestedLink01 = model->LinkByName(linkNestedName);
   EXPECT_NE(nullptr, nestedLink01);
+
+  // Recursively nested
+  EXPECT_EQ(nullptr, model->ModelByName("nested_nested_model"));
+  EXPECT_FALSE(model->ModelNameExists("nested_nested_model"));
+
+  EXPECT_TRUE(model->ModelNameExists("nested_model::nested_nested_model"));
+  const sdf::Model *nested_nested_model =
+      model->ModelByName("nested_model::nested_nested_model");
+  ASSERT_NE(nullptr, nested_nested_model);
+  const sdf::Link *nested_nested_link =
+      nested_nested_model->LinkByName("nested_nested_link01");
+  EXPECT_NE(nullptr, nested_nested_link);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/world_dom.cc
+++ b/test/integration/world_dom.cc
@@ -214,3 +214,87 @@ TEST(DOMWorld, LoadModelFrameSameName)
       SemanticPose().Resolve(pose, "ground").empty());
   EXPECT_EQ(Pose(0, -2, 3, 0, 0, 0), pose);
 }
+
+/////////////////////////////////////////////////
+TEST(DOMWorld, NestedModels)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_nested_model.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty()) << errors;
+
+  // Get the first world
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  EXPECT_EQ("world_nested_model", world->Name());
+  EXPECT_EQ(1u, world->ModelCount());
+  EXPECT_NE(nullptr, world->ModelByIndex(0));
+  EXPECT_EQ(nullptr, world->ModelByIndex(1));
+  EXPECT_EQ(nullptr, world->ModelByIndex(2));
+
+  EXPECT_FALSE(world->ModelNameExists("nested_model"));
+  EXPECT_FALSE(world->ModelNameExists("nested_nested_model"));
+  EXPECT_FALSE(world->ModelNameExists("nested_model::nested_nested_model"));
+  EXPECT_FALSE(world->ModelNameExists("top_level_model::nested_nested_model"));
+
+  EXPECT_TRUE(world->ModelNameExists("top_level_model"));
+  EXPECT_TRUE(world->ModelNameExists("top_level_model::nested_model"));
+  EXPECT_TRUE(
+      world->ModelNameExists(
+          "top_level_model::nested_model::nested_nested_model"));
+
+  EXPECT_EQ(nullptr, world->ModelByName("nested_model"));
+  EXPECT_EQ(nullptr, world->ModelByName("nested_nested_model"));
+  EXPECT_EQ(nullptr, world->ModelByName("nested_model::nested_nested_model"));
+
+  EXPECT_NE(nullptr, world->ModelByName("top_level_model"));
+  EXPECT_NE(nullptr, world->ModelByName("top_level_model::nested_model"));
+  EXPECT_NE(
+      nullptr,
+      world->ModelByName("top_level_model::nested_model::nested_nested_model"));
+}
+
+/////////////////////////////////////////////////
+TEST(DOMWorld, NestedFrames)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_nested_frame.sdf");
+
+  // Load the SDF file
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty()) << errors;
+
+  // Get the first world
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  EXPECT_EQ("world_nested_frame", world->Name());
+  EXPECT_EQ(1u, world->FrameCount());
+  EXPECT_NE(nullptr, world->FrameByIndex(0));
+  EXPECT_EQ(nullptr, world->FrameByIndex(1));
+  EXPECT_EQ(nullptr, world->FrameByIndex(2));
+
+  EXPECT_FALSE(world->FrameNameExists("top_level_model_frame"));
+  EXPECT_FALSE(world->FrameNameExists("nested_model_frame"));
+  EXPECT_FALSE(world->FrameNameExists("nested_model::nested_model_frame"));
+
+  EXPECT_TRUE(world->FrameNameExists("world_frame"));
+  EXPECT_TRUE(world->FrameNameExists("top_level_model::top_level_model_frame"));
+  EXPECT_TRUE(
+      world->FrameNameExists(
+          "top_level_model::nested_model::nested_model_frame"));
+
+  EXPECT_EQ(nullptr, world->FrameByName("top_level_model_frame"));
+  EXPECT_EQ(nullptr, world->FrameByName("nested_model_frame"));
+  EXPECT_EQ(nullptr, world->FrameByName("nested_model::nested_model_frame"));
+
+  EXPECT_NE(nullptr, world->FrameByName("world_frame"));
+  EXPECT_NE(
+      nullptr, world->FrameByName("top_level_model::top_level_model_frame"));
+  EXPECT_NE(
+      nullptr,
+      world->FrameByName("top_level_model::nested_model::nested_model_frame"));
+}

--- a/test/sdf/nested_model.sdf
+++ b/test/sdf/nested_model.sdf
@@ -4,6 +4,9 @@
   <link name='child'/>
   <model name='nested_model'>
     <link name='nested_link01'/>
+    <model name='nested_nested_model'>
+      <link name='nested_nested_link01'/>
+    </model>
   </model>
   <joint name='top_level_joint' type='revolute'>
     <parent>parent</parent>

--- a/test/sdf/world_nested_frame.sdf
+++ b/test/sdf/world_nested_frame.sdf
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<sdf version='1.8'>
+  <world name="world_nested_frame">
+
+    <frame name="world_frame"/>          <!-- VALID: Directly attached_to implicit world frame. -->
+
+    <model name="top_level_model">
+      <link name="L"/>
+      <model name="nested_model">
+        <link name="L"/>
+        <frame name="nested_model_frame" attached_to="L"/> <!-- VALID: Directly attached_to link top_level_model::L. -->
+      </model>
+      <frame name="top_level_model_frame" attached_to="nested_model::L"/> <!-- VALID: Directly attached_to link nested_model::L. -->
+      <joint name="J1" type="fixed">
+        <parent>L</parent>
+        <child>top_level_model_frame</child>
+      </joint>
+    </model>
+  </world>
+</sdf>

--- a/test/sdf/world_nested_model.sdf
+++ b/test/sdf/world_nested_model.sdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="world_nested_model">
+    <model name='top_level_model'>
+      <link name='parent'/>
+      <link name='child'/>
+      <model name='nested_model'>
+        <link name='nested_link01'/>
+        <model name='nested_nested_model'>
+          <link name='nested_nested_link01'/>
+        </model>
+      </model>
+      <joint name='top_level_joint' type='revolute'>
+        <parent>parent</parent>
+        <child>child</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🎉 New feature

Closes #412 

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This adds nested model support to `*ByName` and `*NameExists` functions in `World`, specifically for `Model` and `Frame`. The implementation is the same as the one used in `Model`.

Notes:
* Added 2 new `.sdf` integration test sdf files, `world_nested_frame.sdf` and `world_nested_model.sdf`.
* Additional tests were added for `Model`'s API as well, since these functions will call them.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

```bash
source ws/install/setup.bash
./ws/build/sdformat11/src/UNIT_World_TEST
./ws/build/sdformat11/test/integration/INTEGRATION_model_dom
./ws/build/sdformat11/test/integration/INTEGRATION_world_dom
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**