### PR TITLE
Add scatter ratio parameter to Particle Emitter DOM

### DIFF
--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -276,6 +276,17 @@ namespace sdf
     /// \param[in] _topic The topic used to update the particle emitter.
     public: void SetTopic(const std::string &_topic);
 
+    /// \brief Get the particle scatter ratio. This is used to determine the
+    /// ratio of particles that will be detected by sensors.
+    /// \return Particle scatter ratio
+    /// \sa SetScatterRatio
+    public: float ScatterRatio() const;
+
+    /// \brief Set the particle scatter ratio. This is used to determine the
+    /// ratio of particles that will be detected by sensors.
+    /// \param[in] _ratio Scatter raito. This value should be > 0.
+    public: void SetScatterRatio(float _ratio);
+
     /// \brief Get the pose of the particle emitter. This is the pose of the
     /// emitter as specified in SDF
     /// (<particle_emitter><pose> ... </pose></particle_emitter>).

--- a/include/sdf/ParticleEmitter.hh
+++ b/include/sdf/ParticleEmitter.hh
@@ -284,7 +284,7 @@ namespace sdf
 
     /// \brief Set the particle scatter ratio. This is used to determine the
     /// ratio of particles that will be detected by sensors.
-    /// \param[in] _ratio Scatter raito. This value should be > 0.
+    /// \param[in] _ratio Scatter ratio.
     public: void SetScatterRatio(float _ratio);
 
     /// \brief Get the pose of the particle emitter. This is the pose of the

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -109,8 +109,9 @@
     This is used to determine the ratio of particles that will be detected
     by sensors. Increasing the ratio means there is a higher chance of
     particles reflecting and interfering with depth sensing, making the
-    emitter appear more dense. Decreasing the ratio decreases making it
-    appear less dense. This value should be > 0.
+    emitter appear more dense. Decreasing the ratio decreases the chance
+    of particles reflecting and interfering with depth sensing, making it
+    appear less dense.
     </description>
   </element>
 

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -104,7 +104,7 @@
     </description>
   </element>
 
-  <element name="scatter_ratio" type="float" default="0.65" required="0">
+  <element name="particle_scatter_ratio" type="float" default="0.65" required="0">
     <description>
     This is used to determine the ratio of particles that will be detected
     by sensors. Increasing the ratio means there is a higher chance of

--- a/sdf/1.7/particle_emitter.sdf
+++ b/sdf/1.7/particle_emitter.sdf
@@ -104,6 +104,16 @@
     </description>
   </element>
 
+  <element name="scatter_ratio" type="float" default="0.65" required="0">
+    <description>
+    This is used to determine the ratio of particles that will be detected
+    by sensors. Increasing the ratio means there is a higher chance of
+    particles reflecting and interfering with depth sensing, making the
+    emitter appear more dense. Decreasing the ratio decreases making it
+    appear less dense. This value should be > 0.
+    </description>
+  </element>
+
   <include filename="pose.sdf" required="0"/>
   <include filename="material.sdf" required="0"/>
 </element>

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -281,7 +281,7 @@ Errors ParticleEmitter::Load(ElementPtr _sdf)
       "topic", this->dataPtr->topic).first;
 
   this->dataPtr->scatterRatio = _sdf->Get<float>(
-      "scatter_ratio", this->dataPtr->scatterRatio).first;
+      "particle_scatter_ratio", this->dataPtr->scatterRatio).first;
 
   if (_sdf->HasElement("material"))
   {

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -96,6 +96,13 @@ class sdf::ParticleEmitterPrivate
   /// \brief Topic used to update particle emitter properties at runtime.
   public: std::string topic = "";
 
+  /// \brief Particle scatter ratio. This is used to determine the ratio of
+  /// particles that will be detected by sensors. Increasing the ratio
+  /// means there is a higher chance of particles reflecting and interfering
+  /// with depth sensing, making the emitter appear more dense. Decreasing the
+  /// ratio decreases making it appear less dense. This value should be > 0.
+  public: float scatterRatio = 0.65f;
+
   /// \brief Pose of the emitter
   public: ignition::math::Pose3d pose = ignition::math::Pose3d::Zero;
 
@@ -136,6 +143,7 @@ ParticleEmitterPrivate::ParticleEmitterPrivate(
       colorEnd(_private.colorEnd),
       colorRangeImage(_private.colorRangeImage),
       topic(_private.topic),
+      scatterRatio(_private.scatterRatio),
       pose(_private.pose),
       poseRelativeTo(_private.poseRelativeTo),
       xmlParentName(_private.xmlParentName),
@@ -271,6 +279,9 @@ Errors ParticleEmitter::Load(ElementPtr _sdf)
 
   this->dataPtr->topic = _sdf->Get<std::string>(
       "topic", this->dataPtr->topic).first;
+
+  this->dataPtr->scatterRatio = _sdf->Get<float>(
+      "scatter_ratio", this->dataPtr->scatterRatio).first;
 
   if (_sdf->HasElement("material"))
   {
@@ -485,6 +496,18 @@ std::string ParticleEmitter::Topic() const
 void ParticleEmitter::SetTopic(const std::string &_topic)
 {
   this->dataPtr->topic = _topic;
+}
+
+/////////////////////////////////////////////////
+void ParticleEmitter::SetScatterRatio(float _ratio)
+{
+  this->dataPtr->scatterRatio = _ratio;
+}
+
+/////////////////////////////////////////////////
+float ParticleEmitter::ScatterRatio() const
+{
+  return this->dataPtr->scatterRatio;
 }
 
 /////////////////////////////////////////////////

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -99,8 +99,9 @@ class sdf::ParticleEmitterPrivate
   /// \brief Particle scatter ratio. This is used to determine the ratio of
   /// particles that will be detected by sensors. Increasing the ratio
   /// means there is a higher chance of particles reflecting and interfering
-  /// with depth sensing, making the emitter appear more dense. Decreasing the
-  /// ratio decreases making it appear less dense. This value should be > 0.
+  /// with depth sensing, making the emitter appear more dense. Decreasing
+  /// the ratio decreases the chance of particles reflecting and interfering
+  /// with depth sensing, making it appear less dense.
   public: float scatterRatio = 0.65f;
 
   /// \brief Pose of the emitter

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -104,6 +104,10 @@ TEST(DOMParticleEmitter, Construction)
   emitter.SetTopic("/test/topic");
   EXPECT_EQ("/test/topic", emitter.Topic());
 
+  EXPECT_FLOAT_EQ(0.65f, emitter.ScatterRatio());
+  emitter.SetScatterRatio(0.5f);
+  EXPECT_FLOAT_EQ(0.5f, emitter.ScatterRatio());
+
   EXPECT_EQ(ignition::math::Pose3d::Zero, emitter.RawPose());
   emitter.SetRawPose(ignition::math::Pose3d(1, 2, 3, 0, 0, 1.5707));
   EXPECT_EQ(ignition::math::Pose3d(1, 2, 3, 0, 0, 1.5707), emitter.RawPose());

--- a/test/integration/particle_emitter_dom.cc
+++ b/test/integration/particle_emitter_dom.cc
@@ -78,6 +78,7 @@ TEST(DOMWorld, LoadParticleEmitter)
   EXPECT_DOUBLE_EQ(0.2, linkEmitter->MaxVelocity());
   EXPECT_DOUBLE_EQ(0.5, linkEmitter->ScaleRate());
   EXPECT_DOUBLE_EQ(5, linkEmitter->Rate());
+  EXPECT_FLOAT_EQ(0.2f, linkEmitter->ScatterRatio());
 
   sdf::Material *mat = linkEmitter->Material();
   ASSERT_NE(nullptr, mat);

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -90,7 +90,7 @@
             </pbr>
           </material>
           <color_range_image>materials/textures/fogcolors.png</color_range_image>
-          <scatter_ratio>0.2</scatter_ratio>
+          <particle_scatter_ratio>0.2</particle_scatter_ratio>
         </particle_emitter>
 
         <light name="spot_light" type="spot">

--- a/test/sdf/world_complete.sdf
+++ b/test/sdf/world_complete.sdf
@@ -90,6 +90,7 @@
             </pbr>
           </material>
           <color_range_image>materials/textures/fogcolors.png</color_range_image>
+          <scatter_ratio>0.2</scatter_ratio>
         </particle_emitter>
 
         <light name="spot_light" type="spot">


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Add particle scatter parameter to the Particle Emitter DOM. This affects how noisy / scattered the sensors readings are affected by the particle emitter. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

