### PR TITLE
Reference local schema files

### DIFF
--- a/sdf/1.7/CMakeLists.txt
+++ b/sdf/1.7/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (sdfs
   actor.sdf
+  air_pressure.sdf
   altimeter.sdf
   atmosphere.sdf
   audio_source.sdf
@@ -7,6 +8,7 @@ set (sdfs
   battery.sdf
   box_shape.sdf
   camera.sdf
+  collision_engine.sdf
   collision.sdf
   contact.sdf
   cylinder_shape.sdf
@@ -21,6 +23,7 @@ set (sdfs
   imu.sdf
   inertial.sdf
   joint.sdf
+  lidar.sdf
   light.sdf
   light_state.sdf
   link.sdf
@@ -52,6 +55,7 @@ set (sdfs
   state.sdf
   surface.sdf
   transceiver.sdf
+  urdf.sdf
   visual.sdf
   world.sdf
 )

--- a/sdf/1.7/light_state.sdf
+++ b/sdf/1.7/light_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a light -->
-<element name="light" required="*">
+<element name="light_state" required="*">
   <description>Light state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.7/link_state.sdf
+++ b/sdf/1.7/link_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a link -->
-<element name="link" required="*">
+<element name="link_state" required="*">
   <description>Link state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">

--- a/sdf/1.7/model_state.sdf
+++ b/sdf/1.7/model_state.sdf
@@ -1,5 +1,5 @@
 <!-- State information for a model -->
-<element name="model" required="*">
+<element name="model_state" required="*">
   <description>Model state</description>
 
   <attribute name="name" type="string" default="__default__" required="1">


### PR DESCRIPTION
Signed-off-by: Jenn Nguyen <jenn@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #530 

## Summary
The [xmlschema.rb](https://github.com/osrf/sdformat/blob/5dd47491cd824336c4ecc5ac2ee6c2759d0f0941/tools/xmlschema.rb) script converts .sdf description files to xml schema (.xsd files) and now references local .xsd files instead of referencing files from http://sdformat.org/schemas/ 

Before the fix, running the [integration test](https://github.com/osrf/sdformat/blob/8496164cac259e13083023efb06b76a04b1f8d3e/test/integration/schema_test.cc) required internet connection. With the fix, the internet is no longer required. 

1. In the build directory, delete the `sdf/1.7` folder
2. Recompile
3. Run `INTEGRATION_schema_test` while disconnected to the internet


<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [X] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
