### PR TITLE
Improve docs of collision_bitmask.

### DIFF
--- a/sdf/1.4/surface.sdf
+++ b/sdf/1.4/surface.sdf
@@ -56,7 +56,7 @@
     </element>
 
     <element name="collide_bitmask" type="unsigned int" default="1" required="0">
-      <description>Bitmask for collision filtering. This will override collide_without_contact</description>
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
     </element>
 
     <element name="ode" required="0">

--- a/sdf/1.5/surface.sdf
+++ b/sdf/1.5/surface.sdf
@@ -85,7 +85,7 @@
     </element>
 
     <element name="collide_bitmask" type="unsigned int" default="65535" required="0">
-      <description>Bitmask for collision filtering. This will override collide_without_contact</description>
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
     </element>
 
     <element name="poissons_ratio" type="double" default="0.3" required="0">

--- a/sdf/1.6/surface.sdf
+++ b/sdf/1.6/surface.sdf
@@ -141,11 +141,11 @@
     </element>
 
     <element name="collide_bitmask" type="unsigned int" default="65535" required="0">
-      <description>Bitmask for collision filtering. This will override collide_without_contact</description>
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
     </element>
 
     <element name="category_bitmask" type="unsigned int" default="65535" required="0">
-      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask.]]></description>
+      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask. Parsed as 16-bit unsigned integer.]]></description>
     </element>
 
     <element name="poissons_ratio" type="double" default="0.3" required="0">

--- a/sdf/1.7/surface.sdf
+++ b/sdf/1.7/surface.sdf
@@ -141,11 +141,11 @@
     </element>
 
     <element name="collide_bitmask" type="unsigned int" default="65535" required="0">
-      <description>Bitmask for collision filtering. This will override collide_without_contact</description>
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
     </element>
 
     <element name="category_bitmask" type="unsigned int" default="65535" required="0">
-      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask.]]></description>
+      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask. Parsed as 16-bit unsigned integer.]]></description>
     </element>
 
     <element name="poissons_ratio" type="double" default="0.3" required="0">


### PR DESCRIPTION
# 🎉 New feature

## Summary
It was confusing for me reading sdformat docs to figure out what is the allowed range for `<collision_bitmask>` and `<category_bitmask>`. So I improved the text to clearly state they are treated as 16-bit unsigned ints.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**