### PR TITLE
Param passing prototype: Add action

### DIFF
--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -130,11 +130,7 @@ namespace sdf
     POSE_RELATIVE_TO_GRAPH_ERROR,
 
     /// \brief Indicates that reading an SDF string failed.
-    STRING_READ,
-
-    /// \brief A duplicate element with specified name already exists
-    /// (used for parameter passing).
-    DUPLICATE_ELEMENT
+    STRING_READ
   };
 
   class SDFORMAT_VISIBLE Error

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -18,7 +18,6 @@
 #define SDF_PARSER_HH_
 
 #include <string>
-#include <tinyxml2.h>
 
 #include "sdf/SDFImpl.hh"
 #include "sdf/sdf_config.h"
@@ -56,14 +55,6 @@ namespace sdf
   /// \brief Initialize the SDF interface using a string
   SDFORMAT_VISIBLE
   bool initString(const std::string &_xmlString, SDFPtr _sdf);
-
-  /// \brief Converts XML Element to SDF Element (calls sdf::readXml function)
-  /// \param[in] _xml Pointer to TinyXML element
-  /// \param[in,out] _sdf SDF pointer to parse data into
-  /// \param[out] _errors Captures errors found during parsing
-  /// \return True on success, false on error
-  SDFORMAT_VISIBLE
-  bool xmlToSdf(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors);
 
   /// \brief Populate the SDF values from a file
   ///

--- a/include/sdf/parser.hh
+++ b/include/sdf/parser.hh
@@ -18,6 +18,7 @@
 #define SDF_PARSER_HH_
 
 #include <string>
+#include <tinyxml2.h>
 
 #include "sdf/SDFImpl.hh"
 #include "sdf/sdf_config.h"
@@ -55,6 +56,14 @@ namespace sdf
   /// \brief Initialize the SDF interface using a string
   SDFORMAT_VISIBLE
   bool initString(const std::string &_xmlString, SDFPtr _sdf);
+
+  /// \brief Converts XML Element to SDF Element (calls sdf::readXml function)
+  /// \param[in] _xml Pointer to TinyXML element
+  /// \param[in,out] _sdf SDF pointer to parse data into
+  /// \param[out] _errors Captures errors found during parsing
+  /// \return True on success, false on error
+  SDFORMAT_VISIBLE
+  bool xmlToSdf(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors);
 
   /// \brief Populate the SDF values from a file
   ///

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,7 +187,7 @@ if (BUILD_SDF_TEST)
   endif()
 
   if (NOT WIN32)
-    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ParamPassing.cc)
+    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ParamPassing.cc XmlUtils.cc)
     sdf_build_tests(ParamPassing_TEST.cc)
     target_link_libraries(UNIT_ParamPassing_TEST PRIVATE
       ${TinyXML2_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,8 +187,16 @@ if (BUILD_SDF_TEST)
   endif()
 
   if (NOT WIN32)
-    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ParamPassing.cc XmlUtils.cc)
+    set(SDF_BUILD_TESTS_EXTRA_EXE_SRCS ParamPassing.cc XmlUtils.cc parser.cc
+          parser_urdf.cc FrameSemantics.cc Converter.cc EmbeddedSdf.cc SDFExtension.cc)
     sdf_build_tests(ParamPassing_TEST.cc)
+    if (NOT USE_INTERNAL_URDF)
+      target_compile_options(UNIT_ParamPassing_TEST PRIVATE ${URDF_CFLAGS})
+      if (${CMAKE_VERSION} VERSION_GREATER 3.13)
+        target_link_options(UNIT_ParamPassing_TEST PRIVATE ${URDF_LDFLAGS})
+      endif()
+      target_link_libraries(UNIT_ParamPassing_TEST PRIVATE ${URDF_LIBRARIES})
+    endif()
     target_link_libraries(UNIT_ParamPassing_TEST PRIVATE
       ${TinyXML2_LIBRARIES})
   endif()

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -22,6 +22,7 @@
 #include "sdf/sdf_config.h"
 
 #include "ParamPassing.hh"
+#include "parser_private.hh"
 #include "XmlUtils.hh"
 
 namespace sdf
@@ -300,7 +301,7 @@ void handleIndividualChildActions(tinyxml2::XMLElement *_childrenXml,
     else
       elemChild = elemDesc->GetElementDescription(elemName);
 
-    if (!xmlToSdf(xmlChild, elemChild, _errors))
+    if (!readXml(xmlChild, elemChild, _errors))
     {
       _errors.push_back({ErrorCode::ELEMENT_INVALID,
         "Unable to convert XML to SDF. Skipping child element modification "
@@ -356,7 +357,7 @@ void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem,
 
   newElem->GetAttribute("name")->Set(_elemNameAttr);
 
-  if (xmlToSdf(_childXml, newElem, _errors))
+  if (readXml(_childXml, newElem, _errors))
   {
     _elem->InsertElement(newElem);
   }

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -43,13 +43,10 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
     const char *childElemId = childElemXml->Attribute("element_id");
     if (!childElemId)
     {
-      tinyxml2::XMLPrinter printer;
-      childElemXml->Accept(&printer);
-
       _errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
         "Element identifier requires an element_id attribute, but the "
         "element_id is not set. Skipping element modification:\n"
-        + std::string(printer.CStr())
+        + ElementToString(childElemXml)
       });
       continue;
     }
@@ -61,13 +58,10 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
     if (found != std::string::npos
         && (elemIdAttr.substr(found+2)).empty())
     {
-      tinyxml2::XMLPrinter printer;
-      childElemXml->Accept(&printer);
-
       _errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
         "Missing name after double colons in element identifier. "
         "Skipping element modification:\n"
-        + std::string(printer.CStr())
+        + ElementToString(childElemXml)
       });
       continue;
     }
@@ -86,15 +80,12 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
     {
       if (elem != nullptr)
       {
-        tinyxml2::XMLPrinter printer;
-        childElemXml->Accept(&printer);
-
         _errors.push_back({ErrorCode::DUPLICATE_NAME,
           "Could not add element <" + std::string(childElemXml->Name())
           + " element_id='" + childElemXml->Attribute("element_id")
           + "'> because element already exists in included model. "
           + "Skipping element addition:\n"
-          + printer.CStr()
+          + ElementToString(childElemXml)
         });
         continue;
       }
@@ -121,13 +112,10 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
 
     if (elem == nullptr)
     {
-      tinyxml2::XMLPrinter printer;
-      childElemXml->Accept(&printer);
-
       _errors.push_back({ErrorCode::ELEMENT_MISSING,
         "Could not find element <" + std::string(childElemXml->Name())
         + " element_id='" + childElemXml->Attribute("element_id") + "'>. " +
-        "Skipping element modification:\n" + printer.CStr()
+        "Skipping element modification:\n" + ElementToString(childElemXml)
       });
       continue;
     }
@@ -314,21 +302,7 @@ void handleIndividualChildActions(tinyxml2::XMLElement *_childrenXml,
 
     if (actionStr == "add")
     {
-      // check requirements
-      if ((elemChild->GetRequired() == "0" || elemChild->GetRequired() == "1")
-          && _elem->HasElement(elemName))
-      {
-        _errors.push_back({ErrorCode::DUPLICATE_ELEMENT,
-          "Element already exists in model, skipping child element addition "
-          "with parent <" + std::string(_childrenXml->Name()) + " element_id='"
-          + std::string(_childrenXml->Attribute("element_id")) + "'>: "
-          + ElementToString(xmlChild)
-        });
-      }
-      else
-      {
-        _elem->InsertElement(elemChild);
-      }
+      _elem->InsertElement(elemChild);
     }
 
     // TODO(jenn) finish (direct children only): modify, remove, replace

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -144,7 +144,7 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
     }
     else if (actionStr == "add")
     {
-      add(childElemXml, elem, _errors, elemIdAttr);
+      add(childElemXml, elem, _errors);
     }
 
     // TODO(jenn) element modifications: modify, remove, replace
@@ -325,8 +325,7 @@ void handleIndividualChildActions(tinyxml2::XMLElement *_childrenXml,
 
 
 //////////////////////////////////////////////////
-void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem,
-         Errors &_errors, const std::string &_elemNameAttr)
+void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem, Errors &_errors)
 {
   ElementPtr newElem = std::make_shared<Element>();
   std::string filename = std::string(_childXml->Name()) + ".sdf";

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -77,11 +77,22 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
 
     if (actionStr == "add")
     {
+      // checks name attribute exists
       if (!childElemXml->Attribute("name"))
       {
         _errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
           "Element to be added is missing a 'name' attribute. "
           "Skipping element addition:\n"
+          + ElementToString(childElemXml)
+        });
+        continue;
+      }
+
+      // checks name attribute nonempty
+      if (!strlen(childElemXml->Attribute("name")))
+      {
+        _errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
+          "The 'name' attribute can not be empty. Skipping element addition:\n"
           + ElementToString(childElemXml)
         });
         continue;
@@ -116,8 +127,6 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
                               elemIdAttr,
                               true);
       }
-
-      elemIdAttr = attrName;
     }
     else
     {

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -138,7 +138,6 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
       // action attribute not in childElemXml so must be in all direct children
       // of childElemXml
       handleIndividualChildActions(childElemXml, elem, _errors);
-
     }
     else if (actionStr == "add")
     {
@@ -329,7 +328,6 @@ void handleIndividualChildActions(tinyxml2::XMLElement *_childrenXml,
       {
         _elem->InsertElement(elemChild);
       }
-
     }
 
     // TODO(jenn) finish (direct children only): modify, remove, replace
@@ -370,6 +368,5 @@ void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem,
     });
   }
 }
-
 }
 }

--- a/src/ParamPassing.cc
+++ b/src/ParamPassing.cc
@@ -77,8 +77,10 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
 
     if (actionStr == "add")
     {
+      const char *attr = childElemXml->Attribute("name");
+
       // checks name attribute exists
-      if (!childElemXml->Attribute("name"))
+      if (!attr)
       {
         _errors.push_back({ErrorCode::ATTRIBUTE_MISSING,
           "Element to be added is missing a 'name' attribute. "
@@ -89,7 +91,7 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
       }
 
       // checks name attribute nonempty
-      if (!strlen(childElemXml->Attribute("name")))
+      if (!strlen(attr))
       {
         _errors.push_back({ErrorCode::ATTRIBUTE_INVALID,
           "The 'name' attribute can not be empty. Skipping element addition:\n"
@@ -98,7 +100,7 @@ void updateParams(tinyxml2::XMLElement *_childXmlParams,
         continue;
       }
 
-      std::string attrName = childElemXml->Attribute("name");
+      std::string attrName = attr;
 
       // check that elem doesn't already exist
       elem  = getElementById(_includeSDF, childElemXml->Name(),

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -77,9 +77,8 @@ namespace sdf
     /// \param[out] _elem The element from the included model to add the new
     /// element to
     /// \param[out] _errors Captures errors found during parsing
-    /// \param[in] _elemNameAttr The name attribute for the new element
     void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem,
-             Errors &_errors, const std::string &_elemNameAttr);
+             Errors &_errors);
   }
 }
 #endif

--- a/src/ParamPassing.hh
+++ b/src/ParamPassing.hh
@@ -62,6 +62,24 @@ namespace sdf
     int64_t findPrefixLastIndex(const std::string &_elemId,
                                 const int64_t &_startIdx,
                                 const std::string &_ref);
+
+    /// \brief Handles individual actions of children in _childrenXml
+    /// \param[in] _childrenXml Pointer to xml element
+    /// \param[out] _elem The sdf element to apply actions
+    /// (i.e., add, modify, remove, replace)
+    /// \param[out] _errors Captures errors found during parsing
+    void handleIndividualChildActions(tinyxml2::XMLElement *_childrenXml,
+                                      ElementPtr _elem, Errors &_errors);
+
+    /// \brief Adds a new element to an element from the included model
+    /// \param[in] _childXml Pointer to the new element to add, which is a child
+    /// of //include/experimental:params
+    /// \param[out] _elem The element from the included model to add the new
+    /// element to
+    /// \param[out] _errors Captures errors found during parsing
+    /// \param[in] _elemNameAttr The name attribute for the new element
+    void add(tinyxml2::XMLElement *_childXml, ElementPtr _elem,
+             Errors &_errors, const std::string &_elemNameAttr);
   }
 }
 #endif

--- a/src/XmlUtils.cc
+++ b/src/XmlUtils.cc
@@ -55,6 +55,20 @@ tinyxml2::XMLNode *DeepClone(tinyxml2::XMLDocument *_doc,
 
   return copy;
 }
+
+/////////////////////////////////////////////////
+std::string ElementToString(const tinyxml2::XMLElement *_elem)
+{
+  if (_elem == nullptr)
+  {
+    sdferr << "Pointer to XML Element _elem is nullptr\n";
+    return "";
+  }
+
+  tinyxml2::XMLPrinter printer;
+  _elem->Accept(&printer);
+
+  return std::string(printer.CStr());
+}
 }
 }  // namespace sdf
-

--- a/src/XmlUtils.hh
+++ b/src/XmlUtils.hh
@@ -40,6 +40,11 @@ namespace sdf
   ///          nullptr if an error occurs.
   tinyxml2::XMLNode *DeepClone(tinyxml2::XMLDocument *_doc,
                                const tinyxml2::XMLNode *_src);
+
+  /// \brief Converts the XML Element to a string
+  /// \param[in] _elem Element to be converted
+  /// \return The string representation
+  std::string ElementToString(const tinyxml2::XMLElement *_elem);
   }
 }
 #endif

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -815,12 +815,6 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 }
 
 //////////////////////////////////////////////////
-bool xmlToSdf(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
-{
-  return readXml(_xml, _sdf, _errors);
-}
-
-//////////////////////////////////////////////////
 bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
 {
   // Check if the element pointer is deprecated.

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -815,6 +815,12 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 }
 
 //////////////////////////////////////////////////
+bool xmlToSdf(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
+{
+  return readXml(_xml, _sdf, _errors);
+}
+
+//////////////////////////////////////////////////
 bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
 {
   // Check if the element pointer is deprecated.
@@ -891,9 +897,11 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf, Errors &_errors)
       }
     }
 
-    if (i == _sdf->GetAttributeCount())
+    std::string attrName = attribute->Name();
+    if (i == _sdf->GetAttributeCount()
+        && attrName != "action" && attrName != "element_id")
     {
-      sdfwarn << "XML Attribute[" << attribute->Name()
+      sdfwarn << "XML Attribute[" << attrName
               << "] in element[" << _xml->Value()
               << "] not defined in SDF, ignoring.\n";
     }

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -38,7 +38,7 @@ namespace sdf
   ///            model XML tag
   /// \param[out] _modelFileName file name of the best model file
   /// \return string with the best SDF version supported
-  static std::string getBestSupportedModelVersion(
+  std::string getBestSupportedModelVersion(
       tinyxml2::XMLElement *_modelXML, std::string &_modelFileName);
 
   /// \brief Initialize the SDF interface using a TinyXML2 document.
@@ -47,7 +47,7 @@ namespace sdf
   /// \param[in] _xmlDoc TinyXML2 document containing the SDFormat description
   /// file that corresponds with the input SDFPtr
   /// \param[in] _sdf SDF interface to be initialized
-  static bool initDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf);
+  bool initDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf);
 
   /// \brief Initialize the SDF Element using a TinyXML2 document
   ///
@@ -55,7 +55,7 @@ namespace sdf
   /// \param[in] _xmlDoc TinyXML2 document containing the SDFormat description
   /// file that corresponds with the input ElementPtr
   /// \param[in] _sdf SDF Element to be initialized
-  static bool initDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf);
+  bool initDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf);
 
   /// \brief Initialize the SDF Element by parsing the SDFormat description in
   /// the input TinyXML2 element. This is where SDFormat spec/description files
@@ -64,15 +64,15 @@ namespace sdf
   /// \param[in] _xml TinyXML2 element containing the SDFormat description
   /// file that corresponds with the input ElementPtr
   /// \param[in] _sdf SDF ElementPtr to be initialized
-  static bool initXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf);
+  bool initXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf);
 
   /// \brief Populate the SDF values from a TinyXML document
-  static bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
+  bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
                       const std::string &_source, bool _convert,
                       Errors &_errors);
 
   /// \brief Populate the SDF values from a TinyXML document
-  static bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
+  bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
       const std::string &_source, bool _convert, Errors &_errors);
 
   /// \brief Populate an SDF Element from the XML input. The XML input here is
@@ -83,7 +83,7 @@ namespace sdf
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.
-  static bool readXml(tinyxml2::XMLElement *_xml,
+  bool readXml(tinyxml2::XMLElement *_xml,
                       ElementPtr _sdf,
                       Errors &_errors);
 
@@ -93,7 +93,7 @@ namespace sdf
   /// copied.
   /// \param[in] _onlyUnknown True to copy only elements that are NOT part of
   /// the SDF spec. Set this to false to copy everything.
-  static void copyChildren(ElementPtr _sdf, tinyxml2::XMLElement *_xml,
+  void copyChildren(ElementPtr _sdf, tinyxml2::XMLElement *_xml,
                     const bool _onlyUnknown);
   }
 }

--- a/test/integration/include_custom_model.sdf
+++ b/test/integration/include_custom_model.sdf
@@ -10,7 +10,7 @@
           <visual element_id="chassis::lidar_visual" action="remove"/>
           <sensor element_id="chassis::lidar" action="remove"/>
 
-          <visual element_id="chassis::camera_visual" action="add">
+          <visual element_id="chassis" name="camera_visual" action="add">
             <pose>-1.06 0 0 0 0 3.14</pose>
             <geometry>
               <box>
@@ -19,7 +19,7 @@
             </geometry>
           </visual>
 
-          <link element_id="new_link" action="add">
+          <link element_id="" name="new_link" action="add">
             <pose>0 0 0 0 0 0</pose>
             <sensor type="camera" name="camera_sensor">
               <camera>
@@ -39,7 +39,7 @@
             </sensor>
           </link>
 
-          <visual element_id="nested_links::link1::link2::new_visual" action="add">
+          <visual element_id="nested_links::link1::link2" name="new_visual" action="add">
             <geometry>
               <box>
                 <size>0.1 0.1 0.1</size>

--- a/test/integration/include_custom_model.sdf
+++ b/test/integration/include_custom_model.sdf
@@ -21,7 +21,7 @@
 
           <link element_id="new_link" action="add">
             <pose>0 0 0 0 0 0</pose>
-            <sensor type="camera" element_id="my_sensor">
+            <sensor type="camera" name="camera_sensor">
               <camera>
                 <horizontal_fov>1.047</horizontal_fov>
                 <image>
@@ -54,17 +54,31 @@
 
           <visual element_id="top::camera_visual">
             <transparency action="add">0.5</transparency>
+            <plugin name="some_visual_plugin" filename="/path/to/plugin" action="add"/>
             <geometry action="replace">
               <sphere>
                 <radius>0.05</radius>
               </sphere>
             </geometry>
             <material action="modify">
-              <!-- blue -->
               <ambient>0 0 1 1</ambient>
               <diffuse>0 0 1 1</diffuse>
             </material>
           </visual>
+
+          <link element_id="top">
+            <link name="nested_link" action="add">
+              <visual name="visual">
+                <geometry>
+                  <cylinder>
+                    <radius>1</radius>
+                    <length>1.2</length>
+                  </cylinder>
+                </geometry>
+              </visual>
+            </link>
+          </link>
+
         </experimental:params>
 
       </include>

--- a/test/integration/include_custom_model_expected_output.sdf
+++ b/test/integration/include_custom_model_expected_output.sdf
@@ -1,0 +1,364 @@
+<sdf version='1.7' xmlns:experimental='http://sdformat.org/schemas/experimental'>
+  <world name='world_custom_model'>
+    <model name='robot'>
+
+      <frame name='vehicle::__model__' attached_to='vehicle::chassis'>
+        <pose relative_to='__model__'>0 0 0.325 0 -0 0</pose>
+      </frame>
+
+      <link name='vehicle::chassis'>
+        <pose relative_to='vehicle::__model__'>-0.151427 -0 0.175 0 -0 0</pose>
+        <inertial>
+          <mass>1.14395</mass>
+          <inertia>
+            <ixx>0.126164</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.416519</iyy>
+            <iyz>0</iyz>
+            <izz>0.481014</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 1 1</ambient>
+            <diffuse>0.5 0.5 1 1</diffuse>
+            <specular>0 0 1 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>2.01142 1 0.568726</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='lidar_visual'>
+          <pose>-0.8 0 0.41 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.1</radius>
+              <length>0.25</length>
+            </cylinder>
+          </geometry>
+        </visual>
+        <sensor name='lidar' type='gpu_lidar'>
+          <pose>-0.8 0 0.41 0 -0 0</pose>
+          <topic>lidar</topic>
+          <update_rate>10</update_rate>
+          <lidar>
+            <scan>
+              <horizontal>
+                <samples>640</samples>
+                <resolution>1</resolution>
+                <min_angle>-1.39626</min_angle>
+                <max_angle>1.39626</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>16</samples>
+                <resolution>1</resolution>
+                <min_angle>-0.261799</min_angle>
+                <max_angle>0.261799</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.08</min>
+              <max>10</max>
+              <resolution>0.01</resolution>
+            </range>
+          </lidar>
+          <visualize>1</visualize>
+          <alwaysOn>1</alwaysOn>
+        </sensor>
+        <sensor name='camera' type='camera'>
+          <pose>-1.06 0 0 0 -0 3.14</pose>
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>1</visualize>
+          <topic>chassis/camera</topic>
+        </sensor>
+
+        <!-- added -->
+        <visual name='camera_visual'>
+          <pose>-1.06 0 0 0 -0 3.14</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+
+      <link name='vehicle::top'>
+        <pose relative_to='vehicle::__model__'>0.6 0 0.7 0 -0 0</pose>
+        <collision name='top_collision'>
+          <geometry>
+            <box>
+              <size>0.5 1 0.5</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='top_visual'>
+          <geometry>
+            <box>
+              <size>0.5 1 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+
+        <visual name='camera_visual'>
+          <pose>-0.2 0 0.3 0 -0 3.14</pose>
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+
+          <!-- added -->
+          <transparency>0.5</transparency>
+          <plugin name='some_visual_plugin' filename='/path/to/plugin'/>
+        </visual>
+
+        <sensor name='camera' type='camera'>
+          <pose>-0.2 0 0.3 0 -0 0</pose>
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>1</visualize>
+          <topic>top/camera</topic>
+        </sensor>
+
+        <!-- added -->
+        <link name='nested_link'>
+          <visual name="visual">
+            <geometry>
+              <cylinder>
+                <radius>1</radius>
+                <length>1.2</length>
+              </cylinder>
+            </geometry>
+          </visual>
+        </link>
+      </link>
+
+      <joint name='vehicle::top_to_base' type='fixed'>
+        <parent>vehicle::chassis</parent>
+        <child>vehicle::top</child>
+      </joint>
+      <link name='vehicle::left_wheel'>
+        <pose relative_to='vehicle::__model__'>0.554283 0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+      <link name='vehicle::right_wheel'>
+        <pose relative_to='vehicle::__model__'>0.554282 -0.625029 -0.025 -1.5707 0 0</pose>
+        <inertial>
+          <mass>2</mass>
+          <inertia>
+            <ixx>0.145833</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.145833</iyy>
+            <iyz>0</iyz>
+            <izz>0.125</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.3</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+      <link name='vehicle::caster'>
+        <pose relative_to='vehicle::__model__'>-0.957138 -0 -0.125 0 -0 0</pose>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+        <visual name='visual'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.2 0.2 0.2 1</ambient>
+            <diffuse>0.2 0.2 0.2 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+          </material>
+        </visual>
+        <collision name='collision'>
+          <geometry>
+            <sphere>
+              <radius>0.2</radius>
+            </sphere>
+          </geometry>
+        </collision>
+      </link>
+      <joint name='vehicle::left_wheel_joint' type='revolute'>
+        <parent>vehicle::chassis</parent>
+        <child>vehicle::left_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+      <joint name='vehicle::right_wheel_joint' type='revolute'>
+        <parent>vehicle::chassis</parent>
+        <child>vehicle::right_wheel</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>-1.79769e+308</lower>
+            <upper>1.79769e+308</upper>
+          </limit>
+        </axis>
+      </joint>
+      <joint name='vehicle::caster_wheel' type='ball'>
+        <parent>vehicle::chassis</parent>
+        <child>vehicle::caster</child>
+      </joint>
+
+      <link name='vehicle::nested_links'>
+        <pose relative_to='vehicle::__model__'>0 0 0 0 -0 0</pose>
+        <link name='link1'>
+          <link name='link2'>
+
+            <!-- added -->
+            <visual name='new_visual'>
+              <geometry>
+                <box>
+                  <size>0.1 0.1 0.1</size>
+                </box>
+              </geometry>
+            </visual>
+
+          </link>
+        </link>
+      </link>
+
+      <!-- added -->
+      <link name='vehicle::new_link'>
+        <pose relative_to='vehicle::__model__'>0 0 0 0 -0 0</pose>
+        <sensor name='camera_sensor' type='camera'>
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>1</visualize>
+        </sensor>
+      </link>
+
+    </model>
+    <gravity>0 0 -9.8</gravity>
+    <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
+    <atmosphere type='adiabatic'/>
+    <physics type='ode'>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <real_time_update_rate>1000</real_time_update_rate>
+    </physics>
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>1</shadows>
+    </scene>
+  </world>
+</sdf>

--- a/test/integration/include_invalid_custom_model.sdf
+++ b/test/integration/include_invalid_custom_model.sdf
@@ -40,10 +40,6 @@
             <!-- missing action attribute -->
             <transparency>0.2</transparency>
 
-            <!-- duplicate element -->
-            <transparency action="add">0.2</transparency>
-            <transparency action="add">0.5</transparency>
-
             <!-- incorrect schema (missing required attributes) -->
             <plugin action="add"/>
 

--- a/test/integration/include_invalid_custom_model.sdf
+++ b/test/integration/include_invalid_custom_model.sdf
@@ -18,7 +18,7 @@
             </geometry>
           </visual>
           <!-- element already exists -->
-          <visual element_id="chassis::visual" action="add">
+          <visual element_id="chassis" name="visual" action="add">
             <geometry>
               <box>
                 <size>0.1 0.1 0.1</size>
@@ -26,7 +26,7 @@
             </geometry>
           </visual>
           <!-- parent of new element does not exist -->
-          <visual element_id="chassis::test::visual" action="add">
+          <visual element_id="chassis::test" name="visual" action="add">
             <geometry>
               <box>
                 <size>0.1 0.1 0.1</size>
@@ -34,7 +34,7 @@
             </geometry>
           </visual>
           <!-- missing name after :: -->
-          <link element_id="chassis::test::" action="add"/>
+          <link element_id="chassis::test::" name="foo" action="add"/>
 
           <visual element_id="top::camera_visual">
             <!-- missing action attribute -->
@@ -48,9 +48,13 @@
           </visual>
 
           <!-- not defined sdf element -->
-          <test element_id="chassis::new_elem" action="add"/>
+          <test element_id="chassis" name="new_elem" action="add"/>
 
-          <plugin element_id="some_plugin" action="add"/>
+          <!-- missing 'name' attribute -->
+          <plugin element_id="chassis" action="add"/>
+
+          <!-- incorrect schema (missing required 'filename' attribute) -->
+          <plugin element_id="chassis" name="some_plugin" action="add"/>
         </experimental:params>
       </include>
     </model>

--- a/test/integration/include_invalid_custom_model.sdf
+++ b/test/integration/include_invalid_custom_model.sdf
@@ -35,6 +35,26 @@
           </visual>
           <!-- missing name after :: -->
           <link element_id="chassis::test::" action="add"/>
+
+          <visual element_id="top::camera_visual">
+            <!-- missing action attribute -->
+            <transparency>0.2</transparency>
+
+            <!-- duplicate element -->
+            <transparency action="add">0.2</transparency>
+            <transparency action="add">0.5</transparency>
+
+            <!-- incorrect schema (missing required attributes) -->
+            <plugin action="add"/>
+
+            <!-- not defined sdf element -->
+            <test action="add"/>
+          </visual>
+
+          <!-- not defined sdf element -->
+          <test element_id="chassis::new_elem" action="add"/>
+
+          <plugin element_id="some_plugin" action="add"/>
         </experimental:params>
       </include>
     </model>

--- a/test/integration/include_invalid_custom_model.sdf
+++ b/test/integration/include_invalid_custom_model.sdf
@@ -53,6 +53,9 @@
           <!-- missing 'name' attribute -->
           <plugin element_id="chassis" action="add"/>
 
+          <!-- 'name' attribute is empty -->
+          <plugin element_id="chassis" name="" action="add"/>
+
           <!-- incorrect schema (missing required 'filename' attribute) -->
           <plugin element_id="chassis" name="some_plugin" action="add"/>
         </experimental:params>

--- a/test/integration/model/nested_include/test_nested_include.sdf
+++ b/test/integration/model/nested_include/test_nested_include.sdf
@@ -9,7 +9,7 @@
           <visual element_id="chassis::lidar_visual" action="remove"/>
           <sensor element_id="chassis::lidar" action="remove"/>
 
-          <visual element_id="chassis::camera_visual" action="add">
+          <visual element_id="chassis" name="camera_visual" action="add">
             <pose>-1.06 0 0 0 0 3.14</pose>
             <geometry>
               <box>
@@ -36,7 +36,7 @@
             </material>
           </visual>
 
-          <link element_id="top_model::top_camera::top_camera_link::new_link" action="add"/>
+          <link element_id="top_model::top_camera::top_camera_link" name="new_link" action="add"/>
         </experimental:params>
       </include>
     </model>

--- a/test/integration/param_passing.cc
+++ b/test/integration/param_passing.cc
@@ -56,6 +56,17 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   PrintErrors(errors);
   EXPECT_TRUE(errors.empty());
 
+  // compare with expected output
+  testFile =
+    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+                          "include_custom_model_expected_output.sdf");
+
+  sdf::Root expectedRoot;
+  errors = expectedRoot.Load(testFile);
+  PrintErrors(errors);
+  EXPECT_TRUE(errors.empty());
+  EXPECT_EQ(root.Element()->ToString(""), expectedRoot.Element()->ToString(""));
+
   // Expected errors
   testFile =
     sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
@@ -63,7 +74,7 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   errors = root.Load(testFile);
   PrintErrors(errors);
   EXPECT_FALSE(errors.empty());
-  ASSERT_EQ(errors.size(), 5u);
+  ASSERT_EQ(errors.size(), 13u);
   // missing element_id attribute
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   // element does not exist in included model
@@ -74,6 +85,20 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   EXPECT_EQ(errors[3].Code(), sdf::ErrorCode::ELEMENT_MISSING);
   // missing name after double colons
   EXPECT_EQ(errors[4].Code(), sdf::ErrorCode::ATTRIBUTE_INVALID);
+  // missing action attribute
+  EXPECT_EQ(errors[5].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  // duplicate element
+  EXPECT_EQ(errors[6].Code(), sdf::ErrorCode::DUPLICATE_ELEMENT);
+  // incorrect schema (missing required attributes; in children of element_id)
+  EXPECT_EQ(errors[7].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[8].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  // not defined sdf element (in children of where element_id is defined)
+  EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  // not defined sdf element (where element_id is defined)
+  EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  // incorrect schema (missing required attributes; where element_id defined)
+  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::ELEMENT_INVALID);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/param_passing.cc
+++ b/test/integration/param_passing.cc
@@ -74,7 +74,7 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   errors = root.Load(testFile);
   PrintErrors(errors);
   EXPECT_FALSE(errors.empty());
-  ASSERT_EQ(errors.size(), 12u);
+  ASSERT_EQ(errors.size(), 13u);
   // missing element_id attribute
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   // element does not exist in included model
@@ -94,9 +94,11 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   EXPECT_EQ(errors[8].Code(), sdf::ErrorCode::ELEMENT_INVALID);
   // not defined sdf element (where element_id is defined)
   EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::ELEMENT_INVALID);
-  // incorrect schema (missing required attributes; where element_id defined)
+  // missing 'name' attribute where element_id is with action="add"
   EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
-  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  // incorrect schema (missing required attributes; where element_id defined)
+  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::ELEMENT_INVALID);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/param_passing.cc
+++ b/test/integration/param_passing.cc
@@ -74,7 +74,7 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   errors = root.Load(testFile);
   PrintErrors(errors);
   EXPECT_FALSE(errors.empty());
-  ASSERT_EQ(errors.size(), 13u);
+  ASSERT_EQ(errors.size(), 12u);
   // missing element_id attribute
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   // element does not exist in included model
@@ -87,18 +87,16 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   EXPECT_EQ(errors[4].Code(), sdf::ErrorCode::ATTRIBUTE_INVALID);
   // missing action attribute
   EXPECT_EQ(errors[5].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
-  // duplicate element
-  EXPECT_EQ(errors[6].Code(), sdf::ErrorCode::DUPLICATE_ELEMENT);
   // incorrect schema (missing required attributes; in children of element_id)
-  EXPECT_EQ(errors[7].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
-  EXPECT_EQ(errors[8].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  EXPECT_EQ(errors[6].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[7].Code(), sdf::ErrorCode::ELEMENT_INVALID);
   // not defined sdf element (in children of where element_id is defined)
-  EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  EXPECT_EQ(errors[8].Code(), sdf::ErrorCode::ELEMENT_INVALID);
   // not defined sdf element (where element_id is defined)
-  EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::ELEMENT_INVALID);
   // incorrect schema (missing required attributes; where element_id defined)
-  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
-  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ELEMENT_INVALID);
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/param_passing.cc
+++ b/test/integration/param_passing.cc
@@ -74,7 +74,7 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   errors = root.Load(testFile);
   PrintErrors(errors);
   EXPECT_FALSE(errors.empty());
-  ASSERT_EQ(errors.size(), 13u);
+  ASSERT_EQ(errors.size(), 14u);
   // missing element_id attribute
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   // element does not exist in included model
@@ -96,9 +96,11 @@ TEST(ParamPassingTest, ExperimentalParamsTag)
   EXPECT_EQ(errors[9].Code(), sdf::ErrorCode::ELEMENT_INVALID);
   // missing 'name' attribute where element_id is with action="add"
   EXPECT_EQ(errors[10].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  // 'name' attribute is empty (where element_id is with action="add")
+  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ATTRIBUTE_INVALID);
   // incorrect schema (missing required attributes; where element_id defined)
-  EXPECT_EQ(errors[11].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
-  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::ELEMENT_INVALID);
+  EXPECT_EQ(errors[12].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
+  EXPECT_EQ(errors[13].Code(), sdf::ErrorCode::ELEMENT_INVALID);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

## Summary

Implementation of the `add` action from the [param passing proposal](http://sdformat.org/tutorials?tut=param_passing_proposal&branch=param_passing). Gives users the ability to add new elements to an included model.

~~A limitation is that the resulting include file is not validated and it will be up to the user to have modified elements correctly specified. Once this is transitioned out of the `experimental` phase (and into a core feature), this will be addressed.~~
The resulting include file is validated in the [`addNestedModel` call](https://github.com/osrf/sdformat/blob/1398d15a15b6693901e1ede77353443d89af26c9/src/parser.cc#L1096) after the params have been updated (`addNestedModel` eventually calls `readXml` on the updated included model). This will no longer be the case in `sdf11` but the same logic can be applied (i.e., calling `readXml` on the included model after the params have been updated).

## Test it
`./build/sdformat10/test/integration/INTEGRATION_param_passing`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
