### PR TITLE
Include XPath-like trace in parsing errors

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include <ignition/utils/ImplPtr.hh>
+
 #include "sdf/Param.hh"
 #include "sdf/sdf_config.h"
 #include "sdf/system_util.hh"
@@ -45,7 +47,6 @@ namespace sdf
   inline namespace SDF_VERSION_NAMESPACE {
   //
 
-  class ElementPrivate;
   class SDFORMAT_VISIBLE Element;
 
   /// \def ElementPtr
@@ -405,6 +406,14 @@ namespace sdf
     /// \return Full path to SDF document.
     public: const std::string &FilePath() const;
 
+    /// \brief Set the XML path of this element.
+    /// \param[in] _path Full XML path to the SDF element.
+    public: void SetXmlPath(const std::string &_path);
+
+    /// \brief Get the XML path of this element.
+    /// \return Full XML path to the SDF element.
+    public: const std::string &XmlPath() const;
+
     /// \brief Set the spec version that this was originally parsed from.
     /// \param[in] _version Spec version string.
     public: void SetOriginalVersion(const std::string &_version);
@@ -430,101 +439,8 @@ namespace sdf
     /// \return A pointer to the named element if found, nullptr otherwise.
     public: ElementPtr GetElementImpl(const std::string &_name) const;
 
-    /// \brief Generate a string (XML) representation of this object.
-    /// \param[in] _prefix arbitrary prefix to put on the string.
-    /// \param[out] _out the std::ostreamstream to write output to.
-    private: void ToString(const std::string &_prefix,
-                           std::ostringstream &_out) const;
-
-    /// \brief Generate a string (XML) representation of this object.
-    /// \param[in] _prefix arbitrary prefix to put on the string.
-    /// \param[out] _out the std::ostreamstream to write output to.
-    private: void PrintValuesImpl(const std::string &_prefix,
-                                  std::ostringstream &_out) const;
-
-    /// \brief Create a new Param object and return it.
-    /// \param[in] _key Key for the parameter.
-    /// \param[in] _type String name for the value type (double,
-    /// int,...).
-    /// \param[in] _defaultValue Default value.
-    /// \param[in] _required True if the parameter is required to be set.
-    /// \param[in] _description Description of the parameter.
-    /// \return A pointer to the new Param object.
-    private: ParamPtr CreateParam(const std::string &_key,
-                                  const std::string &_type,
-                                  const std::string &_defaultValue,
-                                  bool _required,
-                                  const std::string &_description="");
-
-
     /// \brief Private data pointer
-    private: std::unique_ptr<ElementPrivate> dataPtr;
-  };
-
-  /// \internal
-  /// \brief Private data for Element
-  class ElementPrivate
-  {
-    /// \brief Element name
-    public: std::string name;
-
-    /// \brief True if element is required
-    public: std::string required;
-
-    /// \brief Element description
-    public: std::string description;
-
-    /// \brief True if element's children should be copied.
-    public: bool copyChildren;
-
-    /// \brief Element's parent
-    public: ElementWeakPtr parent;
-
-    // Attributes of this element
-    public: Param_V attributes;
-
-    // Value of this element
-    public: ParamPtr value;
-
-    // The existing child elements
-    public: ElementPtr_V elements;
-
-    // The possible child elements
-    public: ElementPtr_V elementDescriptions;
-
-    /// \brief The <include> element that was used to load this entity. For
-    /// example, given the following SDFormat:
-    /// <sdf version='1.8'>
-    ///   <world name='default'>
-    ///     <include>
-    ///       <uri>model_uri</uri>
-    ///       <pose>1 2 3 0 0 0</pose>
-    ///     </include>
-    ///   </world>
-    /// </sdf>
-    /// The ElementPtr associated with the model loaded from `model_uri` will
-    /// have the includeElement set to
-    ///     <include>
-    ///       <uri>model_uri</uri>
-    ///       <pose>1 2 3 0 0 0</pose>
-    ///     </include>
-    ///
-    /// This can be used to retrieve additional information available under the
-    /// <include> tag after the entity has been loaded. An example use case for
-    /// this is when saving a loaded world back to SDFormat.
-    public: ElementPtr includeElement;
-
-    /// name of the include file that was used to create this element
-    public: std::string includeFilename;
-
-    /// \brief Name of reference sdf.
-    public: std::string referenceSDF;
-
-    /// \brief Path to file where this element came from
-    public: std::string path;
-
-    /// \brief Spec version that this was originally parsed from.
-    public: std::string originalVersion;
+    IGN_UTILS_IMPL_PTR(dataPtr)
   };
 
   ///////////////////////////////////////////////
@@ -555,10 +471,11 @@ namespace sdf
                                   const T &_defaultValue) const
   {
     std::pair<T, bool> result(_defaultValue, true);
+    ParamPtr value = this->GetValue();
 
-    if (_key.empty() && this->dataPtr->value)
+    if (_key.empty() && value)
     {
-      this->dataPtr->value->Get<T>(result.first);
+      value->Get<T>(result.first);
     }
     else if (!_key.empty())
     {
@@ -592,9 +509,10 @@ namespace sdf
   template<typename T>
   bool Element::Set(const T &_value)
   {
-    if (this->dataPtr->value)
+    ParamPtr value = this->GetValue();
+    if (value)
     {
-      this->dataPtr->value->Set(_value);
+      value->Set(_value);
       return true;
     }
     return false;

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -171,7 +171,7 @@ namespace sdf
     /// \param[in] _filePath The file path that is related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_path);
+                  const std::string &_xmlPath, const std::string &_filePath);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
@@ -182,7 +182,7 @@ namespace sdf
     /// this error was raised.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_path,
+                  const std::string &_xmlPath, const std::string &_filePath,
                   int _lineNumber);
 
     /// \brief Get the error code.

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -159,10 +159,11 @@ namespace sdf
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _filePath The file path that is related to this error.
+    /// \param[in] _path Either the file path or the XPath-like trace that is
+    /// related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_filePath);
+                  const std::string &_path);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
@@ -183,10 +184,12 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the file path associated with this error.
-    /// \return Returns the path of the file that this error is related to.
+    /// \brief Get the file path or the XPath-like trace that is associated with
+    /// this error.
+    /// \return Returns the path of the file or the XPath-like trace that this
+    /// error is related to.
     /// nullopt otherwise.
-    public: std::optional<std::string> FilePath() const;
+    public: std::optional<std::string> Path() const;
 
     /// \brief Get the line number associated with this error.
     /// \return Returns the line number. nullopt otherwise.
@@ -213,7 +216,7 @@ namespace sdf
     public: friend std::ostream &operator<<(std::ostream &_out,
                                             const sdf::Error &_err)
     {
-      if (!_err.FilePath().has_value())
+      if (!_err.Path().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
@@ -225,7 +228,7 @@ namespace sdf
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.FilePath().value() << "]: "
+          << ": [" << _err.Path().value() << "]: "
           << " Msg: " << _err.Message();
       }
       else
@@ -233,7 +236,7 @@ namespace sdf
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.FilePath().value() << ":L"
+          << ": [" << _err.Path().value() << ":L"
           << std::to_string(_err.LineNumber().value()) << "]: "
           << " Msg: " << _err.Message();
       }

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -159,21 +159,31 @@ namespace sdf
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _path Either the file path or the XPath-like trace that is
-    /// related to this error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_path);
+                  const std::string &_xmlPath);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
+    /// \param[in] _filePath The file path that is related to this error.
+    /// \sa ErrorCode.
+    public: Error(const ErrorCode _code, const std::string &_message,
+                  const std::string &_xmlPath, const std::string &_path);
+
+    /// \brief Constructor.
+    /// \param[in] _code The error code.
+    /// \param[in] _message A description of the error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \param[in] _filePath The file path that is related to this error.
     /// \param[in] _lineNumber The line number in the provided file path where
     /// this error was raised.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_filePath, int _lineNumber);
+                  const std::string &_xmlPath, const std::string &_path,
+                  int _lineNumber);
 
     /// \brief Get the error code.
     /// \return An error code.
@@ -184,12 +194,15 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the file path or the XPath-like trace that is associated with
-    /// this error.
-    /// \return Returns the path of the file or the XPath-like trace that this
-    /// error is related to.
+    /// \brief Get the XPath-like trace that is associated with this error.
+    /// \return Returns the XPath-like trace that this error is related to,
     /// nullopt otherwise.
-    public: std::optional<std::string> Path() const;
+    public: std::optional<std::string> XmlPath() const;
+
+    /// \brief Get the file path that is associated with this error.
+    /// \return Returns the path of the file that this error is related to,
+    /// nullopt otherwise.
+    public: std::optional<std::string> FilePath() const;
 
     /// \brief Get the line number associated with this error.
     /// \return Returns the line number. nullopt otherwise.
@@ -216,29 +229,39 @@ namespace sdf
     public: friend std::ostream &operator<<(std::ostream &_out,
                                             const sdf::Error &_err)
     {
-      if (!_err.Path().has_value())
+      if (!_err.XmlPath().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
           << " Msg: " << _err.Message();
+      }
+      else if (!_err.FilePath().has_value())
+      {
+        _out << "Error Code "
+          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
+              _err.Code())
+          << ": [" << _err.XmlPath().value()
+          << "]: Msg: " << _err.Message();
       }
       else if (!_err.LineNumber().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.Path().value() << "]: "
-          << " Msg: " << _err.Message();
+          << ": [" << _err.XmlPath().value()
+          << ":" << _err.FilePath().value()
+          << "]: Msg: " << _err.Message();
       }
       else
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.Path().value() << ":L"
-          << std::to_string(_err.LineNumber().value()) << "]: "
-          << " Msg: " << _err.Message();
+          << ": [" << _err.XmlPath().value()
+          << ":" << _err.FilePath().value()
+          << ":L" << std::to_string(_err.LineNumber().value())
+          << "]: Msg: " << _err.Message();
       }
       return _out;
     }

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -304,7 +304,7 @@ void Element::AddAttribute(const std::string &_key,
                            const std::string &_description)
 {
   this->dataPtr->attributes.push_back(
-      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required, 
+      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required,
                                  _description));
 }
 

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -37,6 +37,7 @@ TEST(Element, Child)
   sdf::Element child;
   sdf::ElementPtr parent = std::make_shared<sdf::Element>();
   parent->SetFilePath("/parent/path/model.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
   ASSERT_EQ(child.GetParent(), nullptr);
@@ -291,6 +292,7 @@ TEST(Element, Clone)
   parent->AddValue("string", "foo", false, "foo description");
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
   auto includeElemToStore = std::make_shared<sdf::Element>();
@@ -300,6 +302,7 @@ TEST(Element, Clone)
   sdf::ElementPtr newelem = parent->Clone();
 
   EXPECT_EQ("/path/to/file.sdf", newelem->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", newelem->XmlPath());
   EXPECT_EQ("1.5", newelem->OriginalVersion());
   ASSERT_NE(newelem->GetFirstElement(), nullptr);
   ASSERT_EQ(newelem->GetElementDescriptionCount(), 1UL);
@@ -315,11 +318,13 @@ TEST(Element, ClearElements)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -339,11 +344,13 @@ TEST(Element, Clear)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -353,6 +360,7 @@ TEST(Element, Clear)
 
   ASSERT_EQ(parent->GetFirstElement(), nullptr);
   EXPECT_TRUE(parent->FilePath().empty());
+  EXPECT_TRUE(parent->XmlPath().empty());
   EXPECT_TRUE(parent->OriginalVersion().empty());
 }
 
@@ -567,6 +575,7 @@ TEST(Element, Copy)
 
   src->SetName("test");
   src->SetFilePath("/path/to/file.sdf");
+  src->SetXmlPath("/sdf/world[@name=\"default\"");
   src->SetOriginalVersion("1.5");
   src->AddValue("string", "val", false, "val description");
   src->AddAttribute("test", "string", "foo", false, "foo description");
@@ -579,6 +588,7 @@ TEST(Element, Copy)
   dest->Copy(src);
 
   EXPECT_EQ("/path/to/file.sdf", dest->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", dest->XmlPath());
   EXPECT_EQ("1.5", dest->OriginalVersion());
 
   sdf::ParamPtr param = dest->GetValue();

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -27,8 +27,11 @@ class sdf::Error::Implementation
   /// \brief Description of the error.
   public: std::string message = "";
 
+  /// \brief Xml path where the error was raised.
+  public: std::optional<std::string> xmlPath = std::nullopt;
+
   /// \brief File path where the error was raised.
-  public: std::optional<std::string> path = std::nullopt;
+  public: std::optional<std::string> filePath = std::nullopt;
 
   /// \brief Line number in the file path where the error was raised.
   public: std::optional<int> lineNumber = std::nullopt;
@@ -49,22 +52,35 @@ Error::Error(const ErrorCode _code, const std::string &_message)
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_path)
+             const std::string &_xmlPath)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _path;
+  this->dataPtr->path = _xmlPath;
 }
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_filePath, int _lineNumber)
+             const std::string &_xmlPath, const std::string &_filePath)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _filePath;
+  this->dataPtr->xmlPath = _xmlPath;
+  this->dataPtr->filePath = _filePath;
+}
+
+/////////////////////////////////////////////////
+Error::Error(const ErrorCode _code, const std::string &_message,
+             const std::string &_xmlPath, const std::string &_filePath,
+             int lineNumber)
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->code = _code;
+  this->dataPtr->message = _message;
+  this->dataPtr->xmlPath = _xmlPath;
+  this->dataPtr->filePath = _filePath;
   this->dataPtr->lineNumber = _lineNumber;
 }
 
@@ -81,9 +97,15 @@ std::string Error::Message() const
 }
 
 /////////////////////////////////////////////////
-std::optional<std::string> Error::Path() const
+std::optional<std::string> Error::XmlPath() const
 {
-  return this->dataPtr->path;
+  return this->dataPtr->xmlPath;
+}
+
+/////////////////////////////////////////////////
+std::optional<std::string> Error::FilePath() const
+{
+  return this->dataPtr->filePath;
 }
 
 /////////////////////////////////////////////////

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -57,7 +57,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _xmlPath;
+  this->dataPtr->xmlPath = _xmlPath;
 }
 
 /////////////////////////////////////////////////
@@ -74,7 +74,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
              const std::string &_xmlPath, const std::string &_filePath,
-             int lineNumber)
+             int _lineNumber)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -28,7 +28,7 @@ class sdf::Error::Implementation
   public: std::string message = "";
 
   /// \brief File path where the error was raised.
-  public: std::optional<std::string> filePath = std::nullopt;
+  public: std::optional<std::string> path = std::nullopt;
 
   /// \brief Line number in the file path where the error was raised.
   public: std::optional<int> lineNumber = std::nullopt;
@@ -49,12 +49,12 @@ Error::Error(const ErrorCode _code, const std::string &_message)
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_filePath)
+             const std::string &_path)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->filePath = _filePath;
+  this->dataPtr->path = _path;
 }
 
 /////////////////////////////////////////////////
@@ -64,7 +64,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->filePath = _filePath;
+  this->dataPtr->path = _filePath;
   this->dataPtr->lineNumber = _lineNumber;
 }
 
@@ -81,9 +81,9 @@ std::string Error::Message() const
 }
 
 /////////////////////////////////////////////////
-std::optional<std::string> Error::FilePath() const
+std::optional<std::string> Error::Path() const
 {
-  return this->dataPtr->filePath;
+  return this->dataPtr->path;
 }
 
 /////////////////////////////////////////////////

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -27,7 +27,8 @@ TEST(Error, DefaultConstruction)
   EXPECT_EQ(error, false);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::NONE);
   EXPECT_TRUE(error.Message().empty());
-  EXPECT_FALSE(error.Path().has_value());
+  EXPECT_FALSE(error.XmlPath().has_value());
+  EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (error)
@@ -41,7 +42,8 @@ TEST(Error, ValueConstructionWithoutFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_FALSE(error.Path().has_value());
+  EXPECT_FALSE(error.XmlPath().has_value());
+  EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (!error)
@@ -49,18 +51,66 @@ TEST(Error, ValueConstructionWithoutFile)
 }
 
 /////////////////////////////////////////////////
-TEST(Error, ValueConstructionWithFile)
+TEST(Error, ValueConstructionWithXmlPath)
 {
-  const std::string emptyFilePath = "Empty/file/path";
-  sdf::Error error(sdf::ErrorCode::FILE_READ, "Unable to read a file",
-                   emptyFilePath, 10);
+  const std::string emptyXmlPath = "/sdf/model";
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath);
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.Path().has_value());
-  EXPECT_EQ(error.Path().value(), emptyFilePath);
+  REQUIRE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.LineNumber().has_value());
+}
+
+/////////////////////////////////////////////////
+TEST(Error, ValueConstructionWithFile)
+{
+  const std::string emptyXmlPath = "/sdf/model";
+  const std::string emptyFilePath = "Empty/file/path";
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath,
+    emptyFilePath);
+  EXPECT_EQ(error, true);
+  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
+  EXPECT_EQ(error.Message(), "Unable to read a file");
+  EXPECT_TRUE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_TRUE(error.FilePath().has_value());
+  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
+  EXPECT_FALSE(error.LineNumber().has_value());
+
+  if (!error)
+    FAIL();
+}
+
+/////////////////////////////////////////////////
+TEST(Error, ValueConstructionWithLineNumber)
+{
+  const std::string emptyXmlPath = "/sdf/model";
+  const std::string emptyFilePath = "Empty/file/path";
+  const int lineNumber = 10;
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath,
+    emptyFilePath,
+    lineNumber);
+  EXPECT_EQ(error, true);
+  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
+  EXPECT_EQ(error.Message(), "Unable to read a file");
+  EXPECT_TRUE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_TRUE(error.FilePath().has_value());
+  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   EXPECT_TRUE(error.LineNumber().has_value());
-  EXPECT_EQ(error.LineNumber().value(), 10);
+  EXPECT_EQ(error.LineNumber().value(), lineNumber);
 
   if (!error)
     FAIL();

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -27,7 +27,7 @@ TEST(Error, DefaultConstruction)
   EXPECT_EQ(error, false);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::NONE);
   EXPECT_TRUE(error.Message().empty());
-  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.Path().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (error)
@@ -41,7 +41,7 @@ TEST(Error, ValueConstructionWithoutFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.Path().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (!error)
@@ -57,8 +57,8 @@ TEST(Error, ValueConstructionWithFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.FilePath().has_value());
-  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
+  EXPECT_TRUE(error.Path().has_value());
+  EXPECT_EQ(error.Path().value(), emptyFilePath);
   EXPECT_TRUE(error.LineNumber().has_value());
   EXPECT_EQ(error.LineNumber().value(), 10);
 

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -61,7 +61,7 @@ TEST(Error, ValueConstructionWithXmlPath)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  REQUIRE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
   EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
@@ -80,9 +80,9 @@ TEST(Error, ValueConstructionWithFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
-  EXPECT_TRUE(error.FilePath().has_value());
+  ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   EXPECT_FALSE(error.LineNumber().has_value());
 
@@ -105,11 +105,11 @@ TEST(Error, ValueConstructionWithLineNumber)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
-  EXPECT_TRUE(error.FilePath().has_value());
+  ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
-  EXPECT_TRUE(error.LineNumber().has_value());
+  ASSERT_TRUE(error.LineNumber().has_value());
   EXPECT_EQ(error.LineNumber().value(), lineNumber);
 
   if (!error)

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -106,24 +106,24 @@ void enforceConfigurablePolicyCondition(
       _errors.push_back(_error);
       break;
     case EnforcementPolicy::WARN:
-      if (!_error.FilePath().has_value())
+      if (!_error.Path().has_value())
         sdfwarn << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfwarn << "[" << _error.FilePath().value() << "]: "
+        sdfwarn << "[" << _error.Path().value() << "]: "
             << _error.Message();
       else
-        sdfwarn << "[" << _error.FilePath().value() << ":L"
+        sdfwarn << "[" << _error.Path().value() << ":L"
             << _error.LineNumber().value() << "]: "
             << _error.Message();
       break;
     case EnforcementPolicy::LOG:
-      if (!_error.FilePath().has_value())
+      if (!_error.Path().has_value())
         sdfdbg << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfdbg << "[" << _error.FilePath().value() << "]: "
+        sdfdbg << "[" << _error.Path().value() << "]: "
             << _error.Message();
       else
-        sdfdbg << "[" << _error.FilePath().value() << ":L"
+        sdfdbg << "[" << _error.Path().value() << ":L"
             << _error.LineNumber().value() << "]: "
             << _error.Message();
       break;

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -106,26 +106,42 @@ void enforceConfigurablePolicyCondition(
       _errors.push_back(_error);
       break;
     case EnforcementPolicy::WARN:
-      if (!_error.Path().has_value())
+      if (!_error.XmlPath().has_value())
         sdfwarn << _error.Message();
+      else if (!_error.FilePath().has_value())
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << "]: " << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfwarn << "[" << _error.Path().value() << "]: "
-            << _error.Message();
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << "]: " << _error.Message();
       else
-        sdfwarn << "[" << _error.Path().value() << ":L"
-            << _error.LineNumber().value() << "]: "
-            << _error.Message();
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << ":L" << _error.LineNumber().value()
+            << "]: " << _error.Message();
       break;
     case EnforcementPolicy::LOG:
-      if (!_error.Path().has_value())
+      if (!_error.XmlPath().has_value())
         sdfdbg << _error.Message();
+      else if (!_error.FilePath().has_value())
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << "]: " << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfdbg << "[" << _error.Path().value() << "]: "
-            << _error.Message();
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << "]: " << _error.Message();
       else
-        sdfdbg << "[" << _error.Path().value() << ":L"
-            << _error.LineNumber().value() << "]: "
-            << _error.Message();
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << ":L" << _error.LineNumber().value()
+            << "]: " << _error.Message();
       break;
     default:
       throw std::runtime_error("Unhandled warning policy enum value");

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -141,8 +141,8 @@ TEST(PolicyUtils, EnforcementPolicyErrors)
   EXPECT_EQ(errors[0], true);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(errors[0].Message(), "Unable to read a file");
-  EXPECT_TRUE(errors[0].FilePath().has_value());
-  EXPECT_EQ(errors[0].FilePath().value(), emptyFilePath);
+  EXPECT_TRUE(errors[0].Path().has_value());
+  EXPECT_EQ(errors[0].Path().value(), emptyFilePath);
   EXPECT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 10);
 }

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -127,9 +127,14 @@ TEST(DOMUtils, ReservedNames)
 TEST(PolicyUtils, EnforcementPolicyErrors)
 {
   sdf::Errors errors;
+  const std::string emptyXmlPath = "/sdf/model";
   const std::string emptyFilePath = "Empty/file/path";
-  sdf::Error error(sdf::ErrorCode::FILE_READ, "Unable to read a file",
-                   emptyFilePath, 10);
+  sdf::Error error(
+      sdf::ErrorCode::FILE_READ,
+      "Unable to read a file",
+      emptyXmlPath,
+      emptyFilePath,
+      10);
   ASSERT_EQ(error, true);
   ASSERT_TRUE(errors.empty());
 
@@ -141,8 +146,10 @@ TEST(PolicyUtils, EnforcementPolicyErrors)
   EXPECT_EQ(errors[0], true);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(errors[0].Message(), "Unable to read a file");
-  EXPECT_TRUE(errors[0].Path().has_value());
-  EXPECT_EQ(errors[0].Path().value(), emptyFilePath);
-  EXPECT_TRUE(errors[0].LineNumber().has_value());
+  ASSERT_TRUE(errors[0].XmlPath().has_value());
+  EXPECT_EQ(errors[0].XmlPath().value(), emptyXmlPath);
+  ASSERT_TRUE(errors[0].FilePath().has_value());
+  EXPECT_EQ(errors[0].FilePath().value(), emptyFilePath);
+  ASSERT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 10);
 }

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -682,6 +682,11 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
       _sdf->Root()->SetOriginalVersion(sdfNode->Attribute("version"));
     }
 
+    if (_sdf->Root()->XmlPath().empty())
+    {
+      _sdf->Root()->SetXmlPath("/sdf");
+    }
+
     if (_convert
         && strcmp(sdfNode->Attribute("version"), SDF::Version().c_str()) != 0)
     {
@@ -691,7 +696,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
 
     // parse new sdf xml
     auto *elemXml = _xmlDoc->FirstChildElement(_sdf->Root()->GetName().c_str());
-    if (!readXml(elemXml, _sdf->Root(), _config, "/sdf", _source, _errors))
+    if (!readXml(elemXml, _sdf->Root(), _config, _source, _errors))
     {
       _errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Error reading element <" + _sdf->Root()->GetName() + ">"});
@@ -757,6 +762,11 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
       _sdf->SetOriginalVersion(sdfNode->Attribute("version"));
     }
 
+    if (_sdf->XmlPath().empty())
+    {
+      _sdf->SetXmlPath("/sdf");
+    }
+
     if (_convert
         && strcmp(sdfNode->Attribute("version"), SDF::Version().c_str()) != 0)
     {
@@ -773,7 +783,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
     }
 
     // parse new sdf xml
-    if (!readXml(elemXml, _sdf, _config, "/sdf", _source, _errors))
+    if (!readXml(elemXml, _sdf, _config, _source, _errors))
     {
       _errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Unable to parse sdf element["+ _sdf->GetName() + "]"});
@@ -927,8 +937,7 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 
 //////////////////////////////////////////////////
 bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
-    const ParserConfig &_config, const std::string &_xmlPath,
-    const std::string &_source, Errors &_errors)
+    const ParserConfig &_config, const std::string &_source, Errors &_errors)
 {
   // Check if the element pointer is deprecated.
   if (_sdf->GetRequired() == "-1")
@@ -937,7 +946,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     ss << "SDF Element[" + _sdf->GetName() + "] is deprecated\n";
     enforceConfigurablePolicyCondition(
         _config.WarningsPolicy(),
-        Error(ErrorCode::ELEMENT_DEPRECATED, ss.str(), _xmlPath),
+        Error(ErrorCode::ELEMENT_DEPRECATED, ss.str(), _sdf->XmlPath()),
         _errors);
   }
 
@@ -948,7 +957,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       _errors.push_back({
           ErrorCode::ELEMENT_MISSING,
           "SDF Element<" + _sdf->GetName() + "> is missing",
-          _xmlPath,
+          _sdf->XmlPath(),
           _source});
       return false;
     }
@@ -1010,8 +1019,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
     // Construct the Xml path of the current attribute
     const std::string attributeXmlPath =
-        _xmlPath + "[@" + attribute->Name() + "=\"" + attribute->Value() +
-        "\"]";
+        _sdf->XmlPath() + "[@" + attribute->Name() + "=\"" +
+        attribute->Value() + "\"]";
 
     // Find the matching attribute in SDF
     for (i = 0; i < _sdf->GetAttributeCount(); ++i)
@@ -1079,7 +1088,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           ErrorCode::ATTRIBUTE_MISSING,
           "Required attribute[" + p->GetKey() + "] in element[" + _xml->Value()
           + "] is not specified in SDF.",
-          _xmlPath,
+          _sdf->XmlPath(),
           _source,
           _xml->GetLineNum()});
       return false;
@@ -1110,7 +1119,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
         includeElemIndex++;
         const std::string includeXmlPath =
-            _xmlPath + "/include[" + std::to_string(includeElemIndex) + "]";
+            _sdf->XmlPath() + "/include[" + std::to_string(includeElemIndex) +
+            "]";
         const std::string uriXmlPath = includeXmlPath + "/uri";
 
         if (uriElement)
@@ -1135,7 +1145,6 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             {
               // Get the model.config filename
               filename = getModelFilePath(modelPath);
-
               if (filename.empty())
               {
                 _errors.push_back({
@@ -1356,9 +1365,9 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
                 sdf::ElementPtr pluginElem;
                 pluginElem = topLevelElem->AddElement("plugin");
+                pluginElem->SetXmlPath(pluginXmlPath);
 
-                if (!readXml(
-                    childElemXml, pluginElem, _config, pluginXmlPath, _source,
+                if (!readXml(childElemXml, pluginElem, _config, _source,
                     _errors))
                 {
                   _errors.push_back({
@@ -1398,14 +1407,15 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
         if (elemDesc->GetName() == elemXml->Value())
         {
-          std::string elemXmlPath = _xmlPath + "/" + elemXml->Value();
+          std::string elemXmlPath = _sdf->XmlPath() + "/" + elemXml->Value();
           const char *name = elemXml->Attribute("name");
           if (name)
             elemXmlPath += "[@name=\"" + std::string(name) + "\"]";
 
           ElementPtr element = elemDesc->Clone();
           element->SetParent(_sdf);
-          if (readXml(elemXml, element, _config, elemXmlPath, _source, _errors))
+          element->SetXmlPath(elemXmlPath);
+          if (readXml(elemXml, element, _config, _source, _errors))
           {
             _sdf->InsertElement(element);
           }
@@ -1427,7 +1437,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       if (descCounter == _sdf->GetElementDescriptionCount()
             && std::strchr(elemXml->Value(), ':') == nullptr)
       {
-        std::string elemXmlPath = _xmlPath + "/" + elemXml->Value();
+        std::string elemXmlPath = _sdf->XmlPath() + "/" + elemXml->Value();
         const char *name = elemXml->Attribute("name");
         if (name)
           elemXmlPath += "[@name=\"" + std::string(name) + "\"]";
@@ -1465,7 +1475,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       {
         if (!_sdf->HasElement(elemDesc->GetName()))
         {
-          const std::string elemXmlPath = _xmlPath + "/" +
+          const std::string elemXmlPath = _sdf->XmlPath() + "/" +
               elemDesc->GetName();
           if (_sdf->GetName() == "joint" &&
               _sdf->Get<std::string>("type") != "ball")

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1145,6 +1145,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             {
               // Get the model.config filename
               filename = getModelFilePath(modelPath);
+
               if (filename.empty())
               {
                 _errors.push_back({
@@ -1367,8 +1368,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 pluginElem = topLevelElem->AddElement("plugin");
                 pluginElem->SetXmlPath(pluginXmlPath);
 
-                if (!readXml(childElemXml, pluginElem, _config, _source,
-                    _errors))
+                if (!readXml(
+                    childElemXml, pluginElem, _config, _source, _errors))
                 {
                   _errors.push_back({
                       ErrorCode::ELEMENT_INVALID,

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -304,6 +304,8 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [bad 0 0 0 0 0 ] for key[pose]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_pose.sdf:L5");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/pose:");
   }
   {
     // clear the contents of the buffer
@@ -316,6 +318,9 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [bad ] for key[linear]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_double.sdf:L7");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/"
+                 "link[@name=\"link\"]/velocity_decay/linear:");
   }
   {
     // clear the contents of the buffer
@@ -328,6 +333,8 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [0 1 bad ] for key[gravity]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_vector.sdf:L4");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/gravity:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests
@@ -364,6 +371,8 @@ TEST(Parser, MissingRequiredAttributesErrors)
                  "Required attribute[name] in element[link] is not specified "
                  "in SDF.");
     EXPECT_PRED2(contains, buffer.str(), "box_bad_test.world:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"box\"]/link:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests
@@ -399,6 +408,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "<include> element missing 'uri' attribute");
     EXPECT_PRED2(contains, buffer.str(), "includes_missing_uri.sdf:L5");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]:");
   }
   {
     // clear the contents of the buffer
@@ -417,6 +428,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to find uri[missing_model]");
     EXPECT_PRED2(contains, buffer.str(), "includes_missing_model.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
     // clear the contents of the buffer
@@ -443,6 +456,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "since it does not contain a model.config");
     EXPECT_PRED2(contains, buffer.str(), "includes_model_without_sdf.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
     // clear the contents of the buffer
@@ -469,6 +484,8 @@ TEST(Parser, IncludesErrors)
                  "Failed to find top level <model> / <actor> / <light> for "
                  "<include>\n");
     EXPECT_PRED2(contains, buffer.str(), "includes_without_top_level.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -83,12 +83,14 @@ namespace sdf
   /// \param[in] _xml Pointer to the TinyXML element
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[in] _config Custom parser configuration
+  /// \param[in] _xmlPath XPath-like trace.
   /// \param[in] _source Source of the XML document, empty if it came from a
   ///            string.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.
   static bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
-      const ParserConfig &_config, const std::string &_source, Errors &_errors);
+      const ParserConfig &_config, const std::string &_xmlPath,
+      const std::string &_source, Errors &_errors);
 
   /// \brief Copy child XML elements into the _sdf element.
   /// \param[in] _sdf Parent Element.

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -83,14 +83,12 @@ namespace sdf
   /// \param[in] _xml Pointer to the TinyXML element
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[in] _config Custom parser configuration
-  /// \param[in] _xmlPath XPath-like trace.
   /// \param[in] _source Source of the XML document, empty if it came from a
   ///            string.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.
   static bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
-      const ParserConfig &_config, const std::string &_xmlPath,
-      const std::string &_source, Errors &_errors);
+      const ParserConfig &_config, const std::string &_source, Errors &_errors);
 
   /// \brief Copy child XML elements into the _sdf element.
   /// \param[in] _sdf Parent Element.


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/osrf/sdformat/issues/510

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This further adds information of where parsing errors occurred, specifically when `readXml` is called.

Changes to `sdf::Error`:
* Added `XmlPath` to the API
* Added more constructors to accommodate this new field
* Operator `<<` now handles printouts depending on availability of `XmlPath`, `FilePath` and `LineNumber`
  * `Error Code #: [XML_PATH]: Msg: ...`
  * `Error Code #: [XML_PATH:FILE_PATH]: Msg: ...`
  * `Error Code #: [XML_PATH:FILE_PATH:L#]: Msg: ...`
* Added tests

Changes to `sdf::Element`:
* `pimpl`-ized
* Added API for `XmlPath`
* Added tests

Changes to `Utils`:
* Added XML path support to `sdfwarn` and `sdfdbg`
* Added tests

Changes to `parser`:
* Keeps track XML path as it parses the SDF
* Attributes the XML path to each corresponding SDF Element

## Test it
<!--Explain how reviewers can test this new feature manually.-->

```bash
source ws/install/setup.bash
./ws/build/sdformat11/src/UNIT_Error_TEST
./ws/build/sdformat11/src/UNIT_Element_TEST
./ws/build/sdformat11/src/UNIT_Utils_TEST
./ws/build/sdformat11/src/UNIT_parser_TEST
```

Testing with `ign sdf -k`
```bash
source ws/install/setup.bash
cd ws/src/sdformat/test/sdf
ign sdf -k bad_syntax_double.sdf
```

We would expect the top of the error message stack to be,
```bash
Error Code 9: [/sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"]/velocity_decay/linear:/ws/src/sdformat/test/sdf/bad_syntax_double.sdf:L7]: Msg: Error reading element <linear>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**