### PR TITLE
Fixed application of <sensor><pose> tags in lumped linkes during URDF conversion

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -18,6 +18,9 @@ but with improved human-readability..
 
 1. Fixed Atmosphere DOM class's temperature default value. Changed from -0.065 to -0.0065.
     * [Pull request 482](https://github.com/osrf/sdformat/pull/482)
+   
+1. Fixed parsing of `<sensor><pose>` tags on lumped links when converting from URDF.
+    * [Pull request 525](https://github.com/osrf/sdformat/pull/525)
 
 ## SDFormat 9.x to 10.0
 

--- a/src/parser_urdf.cc
+++ b/src/parser_urdf.cc
@@ -2125,6 +2125,8 @@ void InsertSDFExtensionLink(tinyxml2::XMLElement *_elem,
         for (auto blobIt = (*ge)->blobs.begin();
             blobIt != (*ge)->blobs.end(); ++blobIt)
         {
+          // Be sure to always copy only the first element; code in
+          // ReduceSDFExtensionSensorTransformReduction depends in this behavior
           CopyBlob((*blobIt)->FirstChildElement(), _elem);
         }
       }
@@ -3354,8 +3356,8 @@ void ReduceSDFExtensionSensorTransformReduction(
     std::vector<XMLDocumentPtr>::iterator _blobIt,
     ignition::math::Pose3d _reductionTransform)
 {
-  // overwrite <xyz> and <rpy> if they exist
-  if ( strcmp((*_blobIt)->FirstChildElement()->Name(), "sensor") == 0)
+  auto sensorElement = (*_blobIt)->FirstChildElement();
+  if ( strcmp(sensorElement->Name(), "sensor") == 0)
   {
     // parse it and add/replace the reduction transform
     // find first instance of xyz and rpy, replace with reduction transform
@@ -3369,15 +3371,57 @@ void ReduceSDFExtensionSensorTransformReduction(
     //   sdfdbg << "    " << streamIn.CStr() << "\n";
     // }
 
+    auto sensorPose {ignition::math::Pose3d::Zero};
     {
-      tinyxml2::XMLNode *oldPoseKey = (*_blobIt)->FirstChildElement("pose");
-      /// @todo: FIXME:  we should read xyz, rpy and aggregate it to
-      /// reductionTransform instead of just throwing the info away.
+      auto sensorPosText = "0 0 0 0 0 0";
+      const auto& oldPoseKey = sensorElement->FirstChildElement("pose");
       if (oldPoseKey)
       {
-        (*_blobIt)->DeleteChild(oldPoseKey);
+        const auto& poseElemXml = oldPoseKey->ToElement();
+        if (poseElemXml->Attribute("relative_to"))
+          return;
+
+        // see below for explanation; if a sibling element exists, it stores the
+        // original <sensor><pose> tag content
+        const auto& sibling = sensorElement->NextSibling();
+        if (poseElemXml->GetText() && !sibling)
+          sensorPosText = poseElemXml->GetText();
+        else if (sibling && sibling->ToElement()->GetText())
+          sensorPosText = sibling->ToElement()->GetText();
+        else
+        {
+          sdferr << "Unexpected case in sensor pose computation\n";
+          return;
+        }
+
+        // delete the <pose> tag, we'll add a new one at the end
+        sensorElement->DeleteChild(oldPoseKey);
       }
+
+      // parse the 6-tuple text into math::Pose3d
+      std::stringstream  ss;
+      ss.imbue(std::locale::classic());
+      ss << sensorPosText;
+      ss >> sensorPose;
+      if (ss.fail())
+      {
+        sdferr << "Could not parse <sensor><pose>: [" << sensorPosText << "]\n";
+        return;
+      }
+
+      // critical part: we store the original <pose> tag from <sensor> actually
+      // as a sibling of <sensor>... only first element of the blob is processed
+      // further, so its siblings can be used as temporary storage; we store the
+      // original <pose> tag there so that we can use the <sensor><pose> tag
+      // for storing the reduced position
+      auto doc = (*_blobIt)->GetDocument();
+      const auto& poseTxt = doc->NewText(sensorPosText);
+      auto poseKey = doc->NewElement("pose");
+      poseKey->LinkEndChild(poseTxt);
+      (*_blobIt)->LinkEndChild(poseKey);
     }
+
+    _reductionTransform = _reductionTransform * sensorPose;
 
     // convert reductionTransform to values
     urdf::Vector3 reductionXyz(_reductionTransform.Pos().X(),
@@ -3403,7 +3447,7 @@ void ReduceSDFExtensionSensorTransformReduction(
 
     poseKey->LinkEndChild(poseTxt);
 
-    (*_blobIt)->LinkEndChild(poseKey);
+    sensorElement->LinkEndChild(poseKey);
   }
 }
 
@@ -3412,8 +3456,8 @@ void ReduceSDFExtensionProjectorTransformReduction(
     std::vector<XMLDocumentPtr>::iterator _blobIt,
     ignition::math::Pose3d _reductionTransform)
 {
-  // overwrite <pose> (xyz/rpy) if it exists
-  if ( strcmp((*_blobIt)->FirstChildElement()->Name(), "projector") == 0)
+  auto projectorElement = (*_blobIt)->FirstChildElement();
+  if ( strcmp(projectorElement->Name(), "projector") == 0)
   {
     // parse it and add/replace the reduction transform
     // find first instance of xyz and rpy, replace with reduction transform
@@ -3426,15 +3470,58 @@ void ReduceSDFExtensionProjectorTransformReduction(
     //   sdfdbg << "    " << streamIn << "\n";
     // }
 
-    // should read <pose>...</pose> and agregate reductionTransform
-    tinyxml2::XMLNode *poseKey = (*_blobIt)->FirstChildElement("pose");
-    // read pose and save it
-
-    // remove the tag for now
-    if (poseKey)
+    auto projectorPose {ignition::math::Pose3d::Zero};
     {
-      (*_blobIt)->DeleteChild(poseKey);
+      auto projectorPosText = "0 0 0 0 0 0";
+      const auto& oldPoseKey = projectorElement->FirstChildElement("pose");
+      if (oldPoseKey)
+      {
+        const auto& poseElemXml = oldPoseKey->ToElement();
+        if (poseElemXml->Attribute("relative_to"))
+          return;
+
+        // see below for explanation; if a sibling element exists, it stores the
+        // original <projector><pose> tag content
+        const auto& sibling = projectorElement->NextSibling();
+        if (poseElemXml->GetText() && !sibling)
+          projectorPosText = poseElemXml->GetText();
+        else if (sibling && sibling->ToElement()->GetText())
+          projectorPosText = sibling->ToElement()->GetText();
+        else
+        {
+          sdferr << "Unexpected case in projector pose computation\n";
+          return;
+        }
+
+        // delete the <pose> tag, we'll add a new one at the end
+        projectorElement->DeleteChild(oldPoseKey);
+      }
+
+      // parse the 6-tuple text into math::Pose3d
+      std::stringstream  ss;
+      ss.imbue(std::locale::classic());
+      ss << projectorPosText;
+      ss >> projectorPose;
+      if (ss.fail())
+      {
+        sdferr << "Could not parse <projector><pose>: ["
+               << projectorPosText << "]\n";
+        return;
+      }
+
+      // critical part: we store the original <pose> tag from <projector>
+      // actually as a sibling of <projector>... only first element of the blob
+      // is processed further, so its siblings can be used as temporary storage;
+      // we store the original <pose> tag there so that we can use the
+      // <projector><pose> tag for storing the reduced position
+      auto doc = (*_blobIt)->GetDocument();
+      const auto& poseTxt = doc->NewText(projectorPosText);
+      auto poseKey = doc->NewElement("pose");
+      poseKey->LinkEndChild(poseTxt);
+      (*_blobIt)->LinkEndChild(poseKey);
     }
+
+    _reductionTransform = _reductionTransform * projectorPose;
 
     // convert reductionTransform to values
     urdf::Vector3 reductionXyz(_reductionTransform.Pos().X(),
@@ -3456,10 +3543,10 @@ void ReduceSDFExtensionProjectorTransformReduction(
 
     auto* doc = (*_blobIt)->GetDocument();
     tinyxml2::XMLText *poseTxt = doc->NewText(poseStream.str().c_str());
-    poseKey = doc->NewElement("pose");
+    auto poseKey = doc->NewElement("pose");
     poseKey->LinkEndChild(poseTxt);
 
-    (*_blobIt)->LinkEndChild(poseKey);
+    projectorElement->LinkEndChild(poseKey);
   }
 }
 

--- a/test/integration/urdf_gazebo_extensions.cc
+++ b/test/integration/urdf_gazebo_extensions.cc
@@ -136,11 +136,11 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 
       const auto& pose = posePair.first;
 
-      EXPECT_FLOAT_EQ(pose.X(), 333.0);
-      EXPECT_FLOAT_EQ(pose.Y(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Z(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Roll(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Pitch(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
       EXPECT_NEAR(pose.Yaw(), IGN_PI_2, 1e-5);
 
       EXPECT_FALSE(poseElem->GetNextElement("pose"));
@@ -157,11 +157,11 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 
       const auto& pose = posePair.first;
 
-      EXPECT_FLOAT_EQ(pose.X(), 333.0);
-      EXPECT_FLOAT_EQ(pose.Y(), 111.0);
-      EXPECT_FLOAT_EQ(pose.Z(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Roll(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Pitch(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
       EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
 
       EXPECT_FALSE(poseElem->GetNextElement("pose"));
@@ -178,11 +178,11 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 
       const auto& pose = posePair.first;
 
-      EXPECT_FLOAT_EQ(pose.X(), 111.0);
-      EXPECT_FLOAT_EQ(pose.Y(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Z(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Roll(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Pitch(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.X(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
       EXPECT_NEAR(pose.Yaw(), -1, 1e-5);
 
       EXPECT_FALSE(poseElem->GetNextElement("pose"));
@@ -199,11 +199,11 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 
       const auto& pose = posePair.first;
 
-      EXPECT_FLOAT_EQ(pose.X(), 333.0);
-      EXPECT_FLOAT_EQ(pose.Y(), 111.0);
-      EXPECT_FLOAT_EQ(pose.Z(), 222.0);
-      EXPECT_FLOAT_EQ(pose.Roll(), 0.0);
-      EXPECT_FLOAT_EQ(pose.Pitch(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.X(), 333.0);
+      EXPECT_DOUBLE_EQ(pose.Y(), 111.0);
+      EXPECT_DOUBLE_EQ(pose.Z(), 222.0);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.0);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.0);
       EXPECT_NEAR(pose.Yaw(), IGN_PI_2 - 1, 1e-5);
 
       EXPECT_FALSE(poseElem->GetNextElement("pose"));
@@ -220,12 +220,12 @@ TEST(SDFParser, UrdfGazeboExtensionURDFTest)
 
       const auto& pose = posePair.first;
 
-      EXPECT_FLOAT_EQ(pose.X(), 1);
-      EXPECT_FLOAT_EQ(pose.Y(), 2);
-      EXPECT_FLOAT_EQ(pose.Z(), 3);
-      EXPECT_FLOAT_EQ(pose.Roll(), 0.1);
-      EXPECT_FLOAT_EQ(pose.Pitch(), 0.2);
-      EXPECT_FLOAT_EQ(pose.Yaw(), 0.3);
+      EXPECT_DOUBLE_EQ(pose.X(), 1);
+      EXPECT_DOUBLE_EQ(pose.Y(), 2);
+      EXPECT_DOUBLE_EQ(pose.Z(), 3);
+      EXPECT_DOUBLE_EQ(pose.Roll(), 0.1);
+      EXPECT_DOUBLE_EQ(pose.Pitch(), 0.2);
+      EXPECT_DOUBLE_EQ(pose.Yaw(), 0.3);
 
       EXPECT_FALSE(poseElem->GetNextElement("pose"));
     }

--- a/test/integration/urdf_gazebo_extensions.urdf
+++ b/test/integration/urdf_gazebo_extensions.urdf
@@ -137,4 +137,182 @@
     </visual>
   </link>
 
+  <!-- Test lumping of sensors with <pose> tags. -->
+
+  <link name="linkSensorNoPose">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorNoPose" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorNoPose"/>
+  </joint>
+  <gazebo reference="linkSensorNoPose">
+    <sensor name="sensorNoPose" type="camera">
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPose">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPose" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorPose"/>
+  </joint>
+  <gazebo reference="linkSensorPose">
+    <sensor name="sensorPose" type="camera">
+      <pose>111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPoseRelative">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseRelative" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="link0"/>
+    <child link="linkSensorPoseRelative"/>
+  </joint>
+  <gazebo reference="linkSensorPoseRelative">
+    <sensor name="sensorPoseRelative" type="camera">
+      <pose relative_to="link0">111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <link name="linkSensorPoseTwoLevel">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseTwoLevel" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 222"/>
+    <parent link="link0"/>
+    <child link="linkSensorPoseTwoLevel"/>
+  </joint>
+  <link name="linkSensorPoseTwoLevel2">
+    <inertial>
+      <mass value="100"/>
+      <origin rpy="1 3 4" xyz="0 -1.5 0"/>
+      <inertia ixx="2" ixy="0" ixz="0" iyy="3" iyz="0" izz="4"/>
+    </inertial>
+  </link>
+  <joint name="jointSensorPoseTwoLevel2" type="fixed">
+    <origin rpy="0 0 1.57079632679" xyz="333 0 0"/>
+    <parent link="linkSensorPoseTwoLevel"/>
+    <child link="linkSensorPoseTwoLevel2"/>
+  </joint>
+  <gazebo reference="linkSensorPoseTwoLevel2">
+    <sensor name="sensorPoseTwoLevel" type="camera">
+      <pose twoLevel_to="link0">111 0 0 0 0 -1</pose>
+      <update_rate>6.0</update_rate>
+      <camera name="cam">
+        <horizontal_fov>1.36869112579</horizontal_fov>
+        <image>
+          <width>1232</width>
+          <height>1616</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+      </camera>
+    </sensor>
+  </gazebo>
+
+  <!-- Issue 378 setting -->
+  <gazebo reference="issue378_link">
+    <sensor name="issue378_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>400</update_rate>
+      <pose>1.0 2.0 3.0 0.1 0.2 0.3</pose>
+    </sensor>
+  </gazebo>
+  <link name="issue378_link"/>
+  <joint name="issue378_link_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <axis xyz="0 0 0"/>
+    <parent link="link0"/>
+    <child link="issue378_link"/>
+  </joint>
+
+  <!-- Issue 67 setting -->
+  <link name="Camera">
+    <inertial>
+      <origin xyz="-7.4418E-06 0.0043274 -0.010112" rpy="0 0 0"/>
+      <mass value="0.10621"/>
+      <inertia ixx="7.3134E-05" ixy="7.9651E-09" ixz="-8.9146E-09"
+              iyy="3.0769E-05" iyz="-3.9082E-06"
+              izz="9.2194E-05"/>
+    </inertial>
+  </link>
+  <joint name="jCamera" type="fixed">
+    <origin xyz="-0.20115 0.42488 0.30943" rpy="1.5708 -0.89012 1.5708"/>
+    <parent link="link0"/>
+    <child link="Camera"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <gazebo reference="Camera">
+    <sensor name="issue67_sensor" type="camera">
+      <visualize>true</visualize>
+      <pose>1 1 1 1.570796 1.570796 1.570796</pose>
+      <camera>
+      </camera>
+    </sensor>
+  </gazebo>
+
 </robot>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #67 and #378.

## Summary
There is a TODO in

https://github.com/osrf/sdformat/blob/8496164cac259e13083023efb06b76a04b1f8d3e/src/parser_urdf.cc#L3374-L3375 

which states that `<sensor><pose>` tags are being silently ignored. This is the culprit of bugs #67 and #378. And of many headaches people spend converting their sensors, finding out after hours that they have to attach them to non-lumped links without any offset for the conversion to work.

This PR fixes the behavior and adds correct processing of `<sensor><pose>` and `<projector><pose>` for lumped links.

In addition to ignoring the `<sensor><pose>` values, there is also weird behavior. First,

https://github.com/osrf/sdformat/blob/8496164cac259e13083023efb06b76a04b1f8d3e/src/parser_urdf.cc#L3378

thinks it deletes the user-specified `<sensor><pose>` tag.

Second,

https://github.com/osrf/sdformat/blob/8496164cac259e13083023efb06b76a04b1f8d3e/src/parser_urdf.cc#L3406

thinks it adds the computed transform to `<sensor><pose>`.

The problem is that both of these lines of code work one level higher than they should. `(*_blobIt)` is a XML snippet containing the `<sensor>` tag, so there is no direct child `<pose>` of `(*_blobIt)`. The second line then adds a new element `<pose>`, but again, as a sibling of `<sensor>`, not as a child. This is interesting and might have had unforseen consequences (as multiple pose tags are allowed, at least syntactically). Fortunately, there is a guard at 

https://github.com/osrf/sdformat/blob/8496164cac259e13083023efb06b76a04b1f8d3e/src/parser_urdf.cc#L2128

that only allows the first child of `(*_blobIt)` to be passed further. This might look like another bug, but I actually utilized this behavior sealing it for the future (it has been this way for a decade, so...).

Currently, when there is no `<sensor><pose>` specified, the conversion process doesn't emit any `<sensor><pose>` in the end, even though it should accumulate something and I see it adding and removing the XML fragments. That is because of the fact it adds the `<pose>` at wrong level, and in the next level, it deletes/re-adds this sibling of `<sensor>`. With `<sensor><pose>` manually specified, it makes it appear in the result (but without the accumulated transform). That's because the `DeleteChild` function has no effect on `<sensor><pose>` but deletes the sibling `<pose>` instead (TinyXML2 doesn't fail when deleting a wrong child).

The fix I propose in this PR is somewhat complicated to grasp on. First idea of just storing `_reductionTransform * sensorPose` in the `<sensor><pose>` field does not work as all but the first lump transforms get doubled. What I do is I take the `<sensor><pose>` when first encountering it and store the `<pose>` as a sibling of `<sensor>`. As said earlier, this sibling will not bubble up anywhere, but it is the scratchpad that is needed. `<sensor><pose>` is then used for storing the actual `_reductionTransform * sensorPose`. What is important is that the original `<sensor><pose>` is not updated and we always have access to it in the original form, so that we can take the recursively computed reduction transform and add the sensor pose exactly once.

I was also looking for a nicer way to parse the 6-tuple transform string, but haven't found any usable part of the library. If you know how e.g. `sdf::Param` could be used to simplify and reuse-ify the code, let me know.

I also added a comprehensive test suite based on both mentioned issues and my experiments. I also verified the change running `ign sdf -p` on https://github.com/osrf/subt/tree/master/submitted_models/ctu_cras_norlab_absolem_sensor_config_1 model which might go as deep as 10 levels of joints/links (or maybe even more) with sensors at the very tips. I tried exchanging the last link transform for a sensor pose and the result was the same.

---

As a workaround until this PR is merged, this is what can be done. 

1. Attach the sensor to a non-lumped link and make the origins of the link and the sensor identical. Non-lumped links are set by `<preserveFixedJoint>true</preserveFixedJoint>`
2. If you want to have the sensor on a lumped link, you have to manually compute the transformation of the sensor to its nearest non-lumped link. Once you have this transformation, add it in `<sensor><pose>`. Even though it seems you're duplicating the tree-induced transform by the `<pose>` tag, you are not because of the reported bugs. 

---

Interestingly, the part of code I fixed was mostly untouched for 8 years. However, it seems that `gz sdf -p` from Gazebo 9 behaves differently.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed) **(how should I do it before submitting the PR when there is need to write down the PR number I don't yet have?)**
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
