### PR TITLE
Particle emitter

### DIFF
--- a/include/sdf/CMakeLists.txt
+++ b/include/sdf/CMakeLists.txt
@@ -32,6 +32,7 @@ set (headers
   Noise.hh
   Param.hh
   parser.hh
+  ParticleEmitter.hh
   Pbr.hh
   Physics.hh
   Plane.hh

--- a/include/sdf/Link.hh
+++ b/include/sdf/Link.hh
@@ -36,6 +36,7 @@ namespace sdf
   class Collision;
   class Light;
   class LinkPrivate;
+  class ParticleEmitter;
   class Sensor;
   class Visual;
   class LinkPrivate;
@@ -170,6 +171,32 @@ namespace sdf
     ///  does not exist.
     /// \sa bool SensorNameExists(const std::string &_name) const
     public: const Sensor *SensorByName(const std::string &_name) const;
+
+    /// \brief Get the number of particle emitters.
+    /// \return Number of particle emitters contained in this Link object.
+    public: uint64_t ParticleEmitterCount() const;
+
+    /// \brief Get a particle emitter based on an index.
+    /// \param[in] _index Index of the particle emitter.
+    /// The index should be in the range [0..ParticleEmitterCount()).
+    /// \return Pointer to the particle emitter. Nullptr if the index does
+    /// not exist.
+    /// \sa uint64_t ParticleEmitterCount() const
+    public: const ParticleEmitter *ParticleEmitterByIndex(
+                const uint64_t _index) const;
+
+    /// \brief Get whether a particle emitter name exists.
+    /// \param[in] _name Name of the particle emitter to check.
+    /// \return True if there exists a particle emitter with the given name.
+    public: bool ParticleEmitterNameExists(const std::string &_name) const;
+
+    /// \brief Get a particle emitter based on a name.
+    /// \param[in] _name Name of the particle emitter.
+    /// \return Pointer to the particle emitter. Nullptr if a particle emitter
+    /// with the given name does not exist.
+    /// \sa bool ParticleEmitterNameExists(const std::string &_name) const
+    public: const ParticleEmitter *ParticleEmitterByName(
+                const std::string &_name) const;
 
     /// \brief Get the inertial value for this link. The inertial object
     /// consists of the link's mass, a 3x3 rotational inertia matrix, and

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -63,7 +63,7 @@ namespace sdf
     public: ParticleEmitter();
 
     /// \brief Copy constructor
-    /// \param[in] _emitter Model to copy.
+    /// \param[in] _emitter Particle emitter to copy.
     public: ParticleEmitter(const ParticleEmitter &_emitter);
 
     /// \brief Move constructor
@@ -83,7 +83,7 @@ namespace sdf
     /// \brief Destructor
     public: ~ParticleEmitter();
 
-    /// \brief Load the particle emitter based on a element pointer. This is
+    /// \brief Load the particle emitter based on an element pointer. This is
     /// *not* the usual entry point. Typical usage of the SDF DOM is through
     /// the Root object.
     /// \param[in] _sdf The SDF Element pointer
@@ -136,7 +136,7 @@ namespace sdf
     public: void SetEmitting(bool _emitting);
 
     /// \brief Get the number of seconds the emitter is active.
-    /// A value of 0 means infinite duration.
+    /// A value less than or equal to zero indicates infinite duration.
     /// \return The number of seconds the emitter is active.
     public: double Duration() const;
 
@@ -152,7 +152,8 @@ namespace sdf
 
     /// \brief Set the number of seconds each particle will 'live' for.
     /// \param[in] _duration The number of seconds a particle will 'life'
-    /// for.
+    /// for. If _duration is <= 0, then the
+    /// value std::numeric_limits<double>::min() will be used.
     public: void SetLifetime(double _duration);
 
     /// \brief Get the number of particles per second that should be
@@ -163,6 +164,7 @@ namespace sdf
     /// \brief Set the number of particles per second that should be
     /// emitted.
     /// \param[in] _rate The number of particle to emit per second.
+    /// A value of zero will be used if _rate is negative.
     public: void SetRate(double _rate);
 
     /// \brief Get the amount by which to scale the particles in both x
@@ -173,6 +175,7 @@ namespace sdf
     /// \brief Set the amount by which to scale the particles in both x
     /// and y direction per second.
     /// \param[in] _scaleRate The caling amount in the x and y directions.
+    /// A value of zero will be used if _scaleRate is negative.
     public: void SetScaleRate(double _scaleRate);
 
     /// \brief Get the minimum velocity for each particle.
@@ -181,6 +184,7 @@ namespace sdf
 
     /// \brief Set the minimum velocity for each particle.
     /// \param[in] _vel The minimum velocity for each particle in m/s.
+    /// A value of zero will be used if _vel is negative.
     public: void SetMinVelocity(double _vel);
 
     /// \brief Get the maximum velocity for each particle.
@@ -189,6 +193,7 @@ namespace sdf
 
     /// \brief Set the maximum velocity for each particle.
     /// \param[in] _vel The maximum velocity for each particle in m/s.
+    /// A value of zero will be used if _vel is negative.
     public: void SetMaxVelocity(double _vel);
 
     /// \brief Get the size of the emitter where the particles are sampled.
@@ -209,8 +214,10 @@ namespace sdf
 
     /// \brief Set the size of the emitter where the particles are sampled.
     /// \param[in] _size Size of the emitter in meters.
+    /// Each component of _size must be greater than or equal to zero. Any
+    /// negative value will be replaced with zero.
     /// \sa ignition::math::Vector3d Size()
-    public: void SetSize(const ignition::math::Vector3d _size);
+    public: void SetSize(const ignition::math::Vector3d &_size);
 
     /// \brief Get the size of a particle in meters.
     /// \return Size of a particle in meters.
@@ -218,7 +225,9 @@ namespace sdf
 
     /// \brief Set the size of a particle in meters.
     /// \param[in] _size Size of a particle in meters.
-    public: void SetParticleSize(const ignition::math::Vector3d _size);
+    /// Each component of _size must be greater than or equal to zero. Any
+    /// negative value will be replaced with zero.
+    public: void SetParticleSize(const ignition::math::Vector3d &_size);
 
     /// \brief Gets the starting color for all particles emitted.
     /// The actual color will be interpolated between this color
@@ -252,6 +261,8 @@ namespace sdf
     /// color values begins from the left side of the image and moves to the
     /// right over the lifetime of the particle, therefore only the horizontal
     /// dimension of the image is used.
+    /// The ColorRangeImage has higher priority than ColorEnd and
+    /// ColorStart. If all three are set, ColorRangeImage should be used.
     public: std::string ColorRangeImage() const;
 
     /// \brief Set the path to the color image used as an affector.

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef SDF_PARTICLE_EMITTER_HH_
+#define SDF_PARTICLE_EMITTER_HH_
+
+#include <string>
+
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include "sdf/Material.hh"
+#include "sdf/SemanticPose.hh"
+#include "sdf/Types.hh"
+#include "sdf/sdf_config.h"
+#include "sdf/system_util.hh"
+
+namespace sdf
+{
+  // Inline bracket to help doxygen filtering.
+  inline namespace SDF_VERSION_NAMESPACE {
+  // Forward declarations.
+  class ParticleEmitterPrivate;
+  struct PoseRelativeToGraph;
+
+  /// \enum ParticleEmitterType
+  /// \brief The set of particle emitter types.
+  // Developer note: Make sure to update emitterTypeStrs in the source
+  // file when changing this enum.
+  enum class ParticleEmitterType
+  {
+    /// \brief A point emitter.
+    POINT = 0,
+
+    /// \brief A box emitter.
+    BOX = 1,
+
+    /// \brief A cylinder emitter.
+    CYLINDER = 2,
+
+    /// \brief An ellipsoid.
+    ELLIPSOID = 3,
+  };
+
+  class SDFORMAT_VISIBLE ParticleEmitter
+  {
+    /// \brief Default constructor
+    public: ParticleEmitter();
+
+    /// \brief Copy constructor
+    /// \param[in] _emitter Model to copy.
+    public: ParticleEmitter(const ParticleEmitter &_emitter);
+
+    /// \brief Move constructor
+    /// \param[in] _model Model to move.
+    public: ParticleEmitter(ParticleEmitter &&_emitter) noexcept;
+
+    /// \brief Move assignment operator.
+    /// \param[in] _emitter Particle emitter to move.
+    /// \return Reference to this.
+    public: ParticleEmitter &operator=(ParticleEmitter &&_emitter);
+
+    /// \brief Copy assignment operator.
+    /// \param[in] _emitter Particle emitter to copy.
+    /// \return Reference to this.
+    public: ParticleEmitter &operator=(const ParticleEmitter &_emitter);
+
+    /// \brief Destructor
+    public: ~ParticleEmitter();
+
+    /// \brief Load the particle emitter based on a element pointer. This is
+    /// *not* the usual entry point. Typical usage of the SDF DOM is through
+    /// the Root object.
+    /// \param[in] _sdf The SDF Element pointer
+    /// \return Errors, which is a vector of Error objects. Each Error includes
+    /// an error code and message. An empty vector indicates no error.
+    public: Errors Load(ElementPtr _sdf);
+
+    /// \brief Get the name of the particle emitter.
+    /// The name of the particle emitter should be unique within the scope of
+    /// a Link.
+    /// \return Name of the particle emitter.
+    public: std::string Name() const;
+
+    /// \brief Set the name of the particle emitter.
+    /// The name of the particle emitter should be unique within the scope of
+    /// a Link.
+    /// \param[in] _name Name of the particle emitter.
+    public: void SetName(const std::string &_name);
+
+    /// \brief Get the type of the particle emitter.
+    /// The type of the particle emitter should be unique within the scope of
+    /// a Link.
+    /// \return Type of the particle emitter.
+    public: ParticleEmitterType Type() const;
+
+    /// \brief Set the type of the particle emitter.
+    /// \param[in] _type Type of the particle emitter.
+    public: void SetType(const ParticleEmitterType _type);
+
+    /// \brief Set the type of the particle emitter.
+    /// The type of the particle emitter should be unique within the scope of
+    /// a Link.
+    /// \param[in] _type Type of the particle emitter.
+    /// \return True if the _typeStr parameter matched a known emitter type.
+    /// False if the emitter type could not be set.
+    public: bool SetType(const std::string &_typeStr);
+
+    /// \brief Get the particle emitter type as a string.
+    /// \return The particle emitter type as a string.
+    public: std::string TypeStr() const;
+
+    /// \brief Get whether the particle emitter is running, emitting
+    /// particles.
+    /// \return True if emitting particles.
+    public: bool Emitting() const;
+
+    /// \brief Set whether the particle emitter is running, emitting
+    /// particles.
+    /// \param[in] _emitting True if the emitter should produce particles.
+    public: void SetEmitting(bool _emitting);
+
+    /// \brief Get the number of seconds the emitter is active.
+    /// A value of 0 means infinite duration.
+    /// \return The number of seconds the emitter is active.
+    public: double Duration() const;
+
+    /// \brief Set the number of seconds the emitter is active.
+    /// \param[in] _duration The number of seconds the emitter is active.
+    /// A value of 0 means infinite duration.
+    public: void SetDuration(double _duration);
+
+    /// \brief Get the number of seconds each particle will 'live' for
+    /// before being destroyed.
+    /// \return The lifetime of a particle in seconds.
+    public: double Lifetime() const;
+
+    /// \brief Set the number of seconds each particle will 'live' for.
+    /// \param[in] _duration The number of seconds a particle will 'life'
+    /// for.
+    public: void SetLifetime(double _duration);
+
+    /// \brief Get the number of particles per second that should be
+    /// emitted.
+    /// \return The number of particles to emitt per second.
+    public: double Rate() const;
+
+    /// \brief Set the number of particles per second that should be
+    /// emitted.
+    /// \param[in] _rate The number of seconds a particle will 'life'
+    /// for.
+    public: void SetRate(double _rate);
+
+    /// \brief Get the amount by which to scale the particles in both x
+    /// and y direction per second.
+    /// \return The scaling amount in the x and y directions.
+    public: double ScaleRate() const;
+
+    /// \brief Set the amount by which to scale the particles in both x
+    /// and y direction per second.
+    /// \param[in] _scaleRate The caling amount in the x and y directions.
+    public: void SetScaleRate(double _scaleRate);
+
+    /// \brief Get the minimum velocity for each particle.
+    /// \return The minimum velocity for each particle in m/s.
+    public: double MinVelocity() const;
+
+    /// \brief Set the minimum velocity for each particle.
+    /// \param[in] _vel The minimum velocity for each particle in m/s.
+    public: void SetMinVelocity(double _vel);
+
+    /// \brief Get the maximum velocity for each particle.
+    /// \return The maximum velocity for each particle in m/s.
+    public: double MaxVelocity() const;
+
+    /// \brief Set the maximum velocity for each particle.
+    /// \param[in] _vel The maximum velocity for each particle in m/s.
+    public: void SetMaxVelocity(double _vel);
+
+    /// \brief Get the size of the emitter where the particles are sampled.
+    // Default value is (1, 1, 1).
+    // Note that the interpretation of the emitter area varies
+    // depending on the emmiter type:
+    //   - point: The area is ignored.
+    //   - box: The area is interpreted as width X height X depth.
+    //   - cylinder: The area is interpreted as the bounding box of the
+    //               cilinder. The cylinder is oriented along the Z-axis.
+    //   - ellipsoid: The area is interpreted as the bounding box of an
+    //                ellipsoid shaped area, i.e. a sphere or
+    //                squashed-sphere area. The parameters are again
+    //                identical to EM_BOX, except that the dimensions
+    //                describe the widest points along each of the axes.
+    /// \return Size of the emitter region in meters..
+    public: ignition::math::Vector3d Size() const;
+
+    /// \brief Set the size of the emitter where the particles are sampled.
+    /// \param[in] _size Size of the emitter in meters..
+    /// \sa ignition::math::Vector3d Size()
+    public: void SetSize(const ignition::math::Vector3d _size);
+
+    /// \brief Get the size of a particle.
+    /// \return Size of a particle in meters.
+    public: ignition::math::Vector3d ParticleSize() const;
+
+    /// \brief Set the size of a particle.
+    /// \param[in] _size Size of a particle in meters.
+    public: void SetParticleSize(const ignition::math::Vector3d _size);
+
+    /// \brief Gets the starting color for all particles emitted.
+    /// The actual color will be interpolated between this color
+    /// and the one set under <color_end>.
+    /// Color::White is the default color for the particles
+    /// unless a specific function is used.
+    /// To specify a color, RGB values should be passed in.
+    /// For example, to specify red, a user should enter:
+    /// <color_start>1 0 0</color_start>
+    /// \return The starting color.
+    public: ignition::math::Color ColorStart() const;
+
+    /// \brief Set the starting color for all particles emitted.
+    /// \param[in] _colorStart The starting color for all particles emitted.
+    /// \sa ignition::math::Color ColorStart()
+    public: void SetColorStart(const ignition::math::Color &_colorStart);
+
+    /// \brief Get the end color for all particles emitted.
+    /// The actual color will be interpolated between this color
+    /// and the one set under <color_start>.
+    /// Color::White is the default color for the particles
+    /// unless a specific function is used (see color_start for
+    /// more information about defining custom colors with RGB
+    /// values).
+    /// \return The end color.
+    public: ignition::math::Color ColorEnd() const;
+
+    /// \brief Set the end color for all particles emitted.
+    /// \param[in] _colorEnd The end color for all particles emitted.
+    /// \sa ignition::math::Color ColorEnd()
+    public: void SetColorEnd(const ignition::math::Color &_colorEnd);
+
+    /// \brief Get the path to the color image used as an affector.
+    /// This affector modifies the color of particles in flight.
+    /// The colors are taken from a specified image file. The range of
+    /// color values begins from the left side of the image and moves to the
+    /// right over the lifetime of the particle, therefore only the horizontal
+    /// dimension of the image is used.
+    public: std::string ColorRangeImage() const;
+
+    /// \brief Set the path to the color image used as an affector.
+    /// \param[in] _image The path to the color image.
+    /// \sa std::String ColorRangeImage()
+    public: void SetColorRangeImage(const std::string &_image);
+
+    /// \brief Get the topic used to update the particle emitter properties.
+    /// \return The topic used to update the particle emitter.
+    public: std::string Topic() const;
+
+    /// \brief Set the topic used to update the particle emitter properties.
+    /// \param[in] _topic The topic used to update the particle emitter.
+    public: void SetTopic(const std::string &_topic);
+
+    /// \brief Get the pose of the particle emitter. This is the pose of the
+    /// emitter as specified in SDF
+    /// (<particle_emitter><pose> ... </pose></particle_emitter>).
+    /// \return The pose of the particle emitter.
+    public: const ignition::math::Pose3d &RawPose() const;
+
+    /// \brief Set the pose of the particle emitter object.
+    /// \sa const ignition::math::Pose3d &RawPose() const
+    /// \param[in] _pose The pose of the particle emitter.
+    public: void SetRawPose(const ignition::math::Pose3d &_pose);
+
+    /// \brief Get the name of the coordinate frame relative to which this
+    /// emitter's pose is expressed. An empty value indicates that the frame is
+    /// relative to the parent link.
+    /// \return The name of the pose relative-to frame.
+    public: const std::string &PoseRelativeTo() const;
+
+    /// \brief Set the name of the coordinate frame relative to which this
+    /// emitter's pose is expressed. An empty value indicates that the frame is
+    /// relative to the parent link.
+    /// \param[in] _frame The name of the pose relative-to frame.
+    public: void SetPoseRelativeTo(const std::string &_frame);
+
+    /// \brief Get SemanticPose object of this object to aid in resolving
+    /// poses.
+    /// \return SemanticPose object for this emitter.
+    public: sdf::SemanticPose SemanticPose() const;
+
+    /// \brief Get a pointer to the SDF element that was used during
+    /// load.
+    /// \return SDF element pointer. The value will be nullptr if Load has
+    /// not been called.
+    public: sdf::ElementPtr Element() const;
+
+    /// \brief Get a pointer to the emitter's material properties. This can
+    /// be a nullptr if material properties have not been set.
+    /// \return Pointer to the visual's material properties. Nullptr
+    /// indicates that material properties have not been set.
+    public: sdf::Material *Material() const;
+
+    /// \brief Set the emitter's material
+    /// \param[in] _material The material of the particle emitter.
+    public: void SetMaterial(const sdf::Material &_material);
+
+    /// \brief The path to the file where this element was loaded from.
+    /// \return Full path to the file on disk.
+    public: const std::string &FilePath() const;
+
+    /// \brief Set the path to the file where this element was loaded from.
+    /// \paramp[in] _filePath Full path to the file on disk.
+    public: void SetFilePath(const std::string &_filePath);
+
+    /// \brief Give the name of the xml parent of this object, to be used
+    /// for resolving poses. This is private and is intended to be called by
+    /// Link::SetPoseRelativeToGraph.
+    /// \param[in] _xmlParentName Name of xml parent object.
+    private: void SetXmlParentName(const std::string &_xmlParentName);
+
+    /// \brief Give a weak pointer to the PoseRelativeToGraph to be used
+    /// for resolving poses. This is private and is intended to be called by
+    /// Link::SetPoseRelativeToGraph.
+    /// \param[in] _graph Weak pointer to PoseRelativeToGraph.
+    private: void SetPoseRelativeToGraph(
+        std::weak_ptr<const PoseRelativeToGraph> _graph);
+
+    /// \brief Allow Link::SetPoseRelativeToGraph to call SetXmlParentName
+    /// and SetPoseRelativeToGraph, but Link::SetPoseRelativeToGraph is
+    /// a private function, so we need to befriend the entire class.
+    friend class Link;
+
+    /// \brief Private data pointer.
+    private: ParticleEmitterPrivate *dataPtr = nullptr;
+  };
+  }
+}
+#endif

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -156,13 +156,11 @@ namespace sdf
     /// value std::numeric_limits<double>::min() will be used.
     public: void SetLifetime(double _duration);
 
-    /// \brief Get the number of particles per second that should be
-    /// emitted.
+    /// \brief Get the number of particles per second that should be emitted.
     /// \return The number of particles to emit per second.
     public: double Rate() const;
 
-    /// \brief Set the number of particles per second that should be
-    /// emitted.
+    /// \brief Set the number of particles per second that should be emitted.
     /// \param[in] _rate The number of particle to emit per second.
     /// A value of zero will be used if _rate is negative.
     public: void SetRate(double _rate);
@@ -203,7 +201,7 @@ namespace sdf
     //   - point: The area is ignored.
     //   - box: The area is interpreted as width X height X depth.
     //   - cylinder: The area is interpreted as the bounding box of the
-    //               cyilinder. The cylinder is oriented along the Z-axis.
+    //               cylinder. The cylinder is oriented along the Z-axis.
     //   - ellipsoid: The area is interpreted as the bounding box of an
     //                ellipsoid shaped area, i.e. a sphere or
     //                squashed-sphere area. The parameters are again
@@ -301,13 +299,11 @@ namespace sdf
     /// \param[in] _frame The name of the pose relative-to frame.
     public: void SetPoseRelativeTo(const std::string &_frame);
 
-    /// \brief Get SemanticPose object of this object to aid in resolving
-    /// poses.
+    /// \brief Get SemanticPose object of this object to aid in resolving poses.
     /// \return SemanticPose object for this emitter.
     public: sdf::SemanticPose SemanticPose() const;
 
-    /// \brief Get a pointer to the SDF element that was used during
-    /// load.
+    /// \brief Get a pointer to the SDF element that was used during load.
     /// \return SDF element pointer. The value will be nullptr if Load has
     /// not been called.
     public: sdf::ElementPtr Element() const;

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -50,10 +50,13 @@ namespace sdf
     /// \brief A cylinder emitter.
     CYLINDER = 2,
 
-    /// \brief An ellipsoid.
+    /// \brief An ellipsoid emitter.
     ELLIPSOID = 3,
   };
 
+  /// \brief A description of a particle emitter, which can be attached
+  /// to a link. A particle emitter can be used to describe fog, smoke, and
+  /// dust.
   class SDFORMAT_VISIBLE ParticleEmitter
   {
     /// \brief Default constructor
@@ -64,7 +67,7 @@ namespace sdf
     public: ParticleEmitter(const ParticleEmitter &_emitter);
 
     /// \brief Move constructor
-    /// \param[in] _model Model to move.
+    /// \param[in] _model Emitter to move.
     public: ParticleEmitter(ParticleEmitter &&_emitter) noexcept;
 
     /// \brief Move assignment operator.
@@ -113,7 +116,7 @@ namespace sdf
     /// \brief Set the type of the particle emitter.
     /// The type of the particle emitter should be unique within the scope of
     /// a Link.
-    /// \param[in] _type Type of the particle emitter.
+    /// \param[in] _typeStr Type of the particle emitter.
     /// \return True if the _typeStr parameter matched a known emitter type.
     /// False if the emitter type could not be set.
     public: bool SetType(const std::string &_typeStr);
@@ -122,9 +125,9 @@ namespace sdf
     /// \return The particle emitter type as a string.
     public: std::string TypeStr() const;
 
-    /// \brief Get whether the particle emitter is running, emitting
-    /// particles.
-    /// \return True if emitting particles.
+    /// \brief Get whether the particle emitter should run (emit
+    /// particles).
+    /// \return True if particles should be emitted.
     public: bool Emitting() const;
 
     /// \brief Set whether the particle emitter is running, emitting
@@ -139,7 +142,7 @@ namespace sdf
 
     /// \brief Set the number of seconds the emitter is active.
     /// \param[in] _duration The number of seconds the emitter is active.
-    /// A value of 0 means infinite duration.
+    /// A value less than or equal to zero means infinite duration.
     public: void SetDuration(double _duration);
 
     /// \brief Get the number of seconds each particle will 'live' for
@@ -154,13 +157,12 @@ namespace sdf
 
     /// \brief Get the number of particles per second that should be
     /// emitted.
-    /// \return The number of particles to emitt per second.
+    /// \return The number of particles to emit per second.
     public: double Rate() const;
 
     /// \brief Set the number of particles per second that should be
     /// emitted.
-    /// \param[in] _rate The number of seconds a particle will 'life'
-    /// for.
+    /// \param[in] _rate The number of particle to emit per second.
     public: void SetRate(double _rate);
 
     /// \brief Get the amount by which to scale the particles in both x
@@ -196,36 +198,33 @@ namespace sdf
     //   - point: The area is ignored.
     //   - box: The area is interpreted as width X height X depth.
     //   - cylinder: The area is interpreted as the bounding box of the
-    //               cilinder. The cylinder is oriented along the Z-axis.
+    //               cyilinder. The cylinder is oriented along the Z-axis.
     //   - ellipsoid: The area is interpreted as the bounding box of an
     //                ellipsoid shaped area, i.e. a sphere or
     //                squashed-sphere area. The parameters are again
     //                identical to EM_BOX, except that the dimensions
     //                describe the widest points along each of the axes.
-    /// \return Size of the emitter region in meters..
+    /// \return Size of the emitter region in meters.
     public: ignition::math::Vector3d Size() const;
 
     /// \brief Set the size of the emitter where the particles are sampled.
-    /// \param[in] _size Size of the emitter in meters..
+    /// \param[in] _size Size of the emitter in meters.
     /// \sa ignition::math::Vector3d Size()
     public: void SetSize(const ignition::math::Vector3d _size);
 
-    /// \brief Get the size of a particle.
+    /// \brief Get the size of a particle in meters.
     /// \return Size of a particle in meters.
     public: ignition::math::Vector3d ParticleSize() const;
 
-    /// \brief Set the size of a particle.
+    /// \brief Set the size of a particle in meters.
     /// \param[in] _size Size of a particle in meters.
     public: void SetParticleSize(const ignition::math::Vector3d _size);
 
     /// \brief Gets the starting color for all particles emitted.
     /// The actual color will be interpolated between this color
-    /// and the one set under <color_end>.
+    /// and the one set using ColorEnd().
     /// Color::White is the default color for the particles
     /// unless a specific function is used.
-    /// To specify a color, RGB values should be passed in.
-    /// For example, to specify red, a user should enter:
-    /// <color_start>1 0 0</color_start>
     /// \return The starting color.
     public: ignition::math::Color ColorStart() const;
 
@@ -236,11 +235,9 @@ namespace sdf
 
     /// \brief Get the end color for all particles emitted.
     /// The actual color will be interpolated between this color
-    /// and the one set under <color_start>.
+    /// and the one set under ColorStart().
     /// Color::White is the default color for the particles
-    /// unless a specific function is used (see color_start for
-    /// more information about defining custom colors with RGB
-    /// values).
+    /// unless a specific function is used.
     /// \return The end color.
     public: ignition::math::Color ColorEnd() const;
 
@@ -306,7 +303,7 @@ namespace sdf
 
     /// \brief Get a pointer to the emitter's material properties. This can
     /// be a nullptr if material properties have not been set.
-    /// \return Pointer to the visual's material properties. Nullptr
+    /// \return Pointer to the emitter's material properties. Nullptr
     /// indicates that material properties have not been set.
     public: sdf::Material *Material() const;
 
@@ -322,13 +319,13 @@ namespace sdf
     /// \paramp[in] _filePath Full path to the file on disk.
     public: void SetFilePath(const std::string &_filePath);
 
-    /// \brief Give the name of the xml parent of this object, to be used
+    /// \brief Set the name of the xml parent of this object, to be used
     /// for resolving poses. This is private and is intended to be called by
     /// Link::SetPoseRelativeToGraph.
     /// \param[in] _xmlParentName Name of xml parent object.
     private: void SetXmlParentName(const std::string &_xmlParentName);
 
-    /// \brief Give a weak pointer to the PoseRelativeToGraph to be used
+    /// \brief Set a weak pointer to the PoseRelativeToGraph to be used
     /// for resolving poses. This is private and is intended to be called by
     /// Link::SetPoseRelativeToGraph.
     /// \param[in] _graph Weak pointer to PoseRelativeToGraph.

--- a/include/sdf/SemanticPose.hh
+++ b/include/sdf/SemanticPose.hh
@@ -111,6 +111,7 @@ namespace sdf
     friend class Joint;
     friend class Light;
     friend class Link;
+    friend class ParticleEmitter;
     friend class Model;
     friend class Sensor;
     friend class Visual;

--- a/sdf/1.6/link.sdf
+++ b/sdf/1.6/link.sdf
@@ -47,5 +47,6 @@
   <include filename="audio_source.sdf" required="*"/>
   <include filename="battery.sdf" required="*"/>
   <include filename="light.sdf" required="*"/>
+  <include filename="particle_emitter.sdf" required="*"/>
 
 </element> <!-- End Link -->

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -15,7 +15,7 @@
   </element>
 
   <element name="duration" type="double" default="0" required="0">
-    <description>The number of seconds the emitter is active. A value of <=0 means infinite duration.</description>
+    <description>The number of seconds the emitter is active. A value less than or equal to zero means infinite duration.</description>
   </element>
 
   <element name="size" type="vector3" default="1 1 1" required="0">
@@ -41,22 +41,22 @@
   </element>
 
   <element name="lifetime" type="double" default="5" required="0">
-    <description>The number of seconds each particle will ’live’ for before being destroyed. Default value is 5.</description>
+    <description>The number of seconds each particle will ’live’ for before being destroyed. This value must be greater than zero.</description>
   </element>
 
-  <element name="rate" type="double" default="10" required="0">
+  <element name="rate" type="double" default="10" required="0" min="0.0">
     <description>The number of particles per second that should be emitted.</description>
   </element>
 
-  <element name="min_velocity" type="double" default="1" required="0">
+  <element name="min_velocity" type="double" default="1" required="0" min="0.0">
     <description>Sets a minimum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="max_velocity" type="double" default="1" required="0">
+  <element name="max_velocity" type="double" default="1" required="0" min="0.0">
     <description>Sets a maximum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="scale_rate" type="double" default="1" required="0">
+  <element name="scale_rate" type="double" default="1" required="0" min="0.0">
     <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
   </element>
 

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -27,7 +27,7 @@
       - point: The area is ignored.
       - box: The area is interpreted as width X height X depth.
       - cylinder: The area is interpreted as the bounding box of the
-                  cyilinder. The cylinder is oriented along the Z-axis.
+                  cylinder. The cylinder is oriented along the Z-axis.
       - ellipsoid: The area is interpreted as the bounding box of an
                    ellipsoid shaped area, i.e. a sphere or
                    squashed-sphere area. The parameters are again

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -1,0 +1,109 @@
+<!-- Particle emitter -->
+<element name="particle_emitter" required="*">
+  <description>A particle emitter that can be used to describe fog, smoke, and dust.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the particle emitter.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="point" required="1">
+    <description>The type of a particle emitter. One of "box", "cylinder", "ellipsoid", or "point".</description>
+  </attribute>
+
+  <element name="emitting" type="bool" default="true" required="0">
+    <description>True indicates that the particle emitter should generate particles when loaded</description>
+  </element>
+
+  <element name="duration" type="double" default="0" required="0">
+    <description>The number of seconds the emitter is active. A value of 0 means infinite duration.</description>
+  </element>
+
+  <element name="size" type="vector3" default="1 1 1" required="0">
+    <description>
+    The size of the emitter where the particles are sampled.
+    Default value is (1, 1, 1).
+    Note that the interpretation of the emitter area varies
+    depending on the emmiter type:
+      - point: The area is ignored.
+      - box: The area is interpreted as width X height X depth.
+      - cylinder: The area is interpreted as the bounding box of the
+                  cilinder. The cylinder is oriented along the Z-axis.
+      - ellipsoid: The area is interpreted as the bounding box of an
+                   ellipsoid shaped area, i.e. a sphere or
+                   squashed-sphere area. The parameters are again
+                   identical to EM_BOX, except that the dimensions
+                   describe the widest points along each of the axes.
+    </description>
+  </element>
+
+  <element name="particle_size" type="vector3" default="1 1 1" required="0">
+    <description>The particle dimensions (width, height, depth).</description>
+  </element>
+
+  <element name="lifetime" type="double" default="5" required="0">
+    <description>The number of seconds each particle will ’live’ for before being destroyed. Default value is 5.</description>
+  </element>
+
+  <element name="rate" type="double" default="10" required="0">
+    <description>The number of particles per second that should be emitted.</description>
+  </element>
+
+  <element name="min_velocity" type="double" default="1" required="0">
+    <description>Sets a minimum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="max_velocity" type="double" default="1" required="0">
+    <description>Sets a maximum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="scale_rate" type="double" default="1" required="0">
+    <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
+  </element>
+
+  <element name="color_start" type="color" default="1 1 1 1" required="0">
+    <description>
+     Sets the starting color for all particles emitted.
+     The actual color will be interpolated between this color
+     and the one set under color_end.
+     Color::White is the default color for the particles
+     unless a specific function is used.
+     To specify a color, RGB values should be passed in.
+     For example, to specify red, a user should enter:
+     <color_start>1 0 0</color_start>
+     Note that this function overrides the particle colors set
+     with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_end" type="color" default="1 1 1 1" required="0">
+    <description>
+    Sets the end color for all particles emitted.
+    The actual color will be interpolated between this color
+    and the one set under color_start.
+    Color::White is the default color for the particles
+    unless a specific function is used (see color_start for
+    more information about defining custom colors with RGB
+    values).
+    Note that this function overrides the particle colors set
+    with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_range_image" type="string" default="__default__" required="0">
+    <description>
+    Sets the path to the color image used as an affector. This affector modifies the color of particles in flight. The colors are taken from a specified image file. The range of color values begins from the left side of the image and moves to the right over the lifetime of the particle, therefore only the horizontal dimension of the image is used.  Note that this function overrides the particle colors set with color_start and color_end.
+    </description>
+  </element>
+
+  <element name="topic" type="string" default="__default__" required="0">
+    <description>
+     Topic used to update particle emitter properties at runtime.
+     The default topic is
+     /model/{model_name}/particle_emitter/{emitter_name}
+     Note that the emitter id and name may not be changed.
+    </description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="material.sdf" required="0"/>
+</element>

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -15,7 +15,7 @@
   </element>
 
   <element name="duration" type="double" default="0" required="0">
-    <description>The number of seconds the emitter is active. A value of 0 means infinite duration.</description>
+    <description>The number of seconds the emitter is active. A value of <=0 means infinite duration.</description>
   </element>
 
   <element name="size" type="vector3" default="1 1 1" required="0">
@@ -27,7 +27,7 @@
       - point: The area is ignored.
       - box: The area is interpreted as width X height X depth.
       - cylinder: The area is interpreted as the bounding box of the
-                  cilinder. The cylinder is oriented along the Z-axis.
+                  cyilinder. The cylinder is oriented along the Z-axis.
       - ellipsoid: The area is interpreted as the bounding box of an
                    ellipsoid shaped area, i.e. a sphere or
                    squashed-sphere area. The parameters are again

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -56,7 +56,7 @@
     <description>Sets a maximum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="scale_rate" type="double" default="1" required="0" min="0.0">
+  <element name="scale_rate" type="double" default="0" required="0" min="0.0">
     <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
   </element>
 

--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -89,13 +89,13 @@
     </description>
   </element>
 
-  <element name="color_range_image" type="string" default="__default__" required="0">
+  <element name="color_range_image" type="string" default="" required="0">
     <description>
     Sets the path to the color image used as an affector. This affector modifies the color of particles in flight. The colors are taken from a specified image file. The range of color values begins from the left side of the image and moves to the right over the lifetime of the particle, therefore only the horizontal dimension of the image is used.  Note that this function overrides the particle colors set with color_start and color_end.
     </description>
   </element>
 
-  <element name="topic" type="string" default="__default__" required="0">
+  <element name="topic" type="string" default="" required="0">
     <description>
      Topic used to update particle emitter properties at runtime.
      The default topic is

--- a/sdf/1.7/link.sdf
+++ b/sdf/1.7/link.sdf
@@ -46,5 +46,6 @@
   <include filename="audio_source.sdf" required="*"/>
   <include filename="battery.sdf" required="*"/>
   <include filename="light.sdf" required="*"/>
+  <include filename="particle_emitter.sdf" required="*"/>
 
 </element> <!-- End Link -->

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -15,7 +15,7 @@
   </element>
 
   <element name="duration" type="double" default="0" required="0">
-    <description>The number of seconds the emitter is active. A value of 0 means infinite duration.</description>
+    <description>The number of seconds the emitter is active. A value less than or equal to zero means infinite duration.</description>
   </element>
 
   <element name="size" type="vector3" default="1 1 1" required="0">
@@ -41,22 +41,22 @@
   </element>
 
   <element name="lifetime" type="double" default="5" required="0">
-    <description>The number of seconds each particle will ’live’ for before being destroyed. Default value is 5.</description>
+    <description>The number of seconds each particle will ’live’ for before being destroyed. This value must be greater than zero.</description>
   </element>
 
-  <element name="rate" type="double" default="10" required="0">
+  <element name="rate" type="double" default="10" required="0" min="0.0">
     <description>The number of particles per second that should be emitted.</description>
   </element>
 
-  <element name="min_velocity" type="double" default="1" required="0">
+  <element name="min_velocity" type="double" default="1" required="0" min="0.0">
     <description>Sets a minimum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="max_velocity" type="double" default="1" required="0">
+  <element name="max_velocity" type="double" default="1" required="0" min="0.0">
     <description>Sets a maximum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="scale_rate" type="double" default="1" required="0">
+  <element name="scale_rate" type="double" default="1" required="0" min="0.0">
     <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
   </element>
 

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -1,0 +1,109 @@
+<!-- Particle emitter -->
+<element name="particle_emitter" required="*">
+  <description>A particle emitter that can be used to describe fog, smoke, and dust.</description>
+
+  <attribute name="name" type="string" default="__default__" required="1">
+    <description>A unique name for the particle emitter.</description>
+  </attribute>
+
+  <attribute name="type" type="string" default="point" required="1">
+    <description>The type of a particle emitter. One of "box", "cylinder", "ellipsoid", or "point".</description>
+  </attribute>
+
+  <element name="emitting" type="bool" default="true" required="0">
+    <description>True indicates that the particle emitter should generate particles when loaded</description>
+  </element>
+
+  <element name="duration" type="double" default="0" required="0">
+    <description>The number of seconds the emitter is active. A value of 0 means infinite duration.</description>
+  </element>
+
+  <element name="size" type="vector3" default="1 1 1" required="0">
+    <description>
+    The size of the emitter where the particles are sampled.
+    Default value is (1, 1, 1).
+    Note that the interpretation of the emitter area varies
+    depending on the emmiter type:
+      - point: The area is ignored.
+      - box: The area is interpreted as width X height X depth.
+      - cylinder: The area is interpreted as the bounding box of the
+                  cilinder. The cylinder is oriented along the Z-axis.
+      - ellipsoid: The area is interpreted as the bounding box of an
+                   ellipsoid shaped area, i.e. a sphere or
+                   squashed-sphere area. The parameters are again
+                   identical to EM_BOX, except that the dimensions
+                   describe the widest points along each of the axes.
+    </description>
+  </element>
+
+  <element name="particle_size" type="vector3" default="1 1 1" required="0">
+    <description>The particle dimensions (width, height, depth).</description>
+  </element>
+
+  <element name="lifetime" type="double" default="5" required="0">
+    <description>The number of seconds each particle will ’live’ for before being destroyed. Default value is 5.</description>
+  </element>
+
+  <element name="rate" type="double" default="10" required="0">
+    <description>The number of particles per second that should be emitted.</description>
+  </element>
+
+  <element name="min_velocity" type="double" default="1" required="0">
+    <description>Sets a minimum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="max_velocity" type="double" default="1" required="0">
+    <description>Sets a maximum velocity for each particle (m/s).</description>
+  </element>
+
+  <element name="scale_rate" type="double" default="1" required="0">
+    <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
+  </element>
+
+  <element name="color_start" type="color" default="1 1 1 1" required="0">
+    <description>
+     Sets the starting color for all particles emitted.
+     The actual color will be interpolated between this color
+     and the one set under color_end.
+     Color::White is the default color for the particles
+     unless a specific function is used.
+     To specify a color, RGB values should be passed in.
+     For example, to specify red, a user should enter:
+     <color_start>1 0 0</color_start>
+     Note that this function overrides the particle colors set
+     with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_end" type="color" default="1 1 1 1" required="0">
+    <description>
+    Sets the end color for all particles emitted.
+    The actual color will be interpolated between this color
+    and the one set under color_start.
+    Color::White is the default color for the particles
+    unless a specific function is used (see color_start for
+    more information about defining custom colors with RGB
+    values).
+    Note that this function overrides the particle colors set
+    with color_range_image.
+    </description>
+  </element>
+
+  <element name="color_range_image" type="string" default="__default__" required="0">
+    <description>
+    Sets the path to the color image used as an affector. This affector modifies the color of particles in flight. The colors are taken from a specified image file. The range of color values begins from the left side of the image and moves to the right over the lifetime of the particle, therefore only the horizontal dimension of the image is used.  Note that this function overrides the particle colors set with color_start and color_end.
+    </description>
+  </element>
+
+  <element name="topic" type="string" default="__default__" required="0">
+    <description>
+     Topic used to update particle emitter properties at runtime.
+     The default topic is
+     /model/{model_name}/particle_emitter/{emitter_name}
+     Note that the emitter id and name may not be changed.
+    </description>
+  </element>
+
+  <include filename="pose.sdf" required="0"/>
+  <include filename="material.sdf" required="0"/>
+</element>

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -27,7 +27,7 @@
       - point: The area is ignored.
       - box: The area is interpreted as width X height X depth.
       - cylinder: The area is interpreted as the bounding box of the
-                  cilinder. The cylinder is oriented along the Z-axis.
+                  cylinder. The cylinder is oriented along the Z-axis.
       - ellipsoid: The area is interpreted as the bounding box of an
                    ellipsoid shaped area, i.e. a sphere or
                    squashed-sphere area. The parameters are again

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -56,7 +56,7 @@
     <description>Sets a maximum velocity for each particle (m/s).</description>
   </element>
 
-  <element name="scale_rate" type="double" default="1" required="0" min="0.0">
+  <element name="scale_rate" type="double" default="0" required="0" min="0.0">
     <description>Sets the amount by which to scale the particles in both x and y direction per second.</description>
   </element>
 

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -89,13 +89,13 @@
     </description>
   </element>
 
-  <element name="color_range_image" type="string" default="__default__" required="0">
+  <element name="color_range_image" type="string" default="" required="0">
     <description>
     Sets the path to the color image used as an affector. This affector modifies the color of particles in flight. The colors are taken from a specified image file. The range of color values begins from the left side of the image and moves to the right over the lifetime of the particle, therefore only the horizontal dimension of the image is used.  Note that this function overrides the particle colors set with color_start and color_end.
     </description>
   </element>
 
-  <element name="topic" type="string" default="__default__" required="0">
+  <element name="topic" type="string" default="" required="0">
     <description>
      Topic used to update particle emitter properties at runtime.
      The default topic is

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set (sources
   parser.cc
   parser_urdf.cc
   Param.cc
+  ParticleEmitter.cc
   Pbr.cc
   Physics.cc
   Plane.cc
@@ -111,6 +112,7 @@ if (BUILD_SDF_TEST)
     Noise_TEST.cc
     Param_TEST.cc
     parser_TEST.cc
+    ParticleEmitter_TEST.cc
     Pbr_TEST.cc
     Physics_TEST.cc
     Plane_TEST.cc

--- a/src/Link.cc
+++ b/src/Link.cc
@@ -25,6 +25,7 @@
 #include "sdf/Error.hh"
 #include "sdf/Light.hh"
 #include "sdf/Link.hh"
+#include "sdf/ParticleEmitter.hh"
 #include "sdf/Sensor.hh"
 #include "sdf/Types.hh"
 #include "sdf/Visual.hh"
@@ -54,6 +55,9 @@ class sdf::LinkPrivate
 
   /// \brief The sensors specified in this link.
   public: std::vector<Sensor> sensors;
+
+  /// \brief The particle emitters specified in this link.
+  public: std::vector<ParticleEmitter> emitters;
 
   /// \brief The inertial information for this link.
   public: ignition::math::Inertiald inertial {{1.0,
@@ -162,6 +166,12 @@ Errors Link::Load(ElementPtr _sdf)
   Errors sensorLoadErrors = loadUniqueRepeated<Sensor>(_sdf, "sensor",
       this->dataPtr->sensors);
   errors.insert(errors.end(), sensorLoadErrors.begin(), sensorLoadErrors.end());
+
+  // Load all the particle emitters.
+  Errors emitterLoadErrors = loadUniqueRepeated<ParticleEmitter>(_sdf,
+      "particle_emitter", this->dataPtr->emitters);
+  errors.insert(errors.end(), emitterLoadErrors.begin(),
+      emitterLoadErrors.end());
 
   ignition::math::Vector3d xxyyzz = ignition::math::Vector3d::One;
   ignition::math::Vector3d xyxzyz = ignition::math::Vector3d::Zero;
@@ -337,6 +347,48 @@ const Sensor *Link::SensorByName(const std::string &_name) const
 }
 
 /////////////////////////////////////////////////
+uint64_t Link::ParticleEmitterCount() const
+{
+  return this->dataPtr->emitters.size();
+}
+
+/////////////////////////////////////////////////
+const ParticleEmitter *Link::ParticleEmitterByIndex(const uint64_t _index) const
+{
+  if (_index < this->dataPtr->emitters.size())
+    return &this->dataPtr->emitters[_index];
+  return nullptr;
+}
+
+/////////////////////////////////////////////////
+bool Link::ParticleEmitterNameExists(const std::string &_name) const
+{
+  for (auto const &e : this->dataPtr->emitters)
+  {
+    if (e.Name() == _name)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+/////////////////////////////////////////////////
+const ParticleEmitter *Link::ParticleEmitterByName(
+    const std::string &_name) const
+{
+  for (auto const &e : this->dataPtr->emitters)
+  {
+    if (e.Name() == _name)
+    {
+      return &e;
+    }
+  }
+  return nullptr;
+}
+
+
+/////////////////////////////////////////////////
 const ignition::math::Inertiald &Link::Inertial() const
 {
   return this->dataPtr->inertial;
@@ -399,6 +451,12 @@ void Link::SetPoseRelativeToGraph(
   {
     visual.SetXmlParentName(this->dataPtr->name);
     visual.SetPoseRelativeToGraph(_graph);
+  }
+
+  for (auto &emitter : this->dataPtr->emitters)
+  {
+    emitter.SetXmlParentName(this->dataPtr->name);
+    emitter.SetPoseRelativeToGraph(_graph);
   }
 }
 

--- a/src/Link_TEST.cc
+++ b/src/Link_TEST.cc
@@ -22,6 +22,7 @@
 #include "sdf/Collision.hh"
 #include "sdf/Light.hh"
 #include "sdf/Link.hh"
+#include "sdf/ParticleEmitter.hh"
 #include "sdf/Sensor.hh"
 #include "sdf/Visual.hh"
 
@@ -47,6 +48,13 @@ TEST(DOMLink, Construction)
   EXPECT_FALSE(link.LightNameExists(""));
   EXPECT_FALSE(link.LightNameExists("default"));
   EXPECT_EQ(nullptr, link.LightByName("no_such_light"));
+
+  EXPECT_EQ(0u, link.ParticleEmitterCount());
+  EXPECT_EQ(nullptr, link.ParticleEmitterByIndex(0));
+  EXPECT_EQ(nullptr, link.ParticleEmitterByIndex(1));
+  EXPECT_FALSE(link.ParticleEmitterNameExists(""));
+  EXPECT_FALSE(link.ParticleEmitterNameExists("default"));
+  EXPECT_EQ(nullptr, link.ParticleEmitterByName("no_such_emitter"));
 
   EXPECT_FALSE(link.EnableWind());
   link.SetEnableWind(true);

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -360,7 +360,7 @@ double ParticleEmitter::Lifetime() const
 /////////////////////////////////////////////////
 void ParticleEmitter::SetLifetime(double _lifetime)
 {
-  this->dataPtr->lifetime = _lifetime;
+  this->dataPtr->lifetime = std::max(_lifetime, ignition::math::MIN_D);
 }
 
 /////////////////////////////////////////////////
@@ -372,7 +372,7 @@ double ParticleEmitter::Rate() const
 /////////////////////////////////////////////////
 void ParticleEmitter::SetRate(double _rate)
 {
-  this->dataPtr->rate = _rate;
+  this->dataPtr->rate = std::max(_rate, 0.0);
 }
 
 /////////////////////////////////////////////////
@@ -384,7 +384,7 @@ double ParticleEmitter::ScaleRate() const
 /////////////////////////////////////////////////
 void ParticleEmitter::SetScaleRate(double _scaleRate)
 {
-  this->dataPtr->scaleRate = _scaleRate;
+  this->dataPtr->scaleRate = std::max(_scaleRate, 0.0);
 }
 
 /////////////////////////////////////////////////
@@ -396,7 +396,7 @@ double ParticleEmitter::MinVelocity() const
 /////////////////////////////////////////////////
 void ParticleEmitter::SetMinVelocity(double _vel)
 {
-  this->dataPtr->minVelocity = _vel;
+  this->dataPtr->minVelocity = std::max(_vel, 0.0);
 }
 
 /////////////////////////////////////////////////
@@ -408,7 +408,7 @@ double ParticleEmitter::MaxVelocity() const
 /////////////////////////////////////////////////
 void ParticleEmitter::SetMaxVelocity(double _vel)
 {
-  this->dataPtr->maxVelocity = _vel;
+  this->dataPtr->maxVelocity = std::max(_vel, 0.0);
 }
 
 /////////////////////////////////////////////////
@@ -418,9 +418,10 @@ ignition::math::Vector3d ParticleEmitter::Size() const
 }
 
 /////////////////////////////////////////////////
-void ParticleEmitter::SetSize(const ignition::math::Vector3d _size)
+void ParticleEmitter::SetSize(const ignition::math::Vector3d &_size)
 {
   this->dataPtr->size = _size;
+  this->dataPtr->size.Max(ignition::math::Vector3d::Zero);
 }
 
 /////////////////////////////////////////////////
@@ -430,9 +431,10 @@ ignition::math::Vector3d ParticleEmitter::ParticleSize() const
 }
 
 /////////////////////////////////////////////////
-void ParticleEmitter::SetParticleSize(const ignition::math::Vector3d _size)
+void ParticleEmitter::SetParticleSize(const ignition::math::Vector3d &_size)
 {
   this->dataPtr->particleSize = _size;
+  this->dataPtr->particleSize.Max(ignition::math::Vector3d::Zero);
 }
 
 /////////////////////////////////////////////////

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -70,7 +70,7 @@ class sdf::ParticleEmitterPrivate
 
   /// \brief The amount by which to scale the particles in both x and y
   /// direction per second.
-  public: double scaleRate = 1;
+  public: double scaleRate = 0;
 
   /// \brief The minimum velocity for each particle (m/s).
   public: double minVelocity = 1;

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -1,0 +1,561 @@
+/*
+ * Copyright 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "sdf/ParticleEmitter.hh"
+#include "sdf/Error.hh"
+#include "sdf/Types.hh"
+#include "Utils.hh"
+
+using namespace sdf;
+
+/// Particel emitter type strings. These should match the data in
+/// `enum class ParticleEmitterType` located in ParticleEmitter.hh.
+const std::vector<std::string> emitterTypeStrs =
+{
+  "point",
+  "box",
+  "cylinder",
+  "ellipsoid",
+};
+
+class sdf::ParticleEmitterPrivate
+{
+  /// \brief Default constructor
+  public: ParticleEmitterPrivate() = default;
+
+  /// \brief Copy constructor
+  /// \param[in] _private ParticleEmitterPrivate to move.
+  public: explicit ParticleEmitterPrivate(
+              const ParticleEmitterPrivate &_private);
+
+  // Delete copy assignment so it is not accidentally used
+  public: ParticleEmitterPrivate &operator=(
+              const ParticleEmitterPrivate &) = delete;
+
+  /// \brief Name of the particle emitter.
+  public: std::string name = "";
+
+  /// \brief Type of the particle emitter.
+  public: ParticleEmitterType type = ParticleEmitterType::POINT;
+
+  /// \brief True if the emitting should produce particles.
+  public: bool emitting = true;
+
+  /// \brief The number of seconds the emitter is active.
+  /// A value of 0 means infinite duration.
+  public: double duration = 0;
+
+  /// \brief The number of seconds each particle will 'live' for.
+  public: double lifetime = 5;
+
+  /// \brief The number of particles per second that should be emitted.
+  public: double rate = 10;
+
+  /// \brief The amount by which to scale the particles in both x and y
+  /// direction per second.
+  public: double scaleRate = 1;
+
+  /// \brief The minimum velocity for each particle (m/s).
+  public: double minVelocity = 1;
+
+  /// \brief The maximum velocity for each particle (m/s).
+  public: double maxVelocity = 1;
+
+  /// \brief The size of the emitter where the particles are sampled.
+  public: ignition::math::Vector3d size = ignition::math::Vector3d::One;
+
+  /// \brief The size of a particle.
+  public: ignition::math::Vector3d particleSize = ignition::math::Vector3d::One;
+
+  /// \brief The starting color for all particle emitted.
+  public: ignition::math::Color colorStart = ignition::math::Color::White;
+
+  /// \brief The ending color for all particle emitted.
+  public: ignition::math::Color colorEnd = ignition::math::Color::White;
+
+  /// \brief The color range image
+  public: std::string colorRangeImage = "";
+
+  /// \brief Topic used to update particle emitter properties at runtime.
+  public: std::string topic = "";
+
+  /// \brief Pose of the emitter
+  public: ignition::math::Pose3d pose = ignition::math::Pose3d::Zero;
+
+  /// \brief Frame of the pose.
+  public: std::string poseRelativeTo = "";
+
+  /// \brief Weak pointer to model's Pose Relative-To Graph.
+  public: std::weak_ptr<const sdf::PoseRelativeToGraph> poseRelativeToGraph;
+
+  /// \brief Name of xml parent object.
+  public: std::string xmlParentName = "";
+
+  /// \brief Pointer to the emitter's material properties.
+  public: std::unique_ptr<Material> material;
+
+  /// \brief The path to the file where this emitter was defined.
+  public: std::string filePath = "";
+
+  /// \brief The SDF element pointer used during load.
+  public: sdf::ElementPtr sdf;
+};
+
+/////////////////////////////////////////////////
+ParticleEmitterPrivate::ParticleEmitterPrivate(
+    const ParticleEmitterPrivate &_private)
+    : name(_private.name),
+      type(_private.type),
+      emitting(_private.emitting),
+      duration(_private.duration),
+      lifetime(_private.lifetime),
+      rate(_private.rate),
+      scaleRate(_private.scaleRate),
+      minVelocity(_private.minVelocity),
+      maxVelocity(_private.maxVelocity),
+      size(_private.size),
+      particleSize(_private.particleSize),
+      colorStart(_private.colorStart),
+      colorEnd(_private.colorEnd),
+      colorRangeImage(_private.colorRangeImage),
+      topic(_private.topic),
+      pose(_private.pose),
+      poseRelativeTo(_private.poseRelativeTo),
+      xmlParentName(_private.xmlParentName),
+      filePath(_private.filePath),
+      sdf(_private.sdf)
+{
+  if (_private.material)
+  {
+    this->material = std::make_unique<Material>(*(_private.material));
+  }
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter::ParticleEmitter()
+  : dataPtr(new ParticleEmitterPrivate)
+{
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter::~ParticleEmitter()
+{
+  delete this->dataPtr;
+  this->dataPtr = nullptr;
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter::ParticleEmitter(const ParticleEmitter &_particleEmitter)
+  : dataPtr(new ParticleEmitterPrivate(*_particleEmitter.dataPtr))
+{
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter::ParticleEmitter(ParticleEmitter &&_particleEmitter) noexcept
+  : dataPtr(std::exchange(_particleEmitter.dataPtr, nullptr))
+{
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter &ParticleEmitter::operator=(
+    const ParticleEmitter &_particleEmitter)
+{
+  return *this = ParticleEmitter(_particleEmitter);
+}
+
+/////////////////////////////////////////////////
+ParticleEmitter &ParticleEmitter::operator=(ParticleEmitter &&_particleEmitter)
+{
+  std::swap(this->dataPtr, _particleEmitter.dataPtr);
+  return *this;
+}
+
+/////////////////////////////////////////////////
+Errors ParticleEmitter::Load(ElementPtr _sdf)
+{
+  Errors errors;
+
+  this->dataPtr->sdf = _sdf;
+
+  this->dataPtr->filePath = _sdf->FilePath();
+
+  // Check that the provided SDF element is a <particle_emitter>
+  // This is an error that cannot be recovered, so return an error.
+  if (_sdf->GetName() != "particle_emitter")
+  {
+    errors.push_back({ErrorCode::ELEMENT_INCORRECT_TYPE,
+        "Attempting to load a particle emitter, but the provided SDF element "
+        "is not a <particle_emitter>."});
+    return errors;
+  }
+
+  // Read the emitter's name
+  if (!loadName(_sdf, this->dataPtr->name))
+  {
+    errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
+                     "A link name is required, but the name is not set."});
+  }
+
+  // Check that the emitter's name is valid
+  if (isReservedName(this->dataPtr->name))
+  {
+    errors.push_back({ErrorCode::RESERVED_NAME,
+        "The supplied particle emitter name [" + this->dataPtr->name +
+        "] is reserved."});
+  }
+
+  // Load the pose. Ignore the return value since the pose is optional.
+  loadPose(_sdf, this->dataPtr->pose, this->dataPtr->poseRelativeTo);
+
+  if (!this->SetType(_sdf->Get<std::string>("type",
+          this->TypeStr()).first))
+  {
+    errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
+        "Attempting to load a particle emitter, but the provided "
+        "particle emitter type is missing or invalid."});
+    return errors;
+  }
+
+  this->dataPtr->emitting = _sdf->Get<bool>("emitting",
+      this->dataPtr->emitting).first;
+
+  this->dataPtr->duration = _sdf->Get<double>("duration",
+      this->dataPtr->duration).first;
+
+  this->dataPtr->lifetime = _sdf->Get<double>("lifetime",
+      this->dataPtr->lifetime).first;
+
+  this->dataPtr->rate = _sdf->Get<double>("rate",
+      this->dataPtr->rate).first;
+
+  this->dataPtr->scaleRate = _sdf->Get<double>("scale_rate",
+      this->dataPtr->scaleRate).first;
+
+  this->dataPtr->minVelocity = _sdf->Get<double>("min_velocity",
+      this->dataPtr->minVelocity).first;
+
+  this->dataPtr->maxVelocity = _sdf->Get<double>("max_velocity",
+      this->dataPtr->maxVelocity).first;
+
+  this->dataPtr->size = _sdf->Get<ignition::math::Vector3d>("size",
+      this->dataPtr->size).first;
+
+  this->dataPtr->particleSize = _sdf->Get<ignition::math::Vector3d>(
+      "particle_size", this->dataPtr->particleSize).first;
+
+  this->dataPtr->colorStart = _sdf->Get<ignition::math::Color>(
+      "color_start", this->dataPtr->colorStart).first;
+
+  this->dataPtr->colorEnd = _sdf->Get<ignition::math::Color>(
+      "color_end", this->dataPtr->colorEnd).first;
+
+  this->dataPtr->colorRangeImage = _sdf->Get<std::string>(
+      "color_range_image", this->dataPtr->colorRangeImage).first;
+
+  this->dataPtr->topic = _sdf->Get<std::string>(
+      "topic", this->dataPtr->topic).first;
+
+  if (_sdf->HasElement("material"))
+  {
+    this->dataPtr->material.reset(new sdf::Material());
+    Errors err = this->dataPtr->material->Load(_sdf->GetElement("material"));
+    errors.insert(errors.end(), err.begin(), err.end());
+  }
+
+  return errors;
+}
+
+/////////////////////////////////////////////////
+std::string ParticleEmitter::Name() const
+{
+  return this->dataPtr->name;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetName(const std::string &_name)
+{
+  this->dataPtr->name = _name;
+}
+
+/////////////////////////////////////////////////
+ParticleEmitterType ParticleEmitter::Type() const
+{
+  return this->dataPtr->type;
+}
+void ParticleEmitter::SetType(const ParticleEmitterType _type)
+{
+  this->dataPtr->type = _type;
+}
+
+/////////////////////////////////////////////////
+bool ParticleEmitter::SetType(const std::string &_typeStr)
+{
+  for (size_t i = 0; i < emitterTypeStrs.size(); ++i)
+  {
+    if (_typeStr == emitterTypeStrs[i])
+    {
+      this->dataPtr->type = static_cast<ParticleEmitterType>(i);
+      return true;
+    }
+  }
+  return false;
+}
+
+/////////////////////////////////////////////////
+std::string ParticleEmitter::TypeStr() const
+{
+  size_t index = static_cast<int>(this->dataPtr->type);
+  if (index < emitterTypeStrs.size())
+    return emitterTypeStrs[index];
+  return "point";
+}
+
+/////////////////////////////////////////////////
+bool ParticleEmitter::Emitting() const
+{
+  return this->dataPtr->emitting;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetEmitting(bool _emitting)
+{
+  this->dataPtr->emitting = _emitting;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::Duration() const
+{
+  return this->dataPtr->duration;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetDuration(double _duration)
+{
+  this->dataPtr->duration = _duration;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::Lifetime() const
+{
+  return this->dataPtr->lifetime;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetLifetime(double _lifetime)
+{
+  this->dataPtr->lifetime = _lifetime;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::Rate() const
+{
+  return this->dataPtr->rate;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetRate(double _rate)
+{
+  this->dataPtr->rate = _rate;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::ScaleRate() const
+{
+  return this->dataPtr->scaleRate;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetScaleRate(double _scaleRate)
+{
+  this->dataPtr->scaleRate = _scaleRate;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::MinVelocity() const
+{
+  return this->dataPtr->minVelocity;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetMinVelocity(double _vel)
+{
+  this->dataPtr->minVelocity = _vel;
+}
+
+/////////////////////////////////////////////////
+double ParticleEmitter::MaxVelocity() const
+{
+  return this->dataPtr->maxVelocity;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetMaxVelocity(double _vel)
+{
+  this->dataPtr->maxVelocity = _vel;
+}
+
+/////////////////////////////////////////////////
+ignition::math::Vector3d ParticleEmitter::Size() const
+{
+  return this->dataPtr->size;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetSize(const ignition::math::Vector3d _size)
+{
+  this->dataPtr->size = _size;
+}
+
+/////////////////////////////////////////////////
+ignition::math::Vector3d ParticleEmitter::ParticleSize() const
+{
+  return this->dataPtr->particleSize;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetParticleSize(const ignition::math::Vector3d _size)
+{
+  this->dataPtr->particleSize = _size;
+}
+
+/////////////////////////////////////////////////
+ignition::math::Color ParticleEmitter::ColorStart() const
+{
+  return this->dataPtr->colorStart;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetColorStart(const ignition::math::Color &_colorStart)
+{
+  this->dataPtr->colorStart = _colorStart;
+}
+
+/////////////////////////////////////////////////
+ignition::math::Color ParticleEmitter::ColorEnd() const
+{
+  return this->dataPtr->colorEnd;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetColorEnd(const ignition::math::Color &_colorEnd)
+{
+  this->dataPtr->colorEnd = _colorEnd;
+}
+
+/////////////////////////////////////////////////
+std::string ParticleEmitter::ColorRangeImage() const
+{
+  return this->dataPtr->colorRangeImage;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetColorRangeImage(const std::string &_image)
+{
+  this->dataPtr->colorRangeImage = _image;
+}
+
+/////////////////////////////////////////////////
+std::string ParticleEmitter::Topic() const
+{
+  return this->dataPtr->topic;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetTopic(const std::string &_topic)
+{
+  this->dataPtr->topic = _topic;
+}
+
+/////////////////////////////////////////////////
+const ignition::math::Pose3d &ParticleEmitter::RawPose() const
+{
+  return this->dataPtr->pose;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetRawPose(const ignition::math::Pose3d &_pose)
+{
+  this->dataPtr->pose = _pose;
+}
+
+/////////////////////////////////////////////////
+const std::string &ParticleEmitter::PoseRelativeTo() const
+{
+  return this->dataPtr->poseRelativeTo;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetPoseRelativeTo(const std::string &_frame)
+{
+  this->dataPtr->poseRelativeTo = _frame;
+}
+
+/////////////////////////////////////////////////
+sdf::SemanticPose ParticleEmitter::SemanticPose() const
+{
+  return sdf::SemanticPose(
+      this->dataPtr->pose,
+      this->dataPtr->poseRelativeTo,
+      this->dataPtr->xmlParentName,
+      this->dataPtr->poseRelativeToGraph);
+}
+
+/////////////////////////////////////////////////
+sdf::ElementPtr ParticleEmitter::Element() const
+{
+  return this->dataPtr->sdf;
+}
+
+/////////////////////////////////////////////////
+sdf::Material *ParticleEmitter::Material() const
+{
+  return this->dataPtr->material.get();
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetMaterial(const sdf::Material &_material)
+{
+  this->dataPtr->material.reset(new sdf::Material(_material));
+}
+
+//////////////////////////////////////////////////
+const std::string &ParticleEmitter::FilePath() const
+{
+  return this->dataPtr->filePath;
+}
+
+//////////////////////////////////////////////////
+void ParticleEmitter::SetFilePath(const std::string &_filePath)
+{
+  this->dataPtr->filePath = _filePath;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetXmlParentName(const std::string &_xmlParentName)
+{
+  this->dataPtr->xmlParentName = _xmlParentName;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetPoseRelativeToGraph(
+    std::weak_ptr<const PoseRelativeToGraph> _graph)
+{
+  this->dataPtr->poseRelativeToGraph = _graph;
+}

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -25,7 +25,7 @@
 
 using namespace sdf;
 
-/// Particel emitter type strings. These should match the data in
+/// Particle emitter type strings. These should match the data in
 /// `enum class ParticleEmitterType` located in ParticleEmitter.hh.
 const std::vector<std::string> emitterTypeStrs =
 {
@@ -299,6 +299,8 @@ ParticleEmitterType ParticleEmitter::Type() const
 {
   return this->dataPtr->type;
 }
+
+/////////////////////////////////////////////////
 void ParticleEmitter::SetType(const ParticleEmitterType _type)
 {
   this->dataPtr->type = _type;

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -48,30 +48,44 @@ TEST(DOMParticleEmitter, Construction)
   EXPECT_DOUBLE_EQ(5.0, emitter.Lifetime());
   emitter.SetLifetime(22.0);
   EXPECT_DOUBLE_EQ(22.0, emitter.Lifetime());
+  emitter.SetLifetime(-1.0);
+  EXPECT_DOUBLE_EQ(ignition::math::MIN_D, emitter.Lifetime());
 
   EXPECT_DOUBLE_EQ(10.0, emitter.Rate());
   emitter.SetRate(123.0);
   EXPECT_DOUBLE_EQ(123.0, emitter.Rate());
+  emitter.SetRate(-123.0);
+  EXPECT_DOUBLE_EQ(0.0, emitter.Rate());
 
   EXPECT_DOUBLE_EQ(1.0, emitter.ScaleRate());
   emitter.SetScaleRate(1.2);
   EXPECT_DOUBLE_EQ(1.2, emitter.ScaleRate());
+  emitter.SetScaleRate(-1.2);
+  EXPECT_DOUBLE_EQ(0.0, emitter.ScaleRate());
 
   EXPECT_DOUBLE_EQ(1.0, emitter.MinVelocity());
   emitter.SetMinVelocity(12.4);
   EXPECT_DOUBLE_EQ(12.4, emitter.MinVelocity());
+  emitter.SetMinVelocity(-12.4);
+  EXPECT_DOUBLE_EQ(0.0, emitter.MinVelocity());
 
   EXPECT_DOUBLE_EQ(1.0, emitter.MaxVelocity());
   emitter.SetMaxVelocity(20.6);
   EXPECT_DOUBLE_EQ(20.6, emitter.MaxVelocity());
+  emitter.SetMaxVelocity(-12.4);
+  EXPECT_DOUBLE_EQ(0.0, emitter.MaxVelocity());
 
   EXPECT_EQ(ignition::math::Vector3d::One, emitter.Size());
   emitter.SetSize(ignition::math::Vector3d(3, 2, 1));
   EXPECT_EQ(ignition::math::Vector3d(3, 2, 1), emitter.Size());
+  emitter.SetSize(ignition::math::Vector3d(-3, -2, -1));
+  EXPECT_EQ(ignition::math::Vector3d(0, 0, 0), emitter.Size());
 
   EXPECT_EQ(ignition::math::Vector3d::One, emitter.ParticleSize());
   emitter.SetParticleSize(ignition::math::Vector3d(4, 5, 6));
   EXPECT_EQ(ignition::math::Vector3d(4, 5, 6), emitter.ParticleSize());
+  emitter.SetParticleSize(ignition::math::Vector3d(-4, -5, -6));
+  EXPECT_EQ(ignition::math::Vector3d(0, 0, 0), emitter.ParticleSize());
 
   EXPECT_EQ(ignition::math::Color::White, emitter.ColorStart());
   emitter.SetColorStart(ignition::math::Color(0.1, 0.2, 0.3, 1.0));

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -57,7 +57,7 @@ TEST(DOMParticleEmitter, Construction)
   emitter.SetRate(-123.0);
   EXPECT_DOUBLE_EQ(0.0, emitter.Rate());
 
-  EXPECT_DOUBLE_EQ(1.0, emitter.ScaleRate());
+  EXPECT_DOUBLE_EQ(0.0, emitter.ScaleRate());
   emitter.SetScaleRate(1.2);
   EXPECT_DOUBLE_EQ(1.2, emitter.ScaleRate());
   emitter.SetScaleRate(-1.2);
@@ -88,12 +88,13 @@ TEST(DOMParticleEmitter, Construction)
   EXPECT_EQ(ignition::math::Vector3d(0, 0, 0), emitter.ParticleSize());
 
   EXPECT_EQ(ignition::math::Color::White, emitter.ColorStart());
-  emitter.SetColorStart(ignition::math::Color(0.1, 0.2, 0.3, 1.0));
-  EXPECT_EQ(ignition::math::Color(0.1, 0.2, 0.3, 1.0), emitter.ColorStart());
+  emitter.SetColorStart(ignition::math::Color(0.1f, 0.2f, 0.3f, 1.0f));
+  EXPECT_EQ(ignition::math::Color(0.1f, 0.2f, 0.3f, 1.0f),
+      emitter.ColorStart());
 
   EXPECT_EQ(ignition::math::Color::White, emitter.ColorEnd());
-  emitter.SetColorEnd(ignition::math::Color(0.4, 0.5, 0.6, 1.0));
-  EXPECT_EQ(ignition::math::Color(0.4, 0.5, 0.6, 1.0), emitter.ColorEnd());
+  emitter.SetColorEnd(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0f));
+  EXPECT_EQ(ignition::math::Color(0.4f, 0.5f, 0.6f, 1.0f), emitter.ColorEnd());
 
   EXPECT_TRUE(emitter.ColorRangeImage().empty());
   emitter.SetColorRangeImage("/test/string");

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include "sdf/ParticleEmitter.hh"
+
+/////////////////////////////////////////////////
+TEST(DOMParticleEmitter, Construction)
+{
+  sdf::ParticleEmitter emitter;
+
+  EXPECT_EQ(nullptr, emitter.Element());
+  EXPECT_TRUE(emitter.Name().empty());
+
+  emitter.SetName("test_emitter");
+  EXPECT_EQ(emitter.Name(), "test_emitter");
+
+  EXPECT_EQ("point", emitter.TypeStr());
+  EXPECT_EQ(sdf::ParticleEmitterType::POINT, emitter.Type());
+  EXPECT_TRUE(emitter.SetType("box"));
+  EXPECT_EQ("box", emitter.TypeStr());
+  EXPECT_EQ(sdf::ParticleEmitterType::BOX, emitter.Type());
+  emitter.SetType(sdf::ParticleEmitterType::CYLINDER);
+  EXPECT_EQ("cylinder", emitter.TypeStr());
+
+  EXPECT_TRUE(emitter.Emitting());
+  emitter.SetEmitting(false);
+  EXPECT_FALSE(emitter.Emitting());
+
+  EXPECT_DOUBLE_EQ(0.0, emitter.Duration());
+  emitter.SetDuration(10.0);
+  EXPECT_DOUBLE_EQ(10.0, emitter.Duration());
+
+  EXPECT_DOUBLE_EQ(5.0, emitter.Lifetime());
+  emitter.SetLifetime(22.0);
+  EXPECT_DOUBLE_EQ(22.0, emitter.Lifetime());
+
+  EXPECT_DOUBLE_EQ(10.0, emitter.Rate());
+  emitter.SetRate(123.0);
+  EXPECT_DOUBLE_EQ(123.0, emitter.Rate());
+
+  EXPECT_DOUBLE_EQ(1.0, emitter.ScaleRate());
+  emitter.SetScaleRate(1.2);
+  EXPECT_DOUBLE_EQ(1.2, emitter.ScaleRate());
+
+  EXPECT_DOUBLE_EQ(1.0, emitter.MinVelocity());
+  emitter.SetMinVelocity(12.4);
+  EXPECT_DOUBLE_EQ(12.4, emitter.MinVelocity());
+
+  EXPECT_DOUBLE_EQ(1.0, emitter.MaxVelocity());
+  emitter.SetMaxVelocity(20.6);
+  EXPECT_DOUBLE_EQ(20.6, emitter.MaxVelocity());
+
+  EXPECT_EQ(ignition::math::Vector3d::One, emitter.Size());
+  emitter.SetSize(ignition::math::Vector3d(3, 2, 1));
+  EXPECT_EQ(ignition::math::Vector3d(3, 2, 1), emitter.Size());
+
+  EXPECT_EQ(ignition::math::Vector3d::One, emitter.ParticleSize());
+  emitter.SetParticleSize(ignition::math::Vector3d(4, 5, 6));
+  EXPECT_EQ(ignition::math::Vector3d(4, 5, 6), emitter.ParticleSize());
+
+  EXPECT_EQ(ignition::math::Color::White, emitter.ColorStart());
+  emitter.SetColorStart(ignition::math::Color(0.1, 0.2, 0.3, 1.0));
+  EXPECT_EQ(ignition::math::Color(0.1, 0.2, 0.3, 1.0), emitter.ColorStart());
+
+  EXPECT_EQ(ignition::math::Color::White, emitter.ColorEnd());
+  emitter.SetColorEnd(ignition::math::Color(0.4, 0.5, 0.6, 1.0));
+  EXPECT_EQ(ignition::math::Color(0.4, 0.5, 0.6, 1.0), emitter.ColorEnd());
+
+  EXPECT_TRUE(emitter.ColorRangeImage().empty());
+  emitter.SetColorRangeImage("/test/string");
+  EXPECT_EQ("/test/string", emitter.ColorRangeImage());
+
+  EXPECT_TRUE(emitter.Topic().empty());
+  emitter.SetTopic("/test/topic");
+  EXPECT_EQ("/test/topic", emitter.Topic());
+
+  EXPECT_EQ(ignition::math::Pose3d::Zero, emitter.RawPose());
+  emitter.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0, 0, 1.5707));
+  EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 1.5707), emitter.RawPose());
+
+  EXPECT_TRUE(emitter.PoseRelativeTo().empty());
+  emitter.SetPoseRelativeTo("/test/relative");
+  EXPECT_EQ("/test/relative", emitter.PoseRelativeTo());
+}

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -31,7 +31,7 @@ class sdf::VisualPrivate
   public: VisualPrivate() = default;
 
   /// \brief Copy constructor
-  /// \param[in] _visualPrivate Joint axis to move.
+  /// \param[in] _visualPrivate VisualPrivate to move.
   public: explicit VisualPrivate(const VisualPrivate &_visualPrivate);
 
   // Delete copy assignment so it is not accidentally used

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,6 +28,7 @@ set(tests
   model_versions.cc
   nested_model.cc
   parser_error_detection.cc
+  particle_emitter_dom.cc
   plugin_attribute.cc
   plugin_bool.cc
   plugin_include.cc

--- a/test/integration/particle_emitter_dom.cc
+++ b/test/integration/particle_emitter_dom.cc
@@ -81,8 +81,8 @@ TEST(DOMWorld, LoadParticleEmitter)
 
   sdf::Material *mat = linkEmitter->Material();
   ASSERT_NE(nullptr, mat);
-  EXPECT_EQ(ignition::math::Color(0.7, 0.7, 0.7), mat->Diffuse());
-  EXPECT_EQ(ignition::math::Color(1.0, 1.0, 1.0), mat->Specular());
+  EXPECT_EQ(ignition::math::Color(0.7f, 0.7f, 0.7f), mat->Diffuse());
+  EXPECT_EQ(ignition::math::Color(1.0f, 1.0f, 1.0f), mat->Specular());
 
   sdf::Pbr *pbr = mat->PbrMaterial();
   ASSERT_NE(nullptr, pbr);

--- a/test/integration/particle_emitter_dom.cc
+++ b/test/integration/particle_emitter_dom.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <string>
+#include <gtest/gtest.h>
+
+#include <ignition/math/Vector3.hh>
+
+#include "sdf/SDFImpl.hh"
+#include "sdf/parser.hh"
+#include "sdf/Root.hh"
+#include "sdf/World.hh"
+#include "sdf/Light.hh"
+#include "sdf/Link.hh"
+#include "sdf/Material.hh"
+#include "sdf/Model.hh"
+#include "sdf/ParticleEmitter.hh"
+#include "sdf/Pbr.hh"
+#include "sdf/Filesystem.hh"
+#include "test_config.h"
+
+//////////////////////////////////////////////////
+TEST(DOMWorld, LoadParticleEmitter)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "world_complete.sdf");
+
+  sdf::Root root;
+  sdf::Errors errors = root.Load(testFile);
+  for (auto e : errors)
+    std::cout << e.Message() << std::endl;
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  ignition::math::Pose3d pose;
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ(ignition::math::Pose3d(0, 0, 0, 0, 0, 0), model->RawPose());
+  EXPECT_EQ("frame1", model->PoseRelativeTo());
+  EXPECT_TRUE(model->SemanticPose().Resolve(pose, "frame1").empty());
+  errors = model->SemanticPose().Resolve(pose, "frame1");
+  for (auto e : errors)
+    std::cout << e.Message() << std::endl;
+  EXPECT_EQ(ignition::math::Pose3d(0, 0, 0, 0, 0, 0), pose);
+  EXPECT_TRUE(model->SemanticPose().Resolve(pose, "world").empty());
+  EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 0), pose);
+  EXPECT_TRUE(model->SemanticPose().Resolve(pose).empty());
+  EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 0), pose);
+
+  const sdf::Link *link = model->LinkByIndex(0);
+  ASSERT_NE(nullptr, link);
+  const sdf::ParticleEmitter *linkEmitter = link->ParticleEmitterByIndex(0);
+  ASSERT_NE(nullptr, linkEmitter);
+  EXPECT_EQ("emitter", linkEmitter->Name());
+  EXPECT_TRUE(linkEmitter->SemanticPose().Resolve(pose).empty());
+  EXPECT_EQ(ignition::math::Pose3d(7, 8, 9, 0, 0, 0), pose);
+
+  EXPECT_TRUE(linkEmitter->Emitting());
+  EXPECT_EQ(ignition::math::Vector3d(10, 11, 12), linkEmitter->Size());
+  EXPECT_EQ(ignition::math::Vector3d(1, 2, 3), linkEmitter->ParticleSize());
+  EXPECT_DOUBLE_EQ(25, linkEmitter->Lifetime());
+  EXPECT_DOUBLE_EQ(0.1, linkEmitter->MinVelocity());
+  EXPECT_DOUBLE_EQ(0.2, linkEmitter->MaxVelocity());
+  EXPECT_DOUBLE_EQ(0.5, linkEmitter->ScaleRate());
+  EXPECT_DOUBLE_EQ(5, linkEmitter->Rate());
+
+  sdf::Material *mat = linkEmitter->Material();
+  ASSERT_NE(nullptr, mat);
+  EXPECT_EQ(ignition::math::Color(0.7, 0.7, 0.7), mat->Diffuse());
+  EXPECT_EQ(ignition::math::Color(1.0, 1.0, 1.0), mat->Specular());
+
+  sdf::Pbr *pbr = mat->PbrMaterial();
+  ASSERT_NE(nullptr, pbr);
+  sdf::PbrWorkflow *metal = pbr->Workflow(sdf::PbrWorkflowType::METAL);
+  ASSERT_NE(nullptr, metal);
+  EXPECT_EQ("materials/textures/fog.png", metal->AlbedoMap());
+
+  EXPECT_EQ("materials/textures/fogcolors.png", linkEmitter->ColorRangeImage());
+}

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -70,6 +70,28 @@
         <pose>4 5 6 0 0 0</pose>
       </frame>
       <link name="link">
+        <particle_emitter name="emitter" type="box">
+          <pose>7 8 9 0 0 0</pose>
+          <emitting>true</emitting>
+          <size>10 11 12</size>
+          <particle_size>1 2 3</particle_size>
+          <lifetime>25</lifetime>
+          <min_velocity>0.1</min_velocity>
+          <max_velocity>0.2</max_velocity>
+          <scale_rate>0.5</scale_rate>
+          <rate>5</rate>
+          <material>
+            <diffuse>0.7 0.7 0.7</diffuse>
+            <specular>1.0 1.0 1.0</specular>
+            <pbr>
+              <metal>
+                <albedo_map>materials/textures/fog.png</albedo_map>
+              </metal>
+            </pbr>
+          </material>
+          <color_range_image>materials/textures/fogcolors.png</color_range_image>
+        </particle_emitter>
+
         <light name="spot_light" type="spot">
           <pose relative_to="frame2">7 8 9 0 0 0</pose>
           <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
# 🎉 New feature

## Summary

Adds `<particle_emitter>` as a child element of `<link>`. The values contained within the particle emitter come from the [Ignition Gazebo Particle Emitter system](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/src/systems/particle_emitter/ParticleEmitter.hh).

## Test it

This is part of a series of pull requests designed to support particle emitter in gz3d.
See also:
  * ~~https://github.com/ignitionrobotics/ign-msgs/pull/149~~
  * https://github.com/ignitionrobotics/ign-gazebo/pull/730
  * https://github.com/ignitionrobotics/ign-launch/pull/104
 
## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**