### PR TITLE
Add an EnforcementPolicy for deprecated elements

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,9 +12,32 @@ forward programmatically.
 This document aims to contain similar information to those files
 but with improved human-readability..
 
+## libsdformat 11.0.0 to 11.x.x
+
+### Additions
+
+1. **sdf/Console.hh** Add functions to retrieve message stream objects. These 
+   can be useful for redirecting the console output to other streams.
+    + ConsoleStream &GetMsgStream()
+    + ConsoleStream &GetLogStream()
+
+1. **sdf/ParserConfig.hh**:
+    + void SetDeprecatedElementsPolicy(EnforcementPolicy _policy)
+    + void ResetDeprecatedElementsPolicy()
+    + EnforcementPolicy DeprecatedElementsPolicy() const
+
+1. **test/test_utils.hh**:
+    + ScopeExit: A utility struct that calls a function when going out of scope.
+    + RedirectConsoleStream: A utility class used for redirecting the output of 
+      sdferr, sdfwarn, etc to a more convenient stream object like a 
+      std::stringstream for testing purposes.
+
 ## libsdformat 10.x to 11.0
 
 ### Additions
+
+1. **sdf/ParserConfig.hh** A class that contains configuration options for the 
+   libsdformat parser.
 
 1. + Depend on ignition-utils1 for the ImplPtr and UniqueImplPtr.
    + [Pull request 474](https://github.com/osrf/sdformat/pull/474)

--- a/include/sdf/Console.hh
+++ b/include/sdf/Console.hh
@@ -92,6 +92,16 @@ namespace sdf
                           const std::string &_file,
                           unsigned int _line, int _color);
 
+      /// \brief Set the stream object.
+      /// \param[in] _stream Pointer to an output stream. This can be
+      /// useful for redirecting the output, for example, to a std::stringstream
+      /// for testing.
+      public: void SetStream(std::ostream *_stream);
+
+      /// \brief Get the current stream object.
+      /// \return Pointer to current stream object.
+      public: std::ostream *GetStream();
+
       /// \brief The ostream to log to; can be NULL/nullptr.
       private: std::ostream *stream;
     };
@@ -130,6 +140,18 @@ namespace sdf
     public: ConsoleStream &Log(const std::string &lbl,
                                const std::string &file,
                                unsigned int line);
+
+    /// \brief Get the current message stream object. This can be
+    /// useful for redirecting the output, for example, to a std::stringstream
+    /// for testing.
+    /// \return Mutable reference to current message stream object.
+    public: ConsoleStream &GetMsgStream();
+
+    /// \brief Get the current log stream object. This can be
+    /// useful for redirecting the output, for example, to a std::stringstream
+    /// for testing.
+    /// \return Mutable reference to current log stream object.
+    public: ConsoleStream &GetLogStream();
 
     /// \internal
     /// \brief Pointer to private data.

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -101,6 +101,7 @@ namespace sdf
 
     /// \brief Set the requirement type.
     /// \param[in] _req Requirement type for this element:
+    /// -1: Deprecated.
     /// 0: Not required.
     /// 1: Exactly one element is required.
     /// +: One or more elements are required.

--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -152,7 +152,7 @@ class SDFORMAT_VISIBLE ParserConfig
   /// WarningsPolicy.
   public: void ResetDeprecatedElementsPolicy();
 
-  /// \brief Get the current deperacted elements policy. By default, the policy
+  /// \brief Get the current deprecated elements policy. By default, the policy
   /// is the same as the overall WarningsPolicy, but it can be overriden by
   /// SetDeprecatedElementsPolicy. Once it is overriden, changing
   /// SetWarningsPolicy will not change the value of DeprecatedElementsPolicy

--- a/include/sdf/ParserConfig.hh
+++ b/include/sdf/ParserConfig.hh
@@ -144,6 +144,22 @@ class SDFORMAT_VISIBLE ParserConfig
   /// \return The unrecognized elements policy enum value
   public: EnforcementPolicy UnrecognizedElementsPolicy() const;
 
+  /// \brief Set the policy for deprecated elements.
+  /// \param[in] _policy The deprecated elements enforcement policy
+  public: void SetDeprecatedElementsPolicy(EnforcementPolicy _policy);
+
+  /// \brief Resets the policy for deprecated elements so that it follows
+  /// WarningsPolicy.
+  public: void ResetDeprecatedElementsPolicy();
+
+  /// \brief Get the current deperacted elements policy. By default, the policy
+  /// is the same as the overall WarningsPolicy, but it can be overriden by
+  /// SetDeprecatedElementsPolicy. Once it is overriden, changing
+  /// SetWarningsPolicy will not change the value of DeprecatedElementsPolicy
+  /// unless ResetDeprecatedElementsPolicy is called.
+  /// \return The deperacted elements policy enum value
+  public: EnforcementPolicy DeprecatedElementsPolicy() const;
+
   /// \brief Registers a custom model parser.
   /// \param[in] _modelParser Callback as described in
   /// sdf/InterfaceElements.hh.

--- a/src/Console.cc
+++ b/src/Console.cc
@@ -109,6 +109,18 @@ void Console::SetQuiet(bool _quiet)
 }
 
 //////////////////////////////////////////////////
+sdf::Console::ConsoleStream &Console::GetMsgStream()
+{
+  return this->dataPtr->msgStream;
+}
+
+//////////////////////////////////////////////////
+sdf::Console::ConsoleStream &Console::GetLogStream()
+{
+  return this->dataPtr->logStream;
+}
+
+//////////////////////////////////////////////////
 Console::ConsoleStream &Console::ColorMsg(const std::string &lbl,
                                           const std::string &file,
                                           unsigned int line, int color)
@@ -159,4 +171,16 @@ void Console::ConsoleStream::Prefix(const std::string &_lbl,
     Console::Instance()->dataPtr->logFileStream << _lbl << " [" <<
       _file.substr(index , _file.size() - index)<< ":" << _line << "] ";
   }
+}
+
+//////////////////////////////////////////////////
+void Console::ConsoleStream::SetStream(std::ostream *_stream)
+{
+  this->stream = _stream;
+}
+
+//////////////////////////////////////////////////
+std::ostream *Console::ConsoleStream::GetStream()
+{
+  return this->stream;
 }

--- a/src/ParserConfig.cc
+++ b/src/ParserConfig.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <optional>
+
 #include "sdf/ParserConfig.hh"
 #include "sdf/Filesystem.hh"
 #include "sdf/Types.hh"
@@ -35,6 +37,11 @@ class sdf::ParserConfig::Implementation
   /// Default is to ignore them for compatibility with legacy behavior
   public: EnforcementPolicy unrecognizedElementsPolicy =
     EnforcementPolicy::LOG;
+
+  /// \brief Policy indicating how deprecated elements are treated.
+  /// Defaults to the value of `warningsPolicy`. It can be overriden by the user
+  /// to behave behave differently than the `warningsPolicy`.
+  public: std::optional<EnforcementPolicy> deprecatedElementsPolicy;
 
   /// \brief Collection of custom model parsers.
   public: std::vector<CustomModelParser> customParsers;
@@ -114,6 +121,25 @@ void ParserConfig::SetUnrecognizedElementsPolicy(EnforcementPolicy _policy)
 EnforcementPolicy ParserConfig::UnrecognizedElementsPolicy() const
 {
   return this->dataPtr->unrecognizedElementsPolicy;
+}
+
+/////////////////////////////////////////////////
+void ParserConfig::SetDeprecatedElementsPolicy(EnforcementPolicy _policy)
+{
+  this->dataPtr->deprecatedElementsPolicy = _policy;
+}
+
+/////////////////////////////////////////////////
+void ParserConfig::ResetDeprecatedElementsPolicy()
+{
+  this->dataPtr->deprecatedElementsPolicy.reset();
+}
+
+/////////////////////////////////////////////////
+EnforcementPolicy ParserConfig::DeprecatedElementsPolicy() const
+{
+  return this->dataPtr->deprecatedElementsPolicy.value_or(
+      this->dataPtr->warningsPolicy);
 }
 
 /////////////////////////////////////////////////

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -935,7 +935,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     std::stringstream ss;
     ss << "SDF Element[" + _sdf->GetName() + "] is deprecated\n";
     enforceConfigurablePolicyCondition(
-        _config.WarningsPolicy(),
+        _config.DeprecatedElementsPolicy(),
         Error(ErrorCode::ELEMENT_DEPRECATED, ss.str()),
         _errors);
   }

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -78,6 +78,11 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
 
 #ifdef _WIN32
   sdf::Console::Instance()->SetQuiet(false);
+  sdf::testing::ScopeExit revertSetQuiet(
+      []
+      {
+        sdf::Console::Instance()->SetQuiet(true);
+      });
 #endif
 
   sdf::SDFPtr sdf(new sdf::SDF());
@@ -123,7 +128,4 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
     ASSERT_FALSE(errors.empty());
     EXPECT_EQ(sdf::ErrorCode::ELEMENT_DEPRECATED, errors[0].Code());
   }
-#ifdef _WIN32
-  sdf::Console::Instance()->SetQuiet(true);
-#endif
 }

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -63,6 +63,11 @@ TEST(DeprecatedElements, CanEmitErrors)
   EXPECT_EQ(sdf::ErrorCode::ELEMENT_DEPRECATED, errors[0].Code());
 }
 
+bool contains(const std::string &_a, const std::string &_b)
+{
+  return _a.find(_b) != std::string::npos;
+}
+
 ////////////////////////////////////////////////////
 TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
 {
@@ -74,11 +79,6 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
 #ifdef _WIN32
   sdf::Console::Instance()->SetQuiet(false);
 #endif
-
-  auto contains = [](const std::string &_a, const std::string &_b)
-  {
-    return _a.find(_b) != std::string::npos;
-  };
 
   sdf::SDFPtr sdf(new sdf::SDF());
   sdf::init(sdf);

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -22,6 +22,7 @@
 #include "sdf/ParserConfig.hh"
 #include "sdf/parser.hh"
 #include "test_config.h"
+#include "test_utils.hh"
 
 ////////////////////////////////////////////////////
 TEST(DeprecatedSpecs, Spec1_0)
@@ -65,9 +66,10 @@ TEST(DeprecatedElements, CanEmitErrors)
 ////////////////////////////////////////////////////
 TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
 {
-  // Capture sdfwarn output, which is treamed to std::cerr
+  // Redirect sdfwarn output
   std::stringstream buffer;
-  auto old = std::cerr.rdbuf(buffer.rdbuf());
+  sdf::testing::RedirectConsoleStream redir(
+      sdf::Console::Instance()->GetMsgStream(), &buffer);
 
 #ifdef _WIN32
   sdf::Console::Instance()->SetQuiet(false);
@@ -121,9 +123,6 @@ TEST(DeprecatedElements, CanEmitWarningWithErrorEnforcmentPolicy)
     ASSERT_FALSE(errors.empty());
     EXPECT_EQ(sdf::ErrorCode::ELEMENT_DEPRECATED, errors[0].Code());
   }
-
-  // Revert cerr rdbug so as to not interfere with other tests
-  std::cerr.rdbuf(old);
 #ifdef _WIN32
   sdf::Console::Instance()->SetQuiet(true);
 #endif

--- a/test/test_utils.hh
+++ b/test/test_utils.hh
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef SDF_TEST_UTILS_HH_
+#define SDF_TEST_UTILS_HH_
+
+#include <ostream>
+#include "sdf/Console.hh"
+
+namespace sdf
+{
+namespace testing
+{
+
+/// \brief A class used for redirecting the output of sdferr, sdfwarn, etc to a
+/// more convenient stream object like a std::stringstream for testing purposes.
+/// The class reverts to the original stream object when it goes out of scope.
+///
+/// Usage example:
+///
+/// Redirect console output to a std::stringstream object:
+///
+/// ```
+///   std::stringstream buffer;
+///   sdf::testing::RedirectConsoleStream redir(
+///       sdf::Console::Instance()->GetMsgStream(), &buffer);
+///
+///   sdfwarn << "Test message";
+///
+/// ```
+/// `buffer` will now contain "Test message" with additional information,
+/// such as the file and line number where sdfwarn was called from.
+///
+/// sdfdbg uses a log file as its output, so to redirect that, we can do
+///
+/// ```
+///   std::stringstream buffer;
+///   sdf::testing::RedirectConsoleStream redir(
+///       sdf::Console::Instance()->GetLogStream(), &buffer);
+///
+///   sdfdbg << "Test message";
+/// ```
+class RedirectConsoleStream
+{
+  /// \brief Constructor
+  /// \param[in] _consoleStream Mutable reference to a console stream.
+  /// \param[in] _newSink Pointer to any object derived from std::ostream
+  public: RedirectConsoleStream(sdf::Console::ConsoleStream &_consoleStream,
+              std::ostream *_newSink)
+      : consoleStreamRef(_consoleStream)
+      , oldStream(_consoleStream)
+  {
+    this->consoleStreamRef = sdf::Console::ConsoleStream(_newSink);
+  }
+
+  /// \brief Destructor. Restores the console to the original ConsoleStream
+  /// object.
+  public: ~RedirectConsoleStream()
+  {
+    this->consoleStreamRef = this->oldStream;
+  }
+
+  /// \brief Reference to the console stream object. This is usually obtained
+  /// from the singleton sdf::Console object by calling either
+  /// sdf::Console::GetMsgStream() or sdf::Console::GetLogStream()
+  private: sdf::Console::ConsoleStream &consoleStreamRef;
+
+  /// \brief Copy of the original console stream object. This will be used to
+  /// restore the console stream when this object goes out of scope.
+  private: sdf::Console::ConsoleStream oldStream;
+};
+
+} // namespace testing
+} // namespace sdf
+
+#endif
+

--- a/test/test_utils.hh
+++ b/test/test_utils.hh
@@ -25,6 +25,27 @@ namespace sdf
 namespace testing
 {
 
+/// \brief Calls a function when going out of scope.
+/// Taken from:
+/// https://github.com/ros2/rclcpp/blob/master/rclcpp/include/rclcpp/scope_exit.hpp
+template <typename Callable>
+struct ScopeExit
+{
+  /// \brief Constructor
+  /// \param[in] _callable Any callable object that does not throw.
+  explicit ScopeExit(Callable _callable)
+      : callable(_callable)
+  {
+  }
+
+  ~ScopeExit()
+  {
+    this->callable();
+  }
+
+  private: Callable callable;
+};
+
 /// \brief A class used for redirecting the output of sdferr, sdfwarn, etc to a
 /// more convenient stream object like a std::stringstream for testing purposes.
 /// The class reverts to the original stream object when it goes out of scope.


### PR DESCRIPTION

# 🎉 New feature

Closes #541

## Summary
If the warning policy of the parser is set to `ERR` in the `sdf::ParserConfig`, the parser emits an error message for deprecated elements. This PR adds a separate `EnforcementPolicy` for deprecated elements so that the behavior of the parser can be configured by the user. The API is such, by default `DeprecatedElementsPolicy` reflects the value of `WarninPolicy`,  but the user can call `SetDeprecatedElementsPolicy` to override the value. Note that the order of the function calls does not matter. Once the `DeprecatedElementsPolicy` overridden, calling `WarninPolicy` will not change the value of `DeprecatedElementsPolicy` unless `ResetDeprecatedElementsPolicy` is called. I'm open to feedback on this API.

## Test it
Tests are in `test/integration/deprecated_specs.cc`

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
