### PR TITLE
Encode XML path and line number in Element and add XML path setter Error.

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -423,7 +423,18 @@ namespace sdf
     public: std::optional<int> LineNumber() const;
 
     /// \brief Set the XML path of this element.
-    /// \param[in] _path Full XML path to the SDF element. (e.g.
+    /// \param[in] _path Full XML path (i.e., XPath) to the SDF element.
+    /// E.g., a SDF document:
+    /// <sdf>
+    ///   <world name="default">
+    ///     <model name="robot1">
+    ///        <link name="link">
+    ///          ...
+    ///        </link>
+    ///     </model>
+    ///   </world>
+    /// </sdf>
+    ///  The full XML path to the SDF link element would be:
     /// /sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"])
     public: void SetXmlPath(const std::string &_path);
 

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -472,6 +472,7 @@ namespace sdf
                                   bool _required,
                                   const std::string &_description="");
 
+
     /// \brief Private data pointer
     private: std::unique_ptr<ElementPrivate> dataPtr;
   };

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -414,7 +414,8 @@ namespace sdf
     public: const std::string &FilePath() const;
 
     /// \brief Set the XML path of this element.
-    /// \param[in] _path Full XML path to the SDF element.
+    /// \param[in] _path Full XML path to the SDF element. (e.g.
+    /// /sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"])
     public: void SetXmlPath(const std::string &_path);
 
     /// \brief Get the XML path of this element.

--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -413,6 +413,15 @@ namespace sdf
     /// \return Full path to SDF document.
     public: const std::string &FilePath() const;
 
+    /// \brief Set the line number of this element within the SDF document.
+    /// \param[in] _lineNumber Line number of element.
+    public: void SetLineNumber(int _lineNumber);
+
+    /// \brief Get the line number of this element within the SDF document.
+    /// \return Line number of this element if it has been set, nullopt
+    /// otherwise.
+    public: std::optional<int> LineNumber() const;
+
     /// \brief Set the XML path of this element.
     /// \param[in] _path Full XML path to the SDF element. (e.g.
     /// /sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"])
@@ -539,6 +548,9 @@ namespace sdf
 
     /// \brief Path to file where this element came from
     public: std::string path;
+
+    /// \brief Line number in file where this element came from
+    public: std::optional<int> lineNumber;
 
     /// \brief XML path of this element.
     public: std::string xmlPath;

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -171,7 +171,7 @@ namespace sdf
     /// \param[in] _filePath The file path that is related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_path);
+                  const std::string &_xmlPath, const std::string &_filePath);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
@@ -182,7 +182,7 @@ namespace sdf
     /// this error was raised.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_path,
+                  const std::string &_xmlPath, const std::string &_filePath,
                   int _lineNumber);
 
     /// \brief Get the error code.

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -159,10 +159,11 @@ namespace sdf
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _filePath The file path that is related to this error.
+    /// \param[in] _path Either the file path or the XPath-like trace that is
+    /// related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_filePath);
+                  const std::string &_path);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
@@ -183,10 +184,12 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the file path associated with this error.
-    /// \return Returns the path of the file that this error is related to.
+    /// \brief Get the file path or the XPath-like trace that is associated with
+    /// this error.
+    /// \return Returns the path of the file or the XPath-like trace that this
+    /// error is related to.
     /// nullopt otherwise.
-    public: std::optional<std::string> FilePath() const;
+    public: std::optional<std::string> Path() const;
 
     /// \brief Get the line number associated with this error.
     /// \return Returns the line number. nullopt otherwise.
@@ -213,7 +216,7 @@ namespace sdf
     public: friend std::ostream &operator<<(std::ostream &_out,
                                             const sdf::Error &_err)
     {
-      if (!_err.FilePath().has_value())
+      if (!_err.Path().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
@@ -225,7 +228,7 @@ namespace sdf
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.FilePath().value() << "]: "
+          << ": [" << _err.Path().value() << "]: "
           << " Msg: " << _err.Message();
       }
       else
@@ -233,7 +236,7 @@ namespace sdf
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.FilePath().value() << ":L"
+          << ": [" << _err.Path().value() << ":L"
           << std::to_string(_err.LineNumber().value()) << "]: "
           << " Msg: " << _err.Message();
       }

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -159,21 +159,31 @@ namespace sdf
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _path Either the file path or the XPath-like trace that is
-    /// related to this error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_path);
+                  const std::string &_xmlPath);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
+    /// \param[in] _filePath The file path that is related to this error.
+    /// \sa ErrorCode.
+    public: Error(const ErrorCode _code, const std::string &_message,
+                  const std::string &_xmlPath, const std::string &_path);
+
+    /// \brief Constructor.
+    /// \param[in] _code The error code.
+    /// \param[in] _message A description of the error.
+    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \param[in] _filePath The file path that is related to this error.
     /// \param[in] _lineNumber The line number in the provided file path where
     /// this error was raised.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_filePath, int _lineNumber);
+                  const std::string &_xmlPath, const std::string &_path,
+                  int _lineNumber);
 
     /// \brief Get the error code.
     /// \return An error code.
@@ -184,12 +194,15 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the file path or the XPath-like trace that is associated with
-    /// this error.
-    /// \return Returns the path of the file or the XPath-like trace that this
-    /// error is related to.
+    /// \brief Get the XPath-like trace that is associated with this error.
+    /// \return Returns the XPath-like trace that this error is related to,
     /// nullopt otherwise.
-    public: std::optional<std::string> Path() const;
+    public: std::optional<std::string> XmlPath() const;
+
+    /// \brief Get the file path that is associated with this error.
+    /// \return Returns the path of the file that this error is related to,
+    /// nullopt otherwise.
+    public: std::optional<std::string> FilePath() const;
 
     /// \brief Get the line number associated with this error.
     /// \return Returns the line number. nullopt otherwise.
@@ -216,29 +229,39 @@ namespace sdf
     public: friend std::ostream &operator<<(std::ostream &_out,
                                             const sdf::Error &_err)
     {
-      if (!_err.Path().has_value())
+      if (!_err.XmlPath().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
           << " Msg: " << _err.Message();
+      }
+      else if (!_err.FilePath().has_value())
+      {
+        _out << "Error Code "
+          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
+              _err.Code())
+          << ": [" << _err.XmlPath().value()
+          << "]: Msg: " << _err.Message();
       }
       else if (!_err.LineNumber().has_value())
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.Path().value() << "]: "
-          << " Msg: " << _err.Message();
+          << ": [" << _err.XmlPath().value()
+          << ":" << _err.FilePath().value()
+          << "]: Msg: " << _err.Message();
       }
       else
       {
         _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
               _err.Code())
-          << ": [" << _err.Path().value() << ":L"
-          << std::to_string(_err.LineNumber().value()) << "]: "
-          << " Msg: " << _err.Message();
+          << ": [" << _err.XmlPath().value()
+          << ":" << _err.FilePath().value()
+          << ":L" << std::to_string(_err.LineNumber().value())
+          << "]: Msg: " << _err.Message();
       }
       return _out;
     }

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -183,7 +183,7 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the file path that is associated with this error.
+    /// \brief Get the file path associated with this error.
     /// \return Returns the path of the file that this error is related to,
     /// nullopt otherwise.
     public: std::optional<std::string> FilePath() const;

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -229,40 +229,25 @@ namespace sdf
     public: friend std::ostream &operator<<(std::ostream &_out,
                                             const sdf::Error &_err)
     {
-      if (!_err.XmlPath().has_value())
-      {
-        _out << "Error Code "
+      std::string pathInfo = "";
+
+      if (_err.XmlPath().has_value())
+        pathInfo += _err.XmlPath().value();
+
+      if (_err.FilePath().has_value())
+        pathInfo += ":" + _err.FilePath().value();
+
+      if (_err.LineNumber().has_value())
+        pathInfo += ":L" + std::to_string(_err.LineNumber().value());
+
+      if (!pathInfo.empty())
+        pathInfo = "[" + pathInfo + "]: ";
+
+      _out << "Error Code "
           << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
-              _err.Code())
-          << " Msg: " << _err.Message();
-      }
-      else if (!_err.FilePath().has_value())
-      {
-        _out << "Error Code "
-          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
-              _err.Code())
-          << ": [" << _err.XmlPath().value()
-          << "]: Msg: " << _err.Message();
-      }
-      else if (!_err.LineNumber().has_value())
-      {
-        _out << "Error Code "
-          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
-              _err.Code())
-          << ": [" << _err.XmlPath().value()
-          << ":" << _err.FilePath().value()
-          << "]: Msg: " << _err.Message();
-      }
-      else
-      {
-        _out << "Error Code "
-          << static_cast<std::underlying_type<sdf::ErrorCode>::type>(
-              _err.Code())
-          << ": [" << _err.XmlPath().value()
-          << ":" << _err.FilePath().value()
-          << ":L" << std::to_string(_err.LineNumber().value())
-          << "]: Msg: " << _err.Message();
-      }
+              _err.Code()) << ": "
+          << pathInfo
+          << "Msg: " << _err.Message();
       return _out;
     }
 

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -159,31 +159,20 @@ namespace sdf
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
-    /// \sa ErrorCode.
-    public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath);
-
-    /// \brief Constructor.
-    /// \param[in] _code The error code.
-    /// \param[in] _message A description of the error.
-    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \param[in] _filePath The file path that is related to this error.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_filePath);
+                  const std::string &_filePath);
 
     /// \brief Constructor.
     /// \param[in] _code The error code.
     /// \param[in] _message A description of the error.
-    /// \param[in] _xmlPath The XPath-like trace that is related to this error.
     /// \param[in] _filePath The file path that is related to this error.
     /// \param[in] _lineNumber The line number in the provided file path where
     /// this error was raised.
     /// \sa ErrorCode.
     public: Error(const ErrorCode _code, const std::string &_message,
-                  const std::string &_xmlPath, const std::string &_filePath,
-                  int _lineNumber);
+                  const std::string &_filePath, int _lineNumber);
 
     /// \brief Get the error code.
     /// \return An error code.
@@ -194,11 +183,6 @@ namespace sdf
     /// \return Error message.
     public: std::string Message() const;
 
-    /// \brief Get the XPath-like trace that is associated with this error.
-    /// \return Returns the XPath-like trace that this error is related to,
-    /// nullopt otherwise.
-    public: std::optional<std::string> XmlPath() const;
-
     /// \brief Get the file path that is associated with this error.
     /// \return Returns the path of the file that this error is related to,
     /// nullopt otherwise.
@@ -207,6 +191,16 @@ namespace sdf
     /// \brief Get the line number associated with this error.
     /// \return Returns the line number. nullopt otherwise.
     public: std::optional<int> LineNumber() const;
+
+    /// \brief Get the XPath-like trace that is associated with this error.
+    /// \return Returns the XPath-like trace that this error is related to,
+    /// nullopt otherwise.
+    public: std::optional<std::string> XmlPath() const;
+
+    /// \brief Sets the XML path that is associated with this error.
+    /// \param[in] _xmlPath The XML path that is related to this error. (e.g.
+    /// /sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"])
+    public: void SetXmlPath(const std::string &_xmlPath);
 
     /// \brief Safe bool conversion.
     /// \return True if this Error's Code() != NONE. In otherwords, this is

--- a/include/sdf/Error.hh
+++ b/include/sdf/Error.hh
@@ -200,6 +200,7 @@ namespace sdf
     /// \brief Sets the XML path that is associated with this error.
     /// \param[in] _xmlPath The XML path that is related to this error. (e.g.
     /// /sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"])
+    /// \sa Element::SetXmlPath
     public: void SetXmlPath(const std::string &_xmlPath);
 
     /// \brief Safe bool conversion.

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -167,6 +167,7 @@ ElementPtr Element::Clone() const
   clone->dataPtr->includeFilename = this->dataPtr->includeFilename;
   clone->dataPtr->referenceSDF = this->dataPtr->referenceSDF;
   clone->dataPtr->path = this->dataPtr->path;
+  clone->dataPtr->lineNumber = this->dataPtr->lineNumber;
   clone->dataPtr->xmlPath = this->dataPtr->xmlPath;
   clone->dataPtr->originalVersion = this->dataPtr->originalVersion;
 
@@ -215,6 +216,7 @@ void Element::Copy(const ElementPtr _elem)
   this->dataPtr->referenceSDF = _elem->ReferenceSDF();
   this->dataPtr->originalVersion = _elem->OriginalVersion();
   this->dataPtr->path = _elem->FilePath();
+  this->dataPtr->lineNumber = _elem->LineNumber();
   this->dataPtr->xmlPath = _elem->XmlPath();
 
   for (Param_V::iterator iter = _elem->dataPtr->attributes.begin();
@@ -869,6 +871,7 @@ void Element::Clear()
   this->ClearElements();
   this->dataPtr->originalVersion.clear();
   this->dataPtr->path.clear();
+  this->dataPtr->lineNumber = std::nullopt;
   this->dataPtr->xmlPath.clear();
 }
 
@@ -975,6 +978,18 @@ void Element::SetFilePath(const std::string &_path)
 const std::string &Element::FilePath() const
 {
   return this->dataPtr->path;
+}
+
+/////////////////////////////////////////////////
+void Element::SetLineNumber(int _lineNumber)
+{
+  this->dataPtr->lineNumber = _lineNumber;
+}
+
+/////////////////////////////////////////////////
+std::optional<int> Element::LineNumber() const
+{
+  return this->dataPtr->lineNumber;
 }
 
 /////////////////////////////////////////////////

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -118,7 +118,7 @@ void Element::AddValue(const std::string &_type,
                        const std::string &_description)
 {
   this->dataPtr->value = this->CreateParam(this->dataPtr->name,
-        _type, _defaultValue, _required, _description);
+      _type, _defaultValue, _required, _description);
 }
 
 /////////////////////////////////////////////////
@@ -507,7 +507,6 @@ void Element::PrintValuesImpl(const std::string &_prefix,
     }
   }
 }
-
 
 /////////////////////////////////////////////////
 void Element::PrintValues(std::string _prefix) const

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -304,7 +304,7 @@ void Element::AddAttribute(const std::string &_key,
                            const std::string &_description)
 {
   this->dataPtr->attributes.push_back(
-      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required, 
+      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required,
                                  _description));
 }
 

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -25,171 +25,9 @@
 
 using namespace sdf;
 
-class sdf::Element::Implementation
-{
-  /// \brief Element name
-  public: std::string name;
-
-  /// \brief True if element is required
-  public: std::string required;
-
-  /// \brief Element description
-  public: std::string description;
-
-  /// \brief True if element's children should be copied.
-  public: bool copyChildren;
-
-  /// \brief Element's parent
-  public: ElementWeakPtr parent;
-
-  // Attributes of this element
-  public: Param_V attributes;
-
-  // Value of this element
-  public: ParamPtr value;
-
-  // The existing child elements
-  public: ElementPtr_V elements;
-
-  // The possible child elements
-  public: ElementPtr_V elementDescriptions;
-
-  /// \brief The <include> element that was used to load this entity. For
-  /// example, given the following SDFormat:
-  /// <sdf version='1.8'>
-  ///   <world name='default'>
-  ///     <include>
-  ///       <uri>model_uri</uri>
-  ///       <pose>1 2 3 0 0 0</pose>
-  ///     </include>
-  ///   </world>
-  /// </sdf>
-  /// The ElementPtr associated with the model loaded from `model_uri` will
-  /// have the includeElement set to
-  ///     <include>
-  ///       <uri>model_uri</uri>
-  ///       <pose>1 2 3 0 0 0</pose>
-  ///     </include>
-  ///
-  /// This can be used to retrieve additional information available under the
-  /// <include> tag after the entity has been loaded. An example use case for
-  /// this is when saving a loaded world back to SDFormat.
-  public: ElementPtr includeElement;
-
-  /// name of the include file that was used to create this element
-  public: std::string includeFilename;
-
-  /// \brief Name of reference sdf.
-  public: std::string referenceSDF;
-
-  /// \brief Path to file where this element came from
-  public: std::string filePath;
-
-  /// \brief Xml path of this element.
-  public: std::string xmlPath;
-
-  /// \brief Spec version that this was originally parsed from.
-  public: std::string originalVersion;
-
-  /// \brief Generate a string (XML) representation of this object.
-  /// \param[in] _prefix arbitrary prefix to put on the string.
-  /// \param[out] _out the std::ostreamstream to write output to.
-  public: void ToString(const std::string &_prefix,
-                        std::ostringstream &_out) const;
-
-  /// \brief Generate a string (XML) representation of this object.
-  /// \param[in] _prefix arbitrary prefix to put on the string.
-  /// \param[out] _out the std::ostreamstream to write output to.
-  public: void PrintValuesImpl(const std::string &_prefix,
-                               std::ostringstream &_out) const;
-
-  /// \brief Create a new Param object and return it.
-  /// \param[in] _key Key for the parameter.
-  /// \param[in] _type String name for the value type (double,
-  /// int,...).
-  /// \param[in] _defaultValue Default value.
-  /// \param[in] _required True if the parameter is required to be set.
-  /// \param[in] _description Description of the parameter.
-  /// \return A pointer to the new Param object.
-  public: ParamPtr CreateParam(const std::string &_key,
-                               const std::string &_type,
-                               const std::string &_defaultValue,
-                               bool _required,
-                               const std::string &_description="");
-};
-
-/////////////////////////////////////////////////
-void Element::Implementation::ToString(const std::string &_prefix,
-                                       std::ostringstream &_out) const
-{
-  if (this->includeFilename.empty())
-  {
-    PrintValuesImpl(_prefix, _out);
-  }
-  else
-  {
-    _out << _prefix << "<include filename='"
-         << this->includeFilename << "'/>\n";
-  }
-}
-
-/////////////////////////////////////////////////
-void Element::Implementation::PrintValuesImpl(const std::string &_prefix,
-                                              std::ostringstream &_out) const
-{
-  _out << _prefix << "<" << this->name;
-
-  for (ParamPtr attrib : attributes)
-  {
-    // Only print attribute values if they were set
-    // TODO(anyone): GetRequired is added here to support up-conversions where a
-    // new required attribute with a default value is added. We would have
-    // better separation of concerns if the conversion process set the required
-    // attributes with their default values.
-    if (attrib->GetSet() || attrib->GetRequired())
-    {
-      _out << " " << attrib->GetKey() << "='"
-           << attrib->GetAsString() << "'";
-    }
-  }
-
-  if (this->elements.size() > 0)
-  {
-    _out << ">\n";
-    for (ElementPtr elem : elements)
-    {
-      elem->dataPtr->ToString(_prefix + "  ", _out);
-    }
-    _out << _prefix << "</" << this->name << ">\n";
-  }
-  else
-  {
-    if (this->value)
-    {
-      _out << ">" << this->value->GetAsString()
-           << "</" << this->name << ">\n";
-    }
-    else
-    {
-      _out << "/>\n";
-    }
-  }
-}
-
-/////////////////////////////////////////////////
-ParamPtr Element::Implementation::CreateParam(const std::string &_key,
-                                              const std::string &_type,
-                                              const std::string &_defaultValue,
-                                              bool _required,
-                                              const std::string &_description)
-{
-  return ParamPtr(
-      new Param(_key, _type, _defaultValue, _required, _description));
-}
-
 /////////////////////////////////////////////////
 Element::Element()
-  : dataPtr(ignition::utils::MakeImpl<Implementation>())
+  : dataPtr(new ElementPrivate)
 {
   this->dataPtr->copyChildren = false;
   this->dataPtr->referenceSDF = "";
@@ -211,7 +49,7 @@ void Element::SetParent(const ElementPtr _parent)
 {
   this->dataPtr->parent = _parent;
 
-  // If this element doesn't have a file path, get it from the parent
+  // If this element doesn't have a path, get it from the parent
   if (nullptr != _parent && (this->FilePath().empty() ||
       this->FilePath() == std::string(kSdfStringSource)))
   {
@@ -279,8 +117,8 @@ void Element::AddValue(const std::string &_type,
                        bool _required,
                        const std::string &_description)
 {
-  this->dataPtr->value = this->dataPtr->CreateParam(this->dataPtr->name,
-      _type, _defaultValue, _required, _description);
+  this->dataPtr->value = this->CreateParam(this->dataPtr->name,
+        _type, _defaultValue, _required, _description);
 }
 
 /////////////////////////////////////////////////
@@ -297,6 +135,17 @@ void Element::AddValue(const std::string &_type,
 }
 
 /////////////////////////////////////////////////
+ParamPtr Element::CreateParam(const std::string &_key,
+                              const std::string &_type,
+                              const std::string &_defaultValue,
+                              bool _required,
+                              const std::string &_description)
+{
+  return ParamPtr(
+      new Param(_key, _type, _defaultValue, _required, _description));
+}
+
+/////////////////////////////////////////////////
 void Element::AddAttribute(const std::string &_key,
                            const std::string &_type,
                            const std::string &_defaultValue,
@@ -304,8 +153,7 @@ void Element::AddAttribute(const std::string &_key,
                            const std::string &_description)
 {
   this->dataPtr->attributes.push_back(
-      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required,
-                                 _description));
+      this->CreateParam(_key, _type, _defaultValue, _required, _description));
 }
 
 /////////////////////////////////////////////////
@@ -318,7 +166,7 @@ ElementPtr Element::Clone() const
   clone->dataPtr->copyChildren = this->dataPtr->copyChildren;
   clone->dataPtr->includeFilename = this->dataPtr->includeFilename;
   clone->dataPtr->referenceSDF = this->dataPtr->referenceSDF;
-  clone->dataPtr->filePath = this->dataPtr->filePath;
+  clone->dataPtr->path = this->dataPtr->path;
   clone->dataPtr->xmlPath = this->dataPtr->xmlPath;
   clone->dataPtr->originalVersion = this->dataPtr->originalVersion;
 
@@ -366,7 +214,7 @@ void Element::Copy(const ElementPtr _elem)
   this->dataPtr->includeFilename = _elem->dataPtr->includeFilename;
   this->dataPtr->referenceSDF = _elem->ReferenceSDF();
   this->dataPtr->originalVersion = _elem->OriginalVersion();
-  this->dataPtr->filePath = _elem->FilePath();
+  this->dataPtr->path = _elem->FilePath();
   this->dataPtr->xmlPath = _elem->XmlPath();
 
   for (Param_V::iterator iter = _elem->dataPtr->attributes.begin();
@@ -454,7 +302,7 @@ void Element::PrintDescription(const std::string &_prefix) const
             << this->dataPtr->description
             << "]]></description>\n";
 
-  Param_V::const_iterator aiter;
+  Param_V::iterator aiter;
   for (aiter = this->dataPtr->attributes.begin();
       aiter != this->dataPtr->attributes.end(); ++aiter)
   {
@@ -481,7 +329,7 @@ void Element::PrintDescription(const std::string &_prefix) const
               << "' required ='*'/>\n";
   }
 
-  ElementPtr_V::const_iterator eiter;
+  ElementPtr_V::iterator eiter;
   for (eiter = this->dataPtr->elementDescriptions.begin();
       eiter != this->dataPtr->elementDescriptions.end(); ++eiter)
   {
@@ -496,7 +344,7 @@ void Element::PrintDocRightPane(std::string &_html, int _spacing,
                                 int &_index) const
 {
   std::ostringstream stream;
-  ElementPtr_V::const_iterator eiter;
+  ElementPtr_V::iterator eiter;
 
   int start = _index++;
 
@@ -548,7 +396,7 @@ void Element::PrintDocRightPane(std::string &_html, int _spacing,
            << "display:inline-block;'>\n";
     stream << "<font style='font-weight:bold'>Attributes</font><br>";
 
-    Param_V::const_iterator aiter;
+    Param_V::iterator aiter;
     for (aiter = this->dataPtr->attributes.begin();
         aiter != this->dataPtr->attributes.end(); ++aiter)
     {
@@ -592,7 +440,7 @@ void Element::PrintDocLeftPane(std::string &_html, int _spacing,
                                int &_index) const
 {
   std::ostringstream stream;
-  ElementPtr_V::const_iterator eiter;
+  ElementPtr_V::iterator eiter;
 
   int start = _index++;
 
@@ -614,11 +462,58 @@ void Element::PrintDocLeftPane(std::string &_html, int _spacing,
   _html += "</div>\n";
 }
 
+void Element::PrintValuesImpl(const std::string &_prefix,
+                              std::ostringstream &_out) const
+{
+  _out << _prefix << "<" << this->dataPtr->name;
+
+  Param_V::const_iterator aiter;
+  for (aiter = this->dataPtr->attributes.begin();
+       aiter != this->dataPtr->attributes.end(); ++aiter)
+  {
+    // Only print attribute values if they were set
+    // TODO(anyone): GetRequired is added here to support up-conversions where a
+    // new required attribute with a default value is added. We would have
+    // better separation of concerns if the conversion process set the required
+    // attributes with their default values.
+    if ((*aiter)->GetSet() || (*aiter)->GetRequired())
+    {
+      _out << " " << (*aiter)->GetKey() << "='"
+           << (*aiter)->GetAsString() << "'";
+    }
+  }
+
+  if (this->dataPtr->elements.size() > 0)
+  {
+    _out << ">\n";
+    ElementPtr_V::const_iterator eiter;
+    for (eiter = this->dataPtr->elements.begin();
+         eiter != this->dataPtr->elements.end(); ++eiter)
+    {
+      (*eiter)->ToString(_prefix + "  ", _out);
+    }
+    _out << _prefix << "</" << this->dataPtr->name << ">\n";
+  }
+  else
+  {
+    if (this->dataPtr->value)
+    {
+      _out << ">" << this->dataPtr->value->GetAsString()
+           << "</" << this->dataPtr->name << ">\n";
+    }
+    else
+    {
+      _out << "/>\n";
+    }
+  }
+}
+
+
 /////////////////////////////////////////////////
 void Element::PrintValues(std::string _prefix) const
 {
   std::ostringstream ss;
-  this->dataPtr->PrintValuesImpl(_prefix, ss);
+  PrintValuesImpl(_prefix, ss);
   std::cout << ss.str();
 }
 
@@ -626,8 +521,23 @@ void Element::PrintValues(std::string _prefix) const
 std::string Element::ToString(const std::string &_prefix) const
 {
   std::ostringstream out;
-  this->dataPtr->ToString(_prefix, out);
+  this->ToString(_prefix, out);
   return out.str();
+}
+
+/////////////////////////////////////////////////
+void Element::ToString(const std::string &_prefix,
+                       std::ostringstream &_out) const
+{
+  if (this->dataPtr->includeFilename.empty())
+  {
+    PrintValuesImpl(_prefix, _out);
+  }
+  else
+  {
+    _out << _prefix << "<include filename='"
+         << this->dataPtr->includeFilename << "'/>\n";
+  }
 }
 
 /////////////////////////////////////////////////
@@ -959,7 +869,7 @@ void Element::Clear()
 {
   this->ClearElements();
   this->dataPtr->originalVersion.clear();
-  this->dataPtr->filePath.clear();
+  this->dataPtr->path.clear();
   this->dataPtr->xmlPath.clear();
 }
 
@@ -1059,13 +969,13 @@ sdf::ElementPtr Element::GetIncludeElement() const
 /////////////////////////////////////////////////
 void Element::SetFilePath(const std::string &_path)
 {
-  this->dataPtr->filePath = _path;
+  this->dataPtr->path = _path;
 }
 
 /////////////////////////////////////////////////
 const std::string &Element::FilePath() const
 {
-  return this->dataPtr->filePath;
+  return this->dataPtr->path;
 }
 
 /////////////////////////////////////////////////

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -25,9 +25,171 @@
 
 using namespace sdf;
 
+class sdf::Element::Implementation
+{
+  /// \brief Element name
+  public: std::string name;
+
+  /// \brief True if element is required
+  public: std::string required;
+
+  /// \brief Element description
+  public: std::string description;
+
+  /// \brief True if element's children should be copied.
+  public: bool copyChildren;
+
+  /// \brief Element's parent
+  public: ElementWeakPtr parent;
+
+  // Attributes of this element
+  public: Param_V attributes;
+
+  // Value of this element
+  public: ParamPtr value;
+
+  // The existing child elements
+  public: ElementPtr_V elements;
+
+  // The possible child elements
+  public: ElementPtr_V elementDescriptions;
+
+  /// \brief The <include> element that was used to load this entity. For
+  /// example, given the following SDFormat:
+  /// <sdf version='1.8'>
+  ///   <world name='default'>
+  ///     <include>
+  ///       <uri>model_uri</uri>
+  ///       <pose>1 2 3 0 0 0</pose>
+  ///     </include>
+  ///   </world>
+  /// </sdf>
+  /// The ElementPtr associated with the model loaded from `model_uri` will
+  /// have the includeElement set to
+  ///     <include>
+  ///       <uri>model_uri</uri>
+  ///       <pose>1 2 3 0 0 0</pose>
+  ///     </include>
+  ///
+  /// This can be used to retrieve additional information available under the
+  /// <include> tag after the entity has been loaded. An example use case for
+  /// this is when saving a loaded world back to SDFormat.
+  public: ElementPtr includeElement;
+
+  /// name of the include file that was used to create this element
+  public: std::string includeFilename;
+
+  /// \brief Name of reference sdf.
+  public: std::string referenceSDF;
+
+  /// \brief Path to file where this element came from
+  public: std::string filePath;
+
+  /// \brief Xml path of this element.
+  public: std::string xmlPath;
+
+  /// \brief Spec version that this was originally parsed from.
+  public: std::string originalVersion;
+
+  /// \brief Generate a string (XML) representation of this object.
+  /// \param[in] _prefix arbitrary prefix to put on the string.
+  /// \param[out] _out the std::ostreamstream to write output to.
+  public: void ToString(const std::string &_prefix,
+                        std::ostringstream &_out) const;
+
+  /// \brief Generate a string (XML) representation of this object.
+  /// \param[in] _prefix arbitrary prefix to put on the string.
+  /// \param[out] _out the std::ostreamstream to write output to.
+  public: void PrintValuesImpl(const std::string &_prefix,
+                               std::ostringstream &_out) const;
+
+  /// \brief Create a new Param object and return it.
+  /// \param[in] _key Key for the parameter.
+  /// \param[in] _type String name for the value type (double,
+  /// int,...).
+  /// \param[in] _defaultValue Default value.
+  /// \param[in] _required True if the parameter is required to be set.
+  /// \param[in] _description Description of the parameter.
+  /// \return A pointer to the new Param object.
+  public: ParamPtr CreateParam(const std::string &_key,
+                               const std::string &_type,
+                               const std::string &_defaultValue,
+                               bool _required,
+                               const std::string &_description="");
+};
+
+/////////////////////////////////////////////////
+void Element::Implementation::ToString(const std::string &_prefix,
+                                       std::ostringstream &_out) const
+{
+  if (this->includeFilename.empty())
+  {
+    PrintValuesImpl(_prefix, _out);
+  }
+  else
+  {
+    _out << _prefix << "<include filename='"
+         << this->includeFilename << "'/>\n";
+  }
+}
+
+/////////////////////////////////////////////////
+void Element::Implementation::PrintValuesImpl(const std::string &_prefix,
+                                              std::ostringstream &_out) const
+{
+  _out << _prefix << "<" << this->name;
+
+  for (ParamPtr attrib : attributes)
+  {
+    // Only print attribute values if they were set
+    // TODO(anyone): GetRequired is added here to support up-conversions where a
+    // new required attribute with a default value is added. We would have
+    // better separation of concerns if the conversion process set the required
+    // attributes with their default values.
+    if (attrib->GetSet() || attrib->GetRequired())
+    {
+      _out << " " << attrib->GetKey() << "='"
+           << attrib->GetAsString() << "'";
+    }
+  }
+
+  if (this->elements.size() > 0)
+  {
+    _out << ">\n";
+    for (ElementPtr elem : elements)
+    {
+      elem->dataPtr->ToString(_prefix + "  ", _out);
+    }
+    _out << _prefix << "</" << this->name << ">\n";
+  }
+  else
+  {
+    if (this->value)
+    {
+      _out << ">" << this->value->GetAsString()
+           << "</" << this->name << ">\n";
+    }
+    else
+    {
+      _out << "/>\n";
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+ParamPtr Element::Implementation::CreateParam(const std::string &_key,
+                                              const std::string &_type,
+                                              const std::string &_defaultValue,
+                                              bool _required,
+                                              const std::string &_description)
+{
+  return ParamPtr(
+      new Param(_key, _type, _defaultValue, _required, _description));
+}
+
 /////////////////////////////////////////////////
 Element::Element()
-  : dataPtr(new ElementPrivate)
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->copyChildren = false;
   this->dataPtr->referenceSDF = "";
@@ -49,7 +211,7 @@ void Element::SetParent(const ElementPtr _parent)
 {
   this->dataPtr->parent = _parent;
 
-  // If this element doesn't have a path, get it from the parent
+  // If this element doesn't have a file path, get it from the parent
   if (nullptr != _parent && (this->FilePath().empty() ||
       this->FilePath() == std::string(kSdfStringSource)))
   {
@@ -117,7 +279,7 @@ void Element::AddValue(const std::string &_type,
                        bool _required,
                        const std::string &_description)
 {
-  this->dataPtr->value = this->CreateParam(this->dataPtr->name,
+  this->dataPtr->value = this->dataPtr->CreateParam(this->dataPtr->name,
       _type, _defaultValue, _required, _description);
 }
 
@@ -135,17 +297,6 @@ void Element::AddValue(const std::string &_type,
 }
 
 /////////////////////////////////////////////////
-ParamPtr Element::CreateParam(const std::string &_key,
-                              const std::string &_type,
-                              const std::string &_defaultValue,
-                              bool _required,
-                              const std::string &_description)
-{
-  return ParamPtr(
-      new Param(_key, _type, _defaultValue, _required, _description));
-}
-
-/////////////////////////////////////////////////
 void Element::AddAttribute(const std::string &_key,
                            const std::string &_type,
                            const std::string &_defaultValue,
@@ -153,7 +304,8 @@ void Element::AddAttribute(const std::string &_key,
                            const std::string &_description)
 {
   this->dataPtr->attributes.push_back(
-      this->CreateParam(_key, _type, _defaultValue, _required, _description));
+      this->dataPtr->CreateParam(_key, _type, _defaultValue, _required, 
+                                 _description));
 }
 
 /////////////////////////////////////////////////
@@ -166,7 +318,8 @@ ElementPtr Element::Clone() const
   clone->dataPtr->copyChildren = this->dataPtr->copyChildren;
   clone->dataPtr->includeFilename = this->dataPtr->includeFilename;
   clone->dataPtr->referenceSDF = this->dataPtr->referenceSDF;
-  clone->dataPtr->path = this->dataPtr->path;
+  clone->dataPtr->filePath = this->dataPtr->filePath;
+  clone->dataPtr->xmlPath = this->dataPtr->xmlPath;
   clone->dataPtr->originalVersion = this->dataPtr->originalVersion;
 
   Param_V::const_iterator aiter;
@@ -213,7 +366,8 @@ void Element::Copy(const ElementPtr _elem)
   this->dataPtr->includeFilename = _elem->dataPtr->includeFilename;
   this->dataPtr->referenceSDF = _elem->ReferenceSDF();
   this->dataPtr->originalVersion = _elem->OriginalVersion();
-  this->dataPtr->path = _elem->FilePath();
+  this->dataPtr->filePath = _elem->FilePath();
+  this->dataPtr->xmlPath = _elem->XmlPath();
 
   for (Param_V::iterator iter = _elem->dataPtr->attributes.begin();
        iter != _elem->dataPtr->attributes.end(); ++iter)
@@ -300,7 +454,7 @@ void Element::PrintDescription(const std::string &_prefix) const
             << this->dataPtr->description
             << "]]></description>\n";
 
-  Param_V::iterator aiter;
+  Param_V::const_iterator aiter;
   for (aiter = this->dataPtr->attributes.begin();
       aiter != this->dataPtr->attributes.end(); ++aiter)
   {
@@ -327,7 +481,7 @@ void Element::PrintDescription(const std::string &_prefix) const
               << "' required ='*'/>\n";
   }
 
-  ElementPtr_V::iterator eiter;
+  ElementPtr_V::const_iterator eiter;
   for (eiter = this->dataPtr->elementDescriptions.begin();
       eiter != this->dataPtr->elementDescriptions.end(); ++eiter)
   {
@@ -342,7 +496,7 @@ void Element::PrintDocRightPane(std::string &_html, int _spacing,
                                 int &_index) const
 {
   std::ostringstream stream;
-  ElementPtr_V::iterator eiter;
+  ElementPtr_V::const_iterator eiter;
 
   int start = _index++;
 
@@ -394,7 +548,7 @@ void Element::PrintDocRightPane(std::string &_html, int _spacing,
            << "display:inline-block;'>\n";
     stream << "<font style='font-weight:bold'>Attributes</font><br>";
 
-    Param_V::iterator aiter;
+    Param_V::const_iterator aiter;
     for (aiter = this->dataPtr->attributes.begin();
         aiter != this->dataPtr->attributes.end(); ++aiter)
     {
@@ -438,7 +592,7 @@ void Element::PrintDocLeftPane(std::string &_html, int _spacing,
                                int &_index) const
 {
   std::ostringstream stream;
-  ElementPtr_V::iterator eiter;
+  ElementPtr_V::const_iterator eiter;
 
   int start = _index++;
 
@@ -460,57 +614,11 @@ void Element::PrintDocLeftPane(std::string &_html, int _spacing,
   _html += "</div>\n";
 }
 
-void Element::PrintValuesImpl(const std::string &_prefix,
-                              std::ostringstream &_out) const
-{
-  _out << _prefix << "<" << this->dataPtr->name;
-
-  Param_V::const_iterator aiter;
-  for (aiter = this->dataPtr->attributes.begin();
-       aiter != this->dataPtr->attributes.end(); ++aiter)
-  {
-    // Only print attribute values if they were set
-    // TODO(anyone): GetRequired is added here to support up-conversions where a
-    // new required attribute with a default value is added. We would have
-    // better separation of concerns if the conversion process set the required
-    // attributes with their default values.
-    if ((*aiter)->GetSet() || (*aiter)->GetRequired())
-    {
-      _out << " " << (*aiter)->GetKey() << "='"
-           << (*aiter)->GetAsString() << "'";
-    }
-  }
-
-  if (this->dataPtr->elements.size() > 0)
-  {
-    _out << ">\n";
-    ElementPtr_V::const_iterator eiter;
-    for (eiter = this->dataPtr->elements.begin();
-         eiter != this->dataPtr->elements.end(); ++eiter)
-    {
-      (*eiter)->ToString(_prefix + "  ", _out);
-    }
-    _out << _prefix << "</" << this->dataPtr->name << ">\n";
-  }
-  else
-  {
-    if (this->dataPtr->value)
-    {
-      _out << ">" << this->dataPtr->value->GetAsString()
-           << "</" << this->dataPtr->name << ">\n";
-    }
-    else
-    {
-      _out << "/>\n";
-    }
-  }
-}
-
 /////////////////////////////////////////////////
 void Element::PrintValues(std::string _prefix) const
 {
   std::ostringstream ss;
-  PrintValuesImpl(_prefix, ss);
+  this->dataPtr->PrintValuesImpl(_prefix, ss);
   std::cout << ss.str();
 }
 
@@ -518,23 +626,8 @@ void Element::PrintValues(std::string _prefix) const
 std::string Element::ToString(const std::string &_prefix) const
 {
   std::ostringstream out;
-  this->ToString(_prefix, out);
+  this->dataPtr->ToString(_prefix, out);
   return out.str();
-}
-
-/////////////////////////////////////////////////
-void Element::ToString(const std::string &_prefix,
-                       std::ostringstream &_out) const
-{
-  if (this->dataPtr->includeFilename.empty())
-  {
-    PrintValuesImpl(_prefix, _out);
-  }
-  else
-  {
-    _out << _prefix << "<include filename='"
-         << this->dataPtr->includeFilename << "'/>\n";
-  }
 }
 
 /////////////////////////////////////////////////
@@ -866,7 +959,8 @@ void Element::Clear()
 {
   this->ClearElements();
   this->dataPtr->originalVersion.clear();
-  this->dataPtr->path.clear();
+  this->dataPtr->filePath.clear();
+  this->dataPtr->xmlPath.clear();
 }
 
 /////////////////////////////////////////////////
@@ -965,13 +1059,25 @@ sdf::ElementPtr Element::GetIncludeElement() const
 /////////////////////////////////////////////////
 void Element::SetFilePath(const std::string &_path)
 {
-  this->dataPtr->path = _path;
+  this->dataPtr->filePath = _path;
 }
 
 /////////////////////////////////////////////////
 const std::string &Element::FilePath() const
 {
-  return this->dataPtr->path;
+  return this->dataPtr->filePath;
+}
+
+/////////////////////////////////////////////////
+void Element::SetXmlPath(const std::string &_path)
+{
+  this->dataPtr->xmlPath = _path;
+}
+
+/////////////////////////////////////////////////
+const std::string &Element::XmlPath() const
+{
+  return this->dataPtr->xmlPath;
 }
 
 /////////////////////////////////////////////////

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -38,7 +38,7 @@ TEST(Element, Child)
   sdf::ElementPtr parent = std::make_shared<sdf::Element>();
   parent->SetFilePath("/parent/path/model.sdf");
   parent->SetLineNumber(12);
-  parent->SetXmlPath("/sdf/world[@name=\"default\"");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"]");
   parent->SetOriginalVersion("1.5");
 
   ASSERT_EQ(child.GetParent(), nullptr);
@@ -328,7 +328,7 @@ TEST(Element, Clone)
 
   parent->SetFilePath("/path/to/file.sdf");
   parent->SetLineNumber(12);
-  parent->SetXmlPath("/sdf/world[@name=\"default\"");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"]");
   parent->SetOriginalVersion("1.5");
 
   auto includeElemToStore = std::make_shared<sdf::Element>();
@@ -340,7 +340,7 @@ TEST(Element, Clone)
   EXPECT_EQ("/path/to/file.sdf", newelem->FilePath());
   ASSERT_TRUE(newelem->LineNumber().has_value());
   EXPECT_EQ(12, newelem->LineNumber().value());
-  EXPECT_EQ("/sdf/world[@name=\"default\"", newelem->XmlPath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"]", newelem->XmlPath());
   EXPECT_EQ("1.5", newelem->OriginalVersion());
   ASSERT_NE(newelem->GetFirstElement(), nullptr);
   ASSERT_EQ(newelem->GetElementDescriptionCount(), 1UL);
@@ -357,7 +357,7 @@ TEST(Element, ClearElements)
 
   parent->SetFilePath("/path/to/file.sdf");
   parent->SetLineNumber(12);
-  parent->SetXmlPath("/sdf/world[@name=\"default\"");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"]");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
@@ -365,7 +365,7 @@ TEST(Element, ClearElements)
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
   ASSERT_TRUE(parent->LineNumber().has_value());
   EXPECT_EQ(12, parent->LineNumber().value());
-  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"]", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -388,7 +388,7 @@ TEST(Element, Clear)
 
   parent->SetFilePath("/path/to/file.sdf");
   parent->SetLineNumber(12);
-  parent->SetXmlPath("/sdf/world[@name=\"default\"");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"]");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
@@ -396,7 +396,7 @@ TEST(Element, Clear)
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
   ASSERT_TRUE(parent->LineNumber().has_value());
   EXPECT_EQ(12, parent->LineNumber().value());
-  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"]", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -623,7 +623,7 @@ TEST(Element, Copy)
   src->SetName("test");
   src->SetFilePath("/path/to/file.sdf");
   src->SetLineNumber(12);
-  src->SetXmlPath("/sdf/world[@name=\"default\"");
+  src->SetXmlPath("/sdf/world[@name=\"default\"]");
   src->SetOriginalVersion("1.5");
   src->AddValue("string", "val", false, "val description");
   src->AddAttribute("test", "string", "foo", false, "foo description");
@@ -638,7 +638,7 @@ TEST(Element, Copy)
   EXPECT_EQ("/path/to/file.sdf", dest->FilePath());
   ASSERT_TRUE(dest->LineNumber().has_value());
   EXPECT_EQ(12, dest->LineNumber().value());
-  EXPECT_EQ("/sdf/world[@name=\"default\"", dest->XmlPath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"]", dest->XmlPath());
   EXPECT_EQ("1.5", dest->OriginalVersion());
 
   sdf::ParamPtr param = dest->GetValue();

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -37,8 +37,6 @@ TEST(Element, Child)
   sdf::Element child;
   sdf::ElementPtr parent = std::make_shared<sdf::Element>();
   parent->SetFilePath("/parent/path/model.sdf");
-  parent->SetLineNumber(12);
-  parent->SetXmlPath("/sdf/world[@name=\"default\"]");
   parent->SetOriginalVersion("1.5");
 
   ASSERT_EQ(child.GetParent(), nullptr);

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -37,6 +37,7 @@ TEST(Element, Child)
   sdf::Element child;
   sdf::ElementPtr parent = std::make_shared<sdf::Element>();
   parent->SetFilePath("/parent/path/model.sdf");
+  parent->SetLineNumber(12);
   parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
@@ -326,6 +327,7 @@ TEST(Element, Clone)
   parent->AddValue("string", "foo", false, "foo description");
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetLineNumber(12);
   parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
@@ -336,6 +338,8 @@ TEST(Element, Clone)
   sdf::ElementPtr newelem = parent->Clone();
 
   EXPECT_EQ("/path/to/file.sdf", newelem->FilePath());
+  ASSERT_TRUE(newelem->LineNumber().has_value());
+  EXPECT_EQ(12, newelem->LineNumber().value());
   EXPECT_EQ("/sdf/world[@name=\"default\"", newelem->XmlPath());
   EXPECT_EQ("1.5", newelem->OriginalVersion());
   ASSERT_NE(newelem->GetFirstElement(), nullptr);
@@ -352,12 +356,15 @@ TEST(Element, ClearElements)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetLineNumber(12);
   parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  ASSERT_TRUE(parent->LineNumber().has_value());
+  EXPECT_EQ(12, parent->LineNumber().value());
   EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
@@ -368,6 +375,8 @@ TEST(Element, ClearElements)
 
   ASSERT_EQ(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  ASSERT_TRUE(parent->LineNumber().has_value());
+  EXPECT_EQ(12, parent->LineNumber().value());
   EXPECT_EQ("1.5", parent->OriginalVersion());
 }
 
@@ -378,12 +387,15 @@ TEST(Element, Clear)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetLineNumber(12);
   parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  ASSERT_TRUE(parent->LineNumber().has_value());
+  EXPECT_EQ(12, parent->LineNumber().value());
   EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
@@ -394,6 +406,7 @@ TEST(Element, Clear)
 
   ASSERT_EQ(parent->GetFirstElement(), nullptr);
   EXPECT_TRUE(parent->FilePath().empty());
+  EXPECT_FALSE(parent->LineNumber().has_value());
   EXPECT_TRUE(parent->XmlPath().empty());
   EXPECT_TRUE(parent->OriginalVersion().empty());
 }
@@ -609,6 +622,7 @@ TEST(Element, Copy)
 
   src->SetName("test");
   src->SetFilePath("/path/to/file.sdf");
+  src->SetLineNumber(12);
   src->SetXmlPath("/sdf/world[@name=\"default\"");
   src->SetOriginalVersion("1.5");
   src->AddValue("string", "val", false, "val description");
@@ -622,6 +636,8 @@ TEST(Element, Copy)
   dest->Copy(src);
 
   EXPECT_EQ("/path/to/file.sdf", dest->FilePath());
+  ASSERT_TRUE(dest->LineNumber().has_value());
+  EXPECT_EQ(12, dest->LineNumber().value());
   EXPECT_EQ("/sdf/world[@name=\"default\"", dest->XmlPath());
   EXPECT_EQ("1.5", dest->OriginalVersion());
 

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -37,6 +37,7 @@ TEST(Element, Child)
   sdf::Element child;
   sdf::ElementPtr parent = std::make_shared<sdf::Element>();
   parent->SetFilePath("/parent/path/model.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
   ASSERT_EQ(child.GetParent(), nullptr);
@@ -325,6 +326,7 @@ TEST(Element, Clone)
   parent->AddValue("string", "foo", false, "foo description");
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
 
   auto includeElemToStore = std::make_shared<sdf::Element>();
@@ -334,6 +336,7 @@ TEST(Element, Clone)
   sdf::ElementPtr newelem = parent->Clone();
 
   EXPECT_EQ("/path/to/file.sdf", newelem->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", newelem->XmlPath());
   EXPECT_EQ("1.5", newelem->OriginalVersion());
   ASSERT_NE(newelem->GetFirstElement(), nullptr);
   ASSERT_EQ(newelem->GetElementDescriptionCount(), 1UL);
@@ -349,11 +352,13 @@ TEST(Element, ClearElements)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -373,11 +378,13 @@ TEST(Element, Clear)
   sdf::ElementPtr child = std::make_shared<sdf::Element>();
 
   parent->SetFilePath("/path/to/file.sdf");
+  parent->SetXmlPath("/sdf/world[@name=\"default\"");
   parent->SetOriginalVersion("1.5");
   child->SetParent(parent);
   parent->InsertElement(child);
 
   EXPECT_EQ("/path/to/file.sdf", parent->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", parent->XmlPath());
   EXPECT_EQ("1.5", parent->OriginalVersion());
   ASSERT_NE(parent->GetFirstElement(), nullptr);
   EXPECT_EQ("/path/to/file.sdf", parent->GetFirstElement()->FilePath());
@@ -387,6 +394,7 @@ TEST(Element, Clear)
 
   ASSERT_EQ(parent->GetFirstElement(), nullptr);
   EXPECT_TRUE(parent->FilePath().empty());
+  EXPECT_TRUE(parent->XmlPath().empty());
   EXPECT_TRUE(parent->OriginalVersion().empty());
 }
 
@@ -601,6 +609,7 @@ TEST(Element, Copy)
 
   src->SetName("test");
   src->SetFilePath("/path/to/file.sdf");
+  src->SetXmlPath("/sdf/world[@name=\"default\"");
   src->SetOriginalVersion("1.5");
   src->AddValue("string", "val", false, "val description");
   src->AddAttribute("test", "string", "foo", false, "foo description");
@@ -613,6 +622,7 @@ TEST(Element, Copy)
   dest->Copy(src);
 
   EXPECT_EQ("/path/to/file.sdf", dest->FilePath());
+  EXPECT_EQ("/sdf/world[@name=\"default\"", dest->XmlPath());
   EXPECT_EQ("1.5", dest->OriginalVersion());
 
   sdf::ParamPtr param = dest->GetValue();

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -27,8 +27,11 @@ class sdf::Error::Implementation
   /// \brief Description of the error.
   public: std::string message = "";
 
+  /// \brief Xml path where the error was raised.
+  public: std::optional<std::string> xmlPath = std::nullopt;
+
   /// \brief File path where the error was raised.
-  public: std::optional<std::string> path = std::nullopt;
+  public: std::optional<std::string> filePath = std::nullopt;
 
   /// \brief Line number in the file path where the error was raised.
   public: std::optional<int> lineNumber = std::nullopt;
@@ -49,22 +52,35 @@ Error::Error(const ErrorCode _code, const std::string &_message)
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_path)
+             const std::string &_xmlPath)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _path;
+  this->dataPtr->path = _xmlPath;
 }
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_filePath, int _lineNumber)
+             const std::string &_xmlPath, const std::string &_filePath)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _filePath;
+  this->dataPtr->xmlPath = _xmlPath;
+  this->dataPtr->filePath = _filePath;
+}
+
+/////////////////////////////////////////////////
+Error::Error(const ErrorCode _code, const std::string &_message,
+             const std::string &_xmlPath, const std::string &_filePath,
+             int lineNumber)
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->code = _code;
+  this->dataPtr->message = _message;
+  this->dataPtr->xmlPath = _xmlPath;
+  this->dataPtr->filePath = _filePath;
   this->dataPtr->lineNumber = _lineNumber;
 }
 
@@ -81,9 +97,15 @@ std::string Error::Message() const
 }
 
 /////////////////////////////////////////////////
-std::optional<std::string> Error::Path() const
+std::optional<std::string> Error::XmlPath() const
 {
-  return this->dataPtr->path;
+  return this->dataPtr->xmlPath;
+}
+
+/////////////////////////////////////////////////
+std::optional<std::string> Error::FilePath() const
+{
+  return this->dataPtr->filePath;
 }
 
 /////////////////////////////////////////////////

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -57,7 +57,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->path = _xmlPath;
+  this->dataPtr->xmlPath = _xmlPath;
 }
 
 /////////////////////////////////////////////////
@@ -74,7 +74,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
              const std::string &_xmlPath, const std::string &_filePath,
-             int lineNumber)
+             int _lineNumber)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -28,7 +28,7 @@ class sdf::Error::Implementation
   public: std::string message = "";
 
   /// \brief File path where the error was raised.
-  public: std::optional<std::string> filePath = std::nullopt;
+  public: std::optional<std::string> path = std::nullopt;
 
   /// \brief Line number in the file path where the error was raised.
   public: std::optional<int> lineNumber = std::nullopt;
@@ -49,12 +49,12 @@ Error::Error(const ErrorCode _code, const std::string &_message)
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_filePath)
+             const std::string &_path)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->filePath = _filePath;
+  this->dataPtr->path = _path;
 }
 
 /////////////////////////////////////////////////
@@ -64,7 +64,7 @@ Error::Error(const ErrorCode _code, const std::string &_message,
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->filePath = _filePath;
+  this->dataPtr->path = _filePath;
   this->dataPtr->lineNumber = _lineNumber;
 }
 
@@ -81,9 +81,9 @@ std::string Error::Message() const
 }
 
 /////////////////////////////////////////////////
-std::optional<std::string> Error::FilePath() const
+std::optional<std::string> Error::Path() const
 {
-  return this->dataPtr->filePath;
+  return this->dataPtr->path;
 }
 
 /////////////////////////////////////////////////

--- a/src/Error.cc
+++ b/src/Error.cc
@@ -52,34 +52,21 @@ Error::Error(const ErrorCode _code, const std::string &_message)
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_xmlPath)
+             const std::string &_filePath)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->xmlPath = _xmlPath;
-}
-
-/////////////////////////////////////////////////
-Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_xmlPath, const std::string &_filePath)
-  : dataPtr(ignition::utils::MakeImpl<Implementation>())
-{
-  this->dataPtr->code = _code;
-  this->dataPtr->message = _message;
-  this->dataPtr->xmlPath = _xmlPath;
   this->dataPtr->filePath = _filePath;
 }
 
 /////////////////////////////////////////////////
 Error::Error(const ErrorCode _code, const std::string &_message,
-             const std::string &_xmlPath, const std::string &_filePath,
-             int _lineNumber)
+             const std::string &_filePath, int _lineNumber)
   : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   this->dataPtr->code = _code;
   this->dataPtr->message = _message;
-  this->dataPtr->xmlPath = _xmlPath;
   this->dataPtr->filePath = _filePath;
   this->dataPtr->lineNumber = _lineNumber;
 }
@@ -97,12 +84,6 @@ std::string Error::Message() const
 }
 
 /////////////////////////////////////////////////
-std::optional<std::string> Error::XmlPath() const
-{
-  return this->dataPtr->xmlPath;
-}
-
-/////////////////////////////////////////////////
 std::optional<std::string> Error::FilePath() const
 {
   return this->dataPtr->filePath;
@@ -112,6 +93,18 @@ std::optional<std::string> Error::FilePath() const
 std::optional<int> Error::LineNumber() const
 {
   return this->dataPtr->lineNumber;
+}
+
+/////////////////////////////////////////////////
+std::optional<std::string> Error::XmlPath() const
+{
+  return this->dataPtr->xmlPath;
+}
+
+/////////////////////////////////////////////////
+void Error::SetXmlPath(const std::string &_xmlPath)
+{
+  this->dataPtr->xmlPath = _xmlPath;
 }
 
 /////////////////////////////////////////////////

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -27,7 +27,8 @@ TEST(Error, DefaultConstruction)
   EXPECT_EQ(error, false);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::NONE);
   EXPECT_TRUE(error.Message().empty());
-  EXPECT_FALSE(error.Path().has_value());
+  EXPECT_FALSE(error.XmlPath().has_value());
+  EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (error)
@@ -41,7 +42,8 @@ TEST(Error, ValueConstructionWithoutFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_FALSE(error.Path().has_value());
+  EXPECT_FALSE(error.XmlPath().has_value());
+  EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (!error)
@@ -49,18 +51,66 @@ TEST(Error, ValueConstructionWithoutFile)
 }
 
 /////////////////////////////////////////////////
-TEST(Error, ValueConstructionWithFile)
+TEST(Error, ValueConstructionWithXmlPath)
 {
-  const std::string emptyFilePath = "Empty/file/path";
-  sdf::Error error(sdf::ErrorCode::FILE_READ, "Unable to read a file",
-                   emptyFilePath, 10);
+  const std::string emptyXmlPath = "/sdf/model";
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath);
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.Path().has_value());
-  EXPECT_EQ(error.Path().value(), emptyFilePath);
+  REQUIRE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.LineNumber().has_value());
+}
+
+/////////////////////////////////////////////////
+TEST(Error, ValueConstructionWithFile)
+{
+  const std::string emptyXmlPath = "/sdf/model";
+  const std::string emptyFilePath = "Empty/file/path";
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath,
+    emptyFilePath);
+  EXPECT_EQ(error, true);
+  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
+  EXPECT_EQ(error.Message(), "Unable to read a file");
+  EXPECT_TRUE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_TRUE(error.FilePath().has_value());
+  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
+  EXPECT_FALSE(error.LineNumber().has_value());
+
+  if (!error)
+    FAIL();
+}
+
+/////////////////////////////////////////////////
+TEST(Error, ValueConstructionWithLineNumber)
+{
+  const std::string emptyXmlPath = "/sdf/model";
+  const std::string emptyFilePath = "Empty/file/path";
+  const int lineNumber = 10;
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyXmlPath,
+    emptyFilePath,
+    lineNumber);
+  EXPECT_EQ(error, true);
+  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
+  EXPECT_EQ(error.Message(), "Unable to read a file");
+  EXPECT_TRUE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_TRUE(error.FilePath().has_value());
+  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   EXPECT_TRUE(error.LineNumber().has_value());
-  EXPECT_EQ(error.LineNumber().value(), 10);
+  EXPECT_EQ(error.LineNumber().value(), lineNumber);
 
   if (!error)
     FAIL();

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -27,7 +27,7 @@ TEST(Error, DefaultConstruction)
   EXPECT_EQ(error, false);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::NONE);
   EXPECT_TRUE(error.Message().empty());
-  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.Path().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (error)
@@ -41,7 +41,7 @@ TEST(Error, ValueConstructionWithoutFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_FALSE(error.FilePath().has_value());
+  EXPECT_FALSE(error.Path().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
 
   if (!error)
@@ -57,8 +57,8 @@ TEST(Error, ValueConstructionWithFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.FilePath().has_value());
-  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
+  EXPECT_TRUE(error.Path().has_value());
+  EXPECT_EQ(error.Path().value(), emptyFilePath);
   EXPECT_TRUE(error.LineNumber().has_value());
   EXPECT_EQ(error.LineNumber().value(), 10);
 

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -61,7 +61,7 @@ TEST(Error, ValueConstructionWithXmlPath)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  REQUIRE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
   EXPECT_FALSE(error.FilePath().has_value());
   EXPECT_FALSE(error.LineNumber().has_value());
@@ -80,9 +80,9 @@ TEST(Error, ValueConstructionWithFile)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
-  EXPECT_TRUE(error.FilePath().has_value());
+  ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   EXPECT_FALSE(error.LineNumber().has_value());
 
@@ -105,11 +105,11 @@ TEST(Error, ValueConstructionWithLineNumber)
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  EXPECT_TRUE(error.XmlPath().has_value());
+  ASSERT_TRUE(error.XmlPath().has_value());
   EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
-  EXPECT_TRUE(error.FilePath().has_value());
+  ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
-  EXPECT_TRUE(error.LineNumber().has_value());
+  ASSERT_TRUE(error.LineNumber().has_value());
   EXPECT_EQ(error.LineNumber().value(), lineNumber);
 
   if (!error)

--- a/src/Error_TEST.cc
+++ b/src/Error_TEST.cc
@@ -51,37 +51,17 @@ TEST(Error, ValueConstructionWithoutFile)
 }
 
 /////////////////////////////////////////////////
-TEST(Error, ValueConstructionWithXmlPath)
-{
-  const std::string emptyXmlPath = "/sdf/model";
-  sdf::Error error(
-    sdf::ErrorCode::FILE_READ,
-    "Unable to read a file",
-    emptyXmlPath);
-  EXPECT_EQ(error, true);
-  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
-  EXPECT_EQ(error.Message(), "Unable to read a file");
-  ASSERT_TRUE(error.XmlPath().has_value());
-  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
-  EXPECT_FALSE(error.FilePath().has_value());
-  EXPECT_FALSE(error.LineNumber().has_value());
-}
-
-/////////////////////////////////////////////////
 TEST(Error, ValueConstructionWithFile)
 {
-  const std::string emptyXmlPath = "/sdf/model";
   const std::string emptyFilePath = "Empty/file/path";
   sdf::Error error(
     sdf::ErrorCode::FILE_READ,
     "Unable to read a file",
-    emptyXmlPath,
     emptyFilePath);
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  ASSERT_TRUE(error.XmlPath().has_value());
-  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_FALSE(error.XmlPath().has_value());
   ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   EXPECT_FALSE(error.LineNumber().has_value());
@@ -93,20 +73,17 @@ TEST(Error, ValueConstructionWithFile)
 /////////////////////////////////////////////////
 TEST(Error, ValueConstructionWithLineNumber)
 {
-  const std::string emptyXmlPath = "/sdf/model";
   const std::string emptyFilePath = "Empty/file/path";
   const int lineNumber = 10;
   sdf::Error error(
     sdf::ErrorCode::FILE_READ,
     "Unable to read a file",
-    emptyXmlPath,
     emptyFilePath,
     lineNumber);
   EXPECT_EQ(error, true);
   EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(error.Message(), "Unable to read a file");
-  ASSERT_TRUE(error.XmlPath().has_value());
-  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+  EXPECT_FALSE(error.XmlPath().has_value());
   ASSERT_TRUE(error.FilePath().has_value());
   EXPECT_EQ(error.FilePath().value(), emptyFilePath);
   ASSERT_TRUE(error.LineNumber().has_value());
@@ -115,3 +92,32 @@ TEST(Error, ValueConstructionWithLineNumber)
   if (!error)
     FAIL();
 }
+
+/////////////////////////////////////////////////
+TEST(Error, ValueConstructionWithXmlPath)
+{
+  const std::string emptyFilePath = "Empty/file/path";
+  const int lineNumber = 10;
+  sdf::Error error(
+    sdf::ErrorCode::FILE_READ,
+    "Unable to read a file",
+    emptyFilePath,
+    lineNumber);
+  EXPECT_EQ(error, true);
+  EXPECT_EQ(error.Code(), sdf::ErrorCode::FILE_READ);
+  EXPECT_EQ(error.Message(), "Unable to read a file");
+  ASSERT_TRUE(error.FilePath().has_value());
+  EXPECT_EQ(error.FilePath().value(), emptyFilePath);
+  ASSERT_TRUE(error.LineNumber().has_value());
+  EXPECT_EQ(error.LineNumber().value(), lineNumber);
+
+  const std::string emptyXmlPath = "/sdf/model";
+  ASSERT_FALSE(error.XmlPath().has_value());
+  error.SetXmlPath(emptyXmlPath);
+  ASSERT_TRUE(error.XmlPath().has_value());
+  EXPECT_EQ(error.XmlPath().value(), emptyXmlPath);
+
+  if (!error)
+    FAIL();
+}
+

--- a/src/Types_TEST.cc
+++ b/src/Types_TEST.cc
@@ -110,10 +110,10 @@ TEST(Types, ErrorsOutputStream)
   std::string expected = "Error Code ";
   expected +=
       std::to_string(static_cast<std::size_t>(sdf::ErrorCode::FILE_READ));
-  expected += " Msg: Error reading file\nError Code ";
+  expected += ": Msg: Error reading file\nError Code ";
   expected +=
       std::to_string(static_cast<std::size_t>(sdf::ErrorCode::DUPLICATE_NAME));
-  expected += " Msg: Found duplicate name\n";
+  expected += ": Msg: Found duplicate name\n";
 
   std::stringstream output;
   output << errors;

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -106,24 +106,24 @@ void enforceConfigurablePolicyCondition(
       _errors.push_back(_error);
       break;
     case EnforcementPolicy::WARN:
-      if (!_error.FilePath().has_value())
+      if (!_error.Path().has_value())
         sdfwarn << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfwarn << "[" << _error.FilePath().value() << "]: "
+        sdfwarn << "[" << _error.Path().value() << "]: "
             << _error.Message();
       else
-        sdfwarn << "[" << _error.FilePath().value() << ":L"
+        sdfwarn << "[" << _error.Path().value() << ":L"
             << _error.LineNumber().value() << "]: "
             << _error.Message();
       break;
     case EnforcementPolicy::LOG:
-      if (!_error.FilePath().has_value())
+      if (!_error.Path().has_value())
         sdfdbg << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfdbg << "[" << _error.FilePath().value() << "]: "
+        sdfdbg << "[" << _error.Path().value() << "]: "
             << _error.Message();
       else
-        sdfdbg << "[" << _error.FilePath().value() << ":L"
+        sdfdbg << "[" << _error.Path().value() << ":L"
             << _error.LineNumber().value() << "]: "
             << _error.Message();
       break;

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -106,26 +106,42 @@ void enforceConfigurablePolicyCondition(
       _errors.push_back(_error);
       break;
     case EnforcementPolicy::WARN:
-      if (!_error.Path().has_value())
+      if (!_error.XmlPath().has_value())
         sdfwarn << _error.Message();
+      else if (!_error.FilePath().has_value())
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << "]: " << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfwarn << "[" << _error.Path().value() << "]: "
-            << _error.Message();
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << "]: " << _error.Message();
       else
-        sdfwarn << "[" << _error.Path().value() << ":L"
-            << _error.LineNumber().value() << "]: "
-            << _error.Message();
+        sdfwarn
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << ":L" << _error.LineNumber().value()
+            << "]: " << _error.Message();
       break;
     case EnforcementPolicy::LOG:
-      if (!_error.Path().has_value())
+      if (!_error.XmlPath().has_value())
         sdfdbg << _error.Message();
+      else if (!_error.FilePath().has_value())
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << "]: " << _error.Message();
       else if (!_error.LineNumber().has_value())
-        sdfdbg << "[" << _error.Path().value() << "]: "
-            << _error.Message();
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << "]: " << _error.Message();
       else
-        sdfdbg << "[" << _error.Path().value() << ":L"
-            << _error.LineNumber().value() << "]: "
-            << _error.Message();
+        sdfdbg
+            << "[" << _error.XmlPath().value()
+            << ":" << _error.FilePath().value()
+            << ":L" << _error.LineNumber().value()
+            << "]: " << _error.Message();
       break;
     default:
       throw std::runtime_error("Unhandled warning policy enum value");

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -107,41 +107,57 @@ void enforceConfigurablePolicyCondition(
       break;
     case EnforcementPolicy::WARN:
       if (!_error.XmlPath().has_value())
+      {
         sdfwarn << _error.Message();
+      }
       else if (!_error.FilePath().has_value())
+      {
         sdfwarn
             << "[" << _error.XmlPath().value()
             << "]: " << _error.Message();
+      }
       else if (!_error.LineNumber().has_value())
+      {
         sdfwarn
             << "[" << _error.XmlPath().value()
             << ":" << _error.FilePath().value()
             << "]: " << _error.Message();
+      }
       else
+      {
         sdfwarn
             << "[" << _error.XmlPath().value()
             << ":" << _error.FilePath().value()
             << ":L" << _error.LineNumber().value()
             << "]: " << _error.Message();
+      }
       break;
     case EnforcementPolicy::LOG:
       if (!_error.XmlPath().has_value())
+      {
         sdfdbg << _error.Message();
+      }
       else if (!_error.FilePath().has_value())
+      {
         sdfdbg
             << "[" << _error.XmlPath().value()
             << "]: " << _error.Message();
+      }
       else if (!_error.LineNumber().has_value())
+      {
         sdfdbg
             << "[" << _error.XmlPath().value()
             << ":" << _error.FilePath().value()
             << "]: " << _error.Message();
+      }
       else
+      {
         sdfdbg
             << "[" << _error.XmlPath().value()
             << ":" << _error.FilePath().value()
             << ":L" << _error.LineNumber().value()
             << "]: " << _error.Message();
+      }
       break;
     default:
       throw std::runtime_error("Unhandled warning policy enum value");

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -141,8 +141,8 @@ TEST(PolicyUtils, EnforcementPolicyErrors)
   EXPECT_EQ(errors[0], true);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(errors[0].Message(), "Unable to read a file");
-  EXPECT_TRUE(errors[0].FilePath().has_value());
-  EXPECT_EQ(errors[0].FilePath().value(), emptyFilePath);
+  EXPECT_TRUE(errors[0].Path().has_value());
+  EXPECT_EQ(errors[0].Path().value(), emptyFilePath);
   EXPECT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 10);
 }

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -127,9 +127,14 @@ TEST(DOMUtils, ReservedNames)
 TEST(PolicyUtils, EnforcementPolicyErrors)
 {
   sdf::Errors errors;
+  const std::string emptyXmlPath = "/sdf/model";
   const std::string emptyFilePath = "Empty/file/path";
-  sdf::Error error(sdf::ErrorCode::FILE_READ, "Unable to read a file",
-                   emptyFilePath, 10);
+  sdf::Error error(
+      sdf::ErrorCode::FILE_READ,
+      "Unable to read a file",
+      emptyXmlPath,
+      emptyFilePath,
+      10);
   ASSERT_EQ(error, true);
   ASSERT_TRUE(errors.empty());
 
@@ -141,8 +146,10 @@ TEST(PolicyUtils, EnforcementPolicyErrors)
   EXPECT_EQ(errors[0], true);
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::FILE_READ);
   EXPECT_EQ(errors[0].Message(), "Unable to read a file");
-  EXPECT_TRUE(errors[0].Path().has_value());
-  EXPECT_EQ(errors[0].Path().value(), emptyFilePath);
-  EXPECT_TRUE(errors[0].LineNumber().has_value());
+  ASSERT_TRUE(errors[0].XmlPath().has_value());
+  EXPECT_EQ(errors[0].XmlPath().value(), emptyXmlPath);
+  ASSERT_TRUE(errors[0].FilePath().has_value());
+  EXPECT_EQ(errors[0].FilePath().value(), emptyFilePath);
+  ASSERT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 10);
 }

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -127,14 +127,14 @@ TEST(DOMUtils, ReservedNames)
 TEST(PolicyUtils, EnforcementPolicyErrors)
 {
   sdf::Errors errors;
-  const std::string emptyXmlPath = "/sdf/model";
   const std::string emptyFilePath = "Empty/file/path";
   sdf::Error error(
       sdf::ErrorCode::FILE_READ,
       "Unable to read a file",
-      emptyXmlPath,
       emptyFilePath,
       10);
+  const std::string emptyXmlPath = "/sdf/model";
+  error.SetXmlPath(emptyXmlPath);
   ASSERT_EQ(error, true);
   ASSERT_TRUE(errors.empty());
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -694,7 +694,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
 
     // parse new sdf xml
     auto *elemXml = _xmlDoc->FirstChildElement(_sdf->Root()->GetName().c_str());
-    if (!readXml(elemXml, _sdf->Root(), _config, "", _source, _errors))
+    if (!readXml(elemXml, _sdf->Root(), _config, "/sdf", _source, _errors))
     {
       _errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Error reading element <" + _sdf->Root()->GetName() + ">"});
@@ -776,7 +776,7 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
     }
 
     // parse new sdf xml
-    if (!readXml(elemXml, _sdf, _config, "", _source, _errors))
+    if (!readXml(elemXml, _sdf, _config, "/sdf", _source, _errors))
     {
       _errors.push_back({ErrorCode::ELEMENT_INVALID,
           "Unable to parse sdf element["+ _sdf->GetName() + "]"});
@@ -1019,7 +1019,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
     // Construct the Xml path of the current attribute
     const std::string attributeXmlPath =
-        currentXmlPath + "[@" + attribute->Name() + "=\"" + attribute->Value() +
+        _xmlPath + "[@" + attribute->Name() + "=\"" + attribute->Value() +
         "\"]";
 
     // Find the matching attribute in SDF
@@ -1103,6 +1103,9 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
   {
     std::string filename;
 
+    // Keep count of the include indices
+    int includeElemIndex = -1;
+
     // Iterate over all the child elements
     tinyxml2::XMLElement *elemXml = nullptr;
     for (elemXml = _xml->FirstChildElement(); elemXml;
@@ -1113,7 +1116,11 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         std::string modelPath;
         std::string uri;
         tinyxml2::XMLElement *uriElement = elemXml->FirstChildElement("uri");
-        const std::string elemXmlPath = currentXmlPath + "/include/uri";
+
+        includeElemIndex++;
+        const std::string includeXmlPath =
+            _xmlPath + "/include[" + std::to_string(includeElemIndex) + "]";
+        const std::string uriXmlPath = includeXmlPath + "/uri";
 
         if (uriElement)
         {
@@ -1126,7 +1133,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             _errors.push_back({
                 ErrorCode::URI_LOOKUP,
                 "Unable to find uri[" + uri + "]",
-                elemXmlPath,
+                uriXmlPath,
                 sourcePath,
                 uriElement->GetLineNum()});
             continue;
@@ -1145,7 +1152,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                     "Unable to resolve uri[" + uri + "] to model path [" +
                     modelPath + "] since it does not contain a model.config " +
                     "file.",
-                    elemXmlPath,
+                    uriXmlPath,
                     sourcePath,
                     uriElement->GetLineNum()});
                 continue;
@@ -1165,7 +1172,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           _errors.push_back({
               ErrorCode::ATTRIBUTE_MISSING,
               "<include> element missing 'uri' attribute",
-              elemXmlPath,
+              includeXmlPath,
               sourcePath,
               elemXml->GetLineNum()});
           continue;
@@ -1195,7 +1202,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             _errors.push_back({
                 ErrorCode::FILE_READ,
                 "Unable to read file[" + filename + "]",
-                elemXmlPath,
+                uriXmlPath,
                 sourcePath,
                 uriElement->GetLineNum()});
             return false;
@@ -1226,6 +1233,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                     Error(
                         ErrorCode::ELEMENT_INCORRECT_TYPE,
                         ss.str(),
+                        "/sdf/" + std::string(elementType),
                         filename),
                     _errors);
               }
@@ -1238,6 +1246,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "Failed to find top level <model> / <actor> / <light> for "
                 "<include>\n",
+                uriXmlPath,
                 sourcePath,
                 uriElement->GetLineNum()});
             continue;
@@ -1257,6 +1266,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 _config.WarningsPolicy(),
                 Error(
                     ErrorCode::ELEMENT_INCORRECT_TYPE,
+                    "/sdf/" + topLevelElementType,
                     ss.str(),
                     filename),
                 _errors);
@@ -1307,12 +1317,15 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
               elemXml->FirstChildElement("placement_frame");
           if (isModel && placementFrameElem)
           {
+            const std::string placementFrameXmlPath =
+                includeXmlPath + "/placement_frame";
             if (nullptr == elemXml->FirstChildElement("pose"))
             {
               _errors.push_back({
                   ErrorCode::MODEL_PLACEMENT_FRAME_INVALID,
                   "<pose> is required when specifying the placement_frame "
                   "element",
+                  placementFrameXmlPath,
                   sourcePath,
                   elemXml->GetLineNum()});
               return false;
@@ -1327,6 +1340,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   "'" + placementFrameVal +
                   "' is reserved; it cannot be used as a value of "
                   "element [placement_frame]",
+                  placementFrameXmlPath,
                   sourcePath,
                   placementFrameElem->GetLineNum()});
             }
@@ -1336,21 +1350,30 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
           if (isModel || isActor)
           {
+            // Using indices for plugins as duplicated plugin names are
+            // allowed.
+            int pluginIndex = -1;
             for (auto *childElemXml = elemXml->FirstChildElement();
                  childElemXml;
                  childElemXml = childElemXml->NextSiblingElement())
             {
               if (std::string("plugin") == childElemXml->Value())
               {
+                pluginIndex++;
+                const std::string pluginXmlPath = includeXmlPath + "/plugin[" +
+                    std::to_string(pluginIndex) + "]";
+
                 sdf::ElementPtr pluginElem;
                 pluginElem = topLevelElem->AddElement("plugin");
 
                 if (!readXml(
-                    childElemXml, pluginElem, _config, sourcePath, _errors))
+                    childElemXml, pluginElem, _config, pluginXmlPath, 
+                    sourcePath, _errors))
                 {
                   _errors.push_back({
                       ErrorCode::ELEMENT_INVALID,
                       "Error reading plugin element",
+                      pluginXmlPath,
                       sourcePath,
                       childElemXml->GetLineNum()});
                   return false;
@@ -1384,9 +1407,15 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         ElementPtr elemDesc = _sdf->GetElementDescription(descCounter);
         if (elemDesc->GetName() == elemXml->Value())
         {
+          std::string elemXmlPath = _xmlPath + "/" + elemXml->Value();
+          const char *name = elemXml->Attribute("name");
+          if (name)
+            elemXmlPath += "[@name=\"" + std::string(name) + "\"]";
+
           ElementPtr element = elemDesc->Clone();
           element->SetParent(_sdf);
-          if (readXml(elemXml, element, _config, sourcePath, _errors))
+          if (readXml(elemXml, element, _config, elemXmlPath, sourcePath,
+              _errors))
           {
             _sdf->InsertElement(element);
           }
@@ -1396,6 +1425,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_INVALID,
                 std::string("Error reading element <") +
                 elemXml->Value() + ">",
+                elemXmlPath,
                 sourcePath,
                 elemXml->GetLineNum()});
             return false;
@@ -1407,6 +1437,11 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       if (descCounter == _sdf->GetElementDescriptionCount()
             && std::strchr(elemXml->Value(), ':') == nullptr)
       {
+        std::string elemXmlPath = _xmlPath + "/" + elemXml->Value();
+        const char *name = elemXml->Attribute("name");
+        if (name)
+          elemXmlPath += "[@name=\"" + std::string(name) + "\"]";
+
         std::stringstream ss;
         ss << "XML Element[" << elemXml->Value()
            << "], child of element[" << _xml->Value()
@@ -1418,6 +1453,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error(
                 ErrorCode::ELEMENT_INCORRECT_TYPE,
                 ss.str(),
+                elemXmlPath,
                 sourcePath,
                 elemXml->GetLineNum()),
             _errors);
@@ -1439,6 +1475,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       {
         if (!_sdf->HasElement(elemDesc->GetName()))
         {
+          const std::string elemXmlPath = _xmlPath + "/" +
+              elemDesc->GetName();
           if (_sdf->GetName() == "joint" &&
               _sdf->Get<std::string>("type") != "ball")
           {
@@ -1446,6 +1484,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "XML Missing required element[" + elemDesc->GetName() +
                 "], child of element[" + _sdf->GetName() + "]",
+                elemXmlPath,
                 sourcePath,
                 elemXml->GetLineNum()});
             return false;

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1160,7 +1160,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         std::string uri;
         tinyxml2::XMLElement *uriElement = elemXml->FirstChildElement("uri");
 
-        includeElemIndex++;
+        ++includeElemIndex;
         const std::string includeXmlPath =
             _sdf->XmlPath() + "/include[" + std::to_string(includeElemIndex) +
             "]";
@@ -1415,7 +1415,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             {
               if (std::string("plugin") == childElemXml->Value())
               {
-                pluginIndex++;
+                ++pluginIndex;
                 const std::string pluginXmlPath = includeXmlPath + "/plugin[" +
                     std::to_string(pluginIndex) + "]";
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1152,6 +1152,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             {
               // Get the model.config filename
               filename = getModelFilePath(modelPath);
+
               if (filename.empty())
               {
                 _errors.push_back({
@@ -1374,8 +1375,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 pluginElem = topLevelElem->AddElement("plugin");
                 pluginElem->SetXmlPath(pluginXmlPath);
 
-                if (!readXml(childElemXml, pluginElem, _config, _source,
-                    _errors))
+                if (!readXml(
+                    childElemXml, pluginElem, _config, _source, _errors))
                 {
                   _errors.push_back({
                       ErrorCode::ELEMENT_INVALID,

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -974,9 +974,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     Error err(ErrorCode::ELEMENT_DEPRECATED, ss.str());
     err.SetXmlPath(_sdf->XmlPath());
     enforceConfigurablePolicyCondition(
-        _config.DeprecatedElementsPolicy(),
-        err,
-        _errors);
+        _config.DeprecatedElementsPolicy(), err, _errors);
   }
 
   if (!_xml)
@@ -985,8 +983,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     {
       Error err(
           ErrorCode::ELEMENT_MISSING,
-          "SDF Element<" + _sdf->GetName() + "> is missing",
-          sourcePath);
+          "SDF Element<" + _sdf->GetName() + "> is missing", sourcePath);
       err.SetXmlPath(_sdf->XmlPath());
       _errors.push_back(err);
       return false;
@@ -1050,16 +1047,14 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     if (std::strchr(attribute->Name(), ':') != nullptr)
     {
       _sdf->AddAttribute(attribute->Name(), "string", "", 1, "");
-      _sdf->GetAttribute(attribute->Name())->SetFromString(
-          attribute->Value());
+      _sdf->GetAttribute(attribute->Name())->SetFromString(attribute->Value());
       attribute = attribute->Next();
       continue;
     }
 
     // Construct the Xml path of the current attribute
-    const std::string attributeXmlPath =
-        _sdf->XmlPath() + "[@" + attribute->Name() + "=\"" +
-        attribute->Value() + "\"]";
+    const std::string attributeXmlPath = _sdf->XmlPath() + "[@" +
+        attribute->Name() + "=\"" + attribute->Value() + "\"]";
 
     // Find the matching attribute in SDF
     for (i = 0; i < _sdf->GetAttributeCount(); ++i)
@@ -1077,8 +1072,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 "'" + std::string(attribute->Value()) +
                 "' is reserved; it cannot be used as a value of "
                 "attribute [" + p->GetKey() + "]",
-                sourcePath,
-                attribute->GetLineNum());
+                sourcePath, attribute->GetLineNum());
             err.SetXmlPath(attributeXmlPath);
             _errors.push_back(err);
           }
@@ -1089,8 +1083,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           Error err(
               ErrorCode::ATTRIBUTE_INVALID,
               "Unable to read attribute[" + p->GetKey() + "]",
-              sourcePath,
-              attribute->GetLineNum());
+              sourcePath, attribute->GetLineNum());
           err.SetXmlPath(attributeXmlPath);
           _errors.push_back(err);
           return false;
@@ -1107,14 +1100,10 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
               << "] not defined in SDF.\n";
       Error err(
           ErrorCode::ATTRIBUTE_INCORRECT_TYPE,
-          ss.str(),
-          sourcePath,
-          _xml->GetLineNum());
+          ss.str(), sourcePath, _xml->GetLineNum());
       err.SetXmlPath(attributeXmlPath);
       enforceConfigurablePolicyCondition(
-          _config.WarningsPolicy(),
-          err,
-          _errors);
+          _config.WarningsPolicy(), err, _errors);
     }
 
     attribute = attribute->Next();
@@ -1130,8 +1119,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           ErrorCode::ATTRIBUTE_MISSING,
           "Required attribute[" + p->GetKey() + "] in element[" + _xml->Value()
           + "] is not specified in SDF.",
-          sourcePath,
-          _xml->GetLineNum());
+          sourcePath, _xml->GetLineNum());
       err.SetXmlPath(_sdf->XmlPath());
       _errors.push_back(err);
       return false;
@@ -1160,10 +1148,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         std::string uri;
         tinyxml2::XMLElement *uriElement = elemXml->FirstChildElement("uri");
 
-        ++includeElemIndex;
-        const std::string includeXmlPath =
-            _sdf->XmlPath() + "/include[" + std::to_string(includeElemIndex) +
-            "]";
+        const std::string includeXmlPath = _sdf->XmlPath() + "/include[" +
+            std::to_string(++includeElemIndex) + "]";
         const std::string uriXmlPath = includeXmlPath + "/uri";
 
         if (uriElement)
@@ -1177,8 +1163,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error err(
                 ErrorCode::URI_LOOKUP,
                 "Unable to find uri[" + uri + "]",
-                sourcePath,
-                uriElement->GetLineNum());
+                sourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             continue;
@@ -1197,8 +1182,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                     "Unable to resolve uri[" + uri + "] to model path [" +
                     modelPath + "] since it does not contain a model.config " +
                     "file.",
-                    sourcePath,
-                    uriElement->GetLineNum());
+                    sourcePath, uriElement->GetLineNum());
                 err.SetXmlPath(uriXmlPath);
                 _errors.push_back(err);
                 continue;
@@ -1218,8 +1202,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           Error err(
               ErrorCode::ATTRIBUTE_MISSING,
               "<include> element missing 'uri' attribute",
-              sourcePath,
-              elemXml->GetLineNum());
+              sourcePath, elemXml->GetLineNum());
           err.SetXmlPath(includeXmlPath);
           _errors.push_back(err);
           continue;
@@ -1249,8 +1232,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error err(
                 ErrorCode::FILE_READ,
                 "Unable to read file[" + filename + "]",
-                sourcePath,
-                uriElement->GetLineNum());
+                sourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             return false;
@@ -1277,14 +1259,10 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   << "> in include file. This is unsupported and in future "
                   << "versions of libsdformat will become an error";
                 Error err(
-                    ErrorCode::ELEMENT_INCORRECT_TYPE,
-                    ss.str(),
-                    filename);
+                    ErrorCode::ELEMENT_INCORRECT_TYPE, ss.str(), filename);
                 err.SetXmlPath("/sdf/" + std::string(elementType));
                 enforceConfigurablePolicyCondition(
-                    _config.WarningsPolicy(),
-                    err,
-                    _errors);
+                    _config.WarningsPolicy(), err, _errors);
               }
             }
           }
@@ -1295,8 +1273,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "Failed to find top level <model> / <actor> / <light> for "
                 "<include>\n",
-                sourcePath,
-                uriElement->GetLineNum());
+                sourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             continue;
@@ -1313,14 +1290,10 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
               << " for <include>. This is unsupported and in future "
               << "versions of libsdformat will become an error";
             Error err(
-                ErrorCode::ELEMENT_INCORRECT_TYPE,
-                ss.str(),
-                filename);
+                ErrorCode::ELEMENT_INCORRECT_TYPE, ss.str(), filename);
             err.SetXmlPath("/sdf/" + topLevelElementType);
             enforceConfigurablePolicyCondition(
-                _config.WarningsPolicy(),
-                err,
-                _errors);
+                _config.WarningsPolicy(), err, _errors);
           }
 
           bool isModel = topLevelElementType == "model";
@@ -1379,8 +1352,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   ErrorCode::MODEL_PLACEMENT_FRAME_INVALID,
                   "<pose> is required when specifying the placement_frame "
                   "element",
-                  sourcePath,
-                  elemXml->GetLineNum());
+                  sourcePath, elemXml->GetLineNum());
               err.SetXmlPath(placementFrameXmlPath);
               _errors.push_back(err);
               return false;
@@ -1395,8 +1367,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   "'" + placementFrameVal +
                   "' is reserved; it cannot be used as a value of "
                   "element [placement_frame]",
-                  sourcePath,
-                  placementFrameElem->GetLineNum());
+                  sourcePath, placementFrameElem->GetLineNum());
               err.SetXmlPath(placementFrameXmlPath);
               _errors.push_back(err);
             }
@@ -1415,9 +1386,8 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             {
               if (std::string("plugin") == childElemXml->Value())
               {
-                ++pluginIndex;
                 const std::string pluginXmlPath = includeXmlPath + "/plugin[" +
-                    std::to_string(pluginIndex) + "]";
+                    std::to_string(++pluginIndex) + "]";
 
                 sdf::ElementPtr pluginElem;
                 pluginElem = topLevelElem->AddElement("plugin");
@@ -1431,8 +1401,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   Error err(
                       ErrorCode::ELEMENT_INVALID,
                       "Error reading plugin element",
-                      sourcePath,
-                      childElemXml->GetLineNum());
+                      sourcePath, childElemXml->GetLineNum());
                   err.SetXmlPath(pluginXmlPath);
                   _errors.push_back(err);
                   return false;
@@ -1486,8 +1455,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_INVALID,
                 std::string("Error reading element <") +
                 elemXml->Value() + ">",
-                sourcePath,
-                elemXml->GetLineNum());
+                sourcePath, elemXml->GetLineNum());
             err.SetXmlPath(elemXmlPath);
             _errors.push_back(err);
             return false;
@@ -1512,14 +1480,10 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
         Error err(
             ErrorCode::ELEMENT_INCORRECT_TYPE,
-            ss.str(),
-            sourcePath,
-            elemXml->GetLineNum());
+            ss.str(), sourcePath, elemXml->GetLineNum());
         err.SetXmlPath(elemXmlPath);
         enforceConfigurablePolicyCondition(
-            _config.UnrecognizedElementsPolicy(),
-            err,
-            _errors);
+            _config.UnrecognizedElementsPolicy(), err, _errors);
 
         continue;
       }
@@ -1547,8 +1511,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "XML Missing required element[" + elemDesc->GetName() +
                 "], child of element[" + _sdf->GetName() + "]",
-                sourcePath,
-                elemXml->GetLineNum());
+                sourcePath, elemXml->GetLineNum());
             err.SetXmlPath(elemXmlPath);
             _errors.push_back(err);
             return false;

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -945,7 +945,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
   std::string sourcePath = _source;
   if (_source == kSdfStringSource || _source == kUrdfStringSource)
     sourcePath = "<" + _source + ">";
-  
+
   // Check if the element pointer is deprecated.
   if (_sdf->GetRequired() == "-1")
   {

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -304,6 +304,8 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [bad 0 0 0 0 0 ] for key[pose]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_pose.sdf:L5");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/pose:");
   }
   {
     // clear the contents of the buffer
@@ -316,6 +318,9 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [bad ] for key[linear]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_double.sdf:L7");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"robot1\"]/"
+                 "link[@name=\"link\"]/velocity_decay/linear:");
   }
   {
     // clear the contents of the buffer
@@ -328,6 +333,8 @@ TEST(Parser, SyntaxErrorInValues)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to set value [0 1 bad ] for key[gravity]");
     EXPECT_PRED2(contains, buffer.str(), "bad_syntax_vector.sdf:L4");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/gravity:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests
@@ -364,6 +371,8 @@ TEST(Parser, MissingRequiredAttributesErrors)
                  "Required attribute[name] in element[link] is not specified "
                  "in SDF.");
     EXPECT_PRED2(contains, buffer.str(), "box_bad_test.world:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/model[@name=\"box\"]/link:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests
@@ -399,6 +408,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "<include> element missing 'uri' attribute");
     EXPECT_PRED2(contains, buffer.str(), "includes_missing_uri.sdf:L5");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]:");
   }
   {
     // clear the contents of the buffer
@@ -417,6 +428,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "Unable to find uri[missing_model]");
     EXPECT_PRED2(contains, buffer.str(), "includes_missing_model.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
     // clear the contents of the buffer
@@ -441,6 +454,8 @@ TEST(Parser, IncludesErrors)
     EXPECT_PRED2(contains, buffer.str(),
                  "since it does not contain a model.config");
     EXPECT_PRED2(contains, buffer.str(), "includes_model_without_sdf.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
   {
     // clear the contents of the buffer
@@ -465,6 +480,8 @@ TEST(Parser, IncludesErrors)
                  "Failed to find top level <model> / <actor> / <light> for "
                  "<include>\n");
     EXPECT_PRED2(contains, buffer.str(), "includes_without_top_level.sdf:L6");
+    EXPECT_PRED2(contains, buffer.str(),
+                 "/sdf/world[@name=\"default\"]/include[0]/uri:");
   }
 
   // Revert cerr rdbug so as to not interfere with other tests

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -83,12 +83,14 @@ namespace sdf
   /// \param[in] _xml Pointer to the TinyXML element
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[in] _config Custom parser configuration
+  /// \param[in] _xmlPath XPath-like trace.
   /// \param[in] _source Source of the XML document, empty if it came from a
   ///            string.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.
   static bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
-      const ParserConfig &_config, const std::string &_source, Errors &_errors);
+      const ParserConfig &_config, const std::string &_xmlPath,
+      const std::string &_source, Errors &_errors);
 
   /// \brief Copy child XML elements into the _sdf element.
   /// \param[in] _sdf Parent Element.

--- a/src/parser_private.hh
+++ b/src/parser_private.hh
@@ -83,14 +83,12 @@ namespace sdf
   /// \param[in] _xml Pointer to the TinyXML element
   /// \param[in,out] _sdf SDF pointer to parse data into.
   /// \param[in] _config Custom parser configuration
-  /// \param[in] _xmlPath XPath-like trace.
   /// \param[in] _source Source of the XML document, empty if it came from a
   ///            string.
   /// \param[out] _errors Captures errors found during parsing.
   /// \return True on success, false on error.
   static bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
-      const ParserConfig &_config, const std::string &_xmlPath,
-      const std::string &_source, Errors &_errors);
+      const ParserConfig &_config, const std::string &_source, Errors &_errors);
 
   /// \brief Copy child XML elements into the _sdf element.
   /// \param[in] _sdf Parent Element.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
   converter.cc
   deprecated_specs.cc
   disable_fixed_joint_reduction.cc
+  element_tracing.cc
   fixed_joint_reduction.cc
   force_torque_sensor.cc
   frame.cc

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -17,7 +17,6 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <gtest/gtest.h>
 
 #include "sdf/SDFImpl.hh"

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -37,17 +37,6 @@ std::string findFileCb(const std::string &_input)
 }
 
 //////////////////////////////////////////////////
-void checkElementPtr(const sdf::ElementPtr &_elem,
-    const std::string &_filePath, int _lineNumber, const std::string &_xmlPath)
-{
-  ASSERT_NE(nullptr, _elem);
-  EXPECT_EQ(_filePath, _elem->FilePath());
-  ASSERT_TRUE(_elem->LineNumber().has_value());
-  EXPECT_EQ(_lineNumber, _elem->LineNumber().value());
-  EXPECT_EQ(_xmlPath, _elem->XmlPath());
-}
-
-//////////////////////////////////////////////////
 TEST(ElementTracing, NestedModels)
 {
   const std::string testFile =
@@ -64,7 +53,11 @@ TEST(ElementTracing, NestedModels)
   const std::string xmlPath = "/sdf/model[@name=\"top_level_model\"]";
 
   sdf::ElementPtr modelElem = model->Element();
-  checkElementPtr(modelElem, testFile, 2, xmlPath);
+  ASSERT_NE(nullptr, modelElem);
+  EXPECT_EQ(testFile, modelElem->FilePath());
+  ASSERT_TRUE(modelElem->LineNumber().has_value());
+  EXPECT_EQ(2, modelElem->LineNumber().value());
+  EXPECT_EQ(xmlPath, modelElem->XmlPath());
   EXPECT_EQ(2, static_cast<int>(model->LinkCount()));
   EXPECT_EQ(1, static_cast<int>(model->JointCount()));
   EXPECT_EQ(1, static_cast<int>(model->ModelCount()));
@@ -74,14 +67,22 @@ TEST(ElementTracing, NestedModels)
   const sdf::Link *parentLink = model->LinkByName("parent");
   ASSERT_NE(nullptr, parentLink);
   sdf::ElementPtr parentLinkElem = parentLink->Element();
-  checkElementPtr(parentLinkElem, testFile, 3, parentLinkXmlPath);
+  ASSERT_NE(nullptr, parentLinkElem);
+  EXPECT_EQ(testFile, parentLinkElem->FilePath());
+  ASSERT_TRUE(parentLinkElem->LineNumber().has_value());
+  EXPECT_EQ(3, parentLinkElem->LineNumber().value());
+  EXPECT_EQ(parentLinkXmlPath, parentLinkElem->XmlPath());
 
   const std::string childLinkXmlPath = xmlPath + "/link[@name=\"child\"]";
 
   const sdf::Link *childLink = model->LinkByName("child");
   ASSERT_NE(nullptr, childLink);
   sdf::ElementPtr childLinkElem = childLink->Element();
-  checkElementPtr(childLinkElem, testFile, 4, childLinkXmlPath);
+  ASSERT_NE(nullptr, childLinkElem);
+  EXPECT_EQ(testFile, childLinkElem->FilePath());
+  ASSERT_TRUE(childLinkElem->LineNumber().has_value());
+  EXPECT_EQ(4, childLinkElem->LineNumber().value());
+  EXPECT_EQ(childLinkXmlPath, childLinkElem->XmlPath());
 
   const std::string jointXmlPath =
     xmlPath + "/joint[@name=\"top_level_joint\"]";
@@ -89,7 +90,11 @@ TEST(ElementTracing, NestedModels)
   const sdf::Joint *joint = model->JointByIndex(0);
   ASSERT_NE(nullptr, joint);
   sdf::ElementPtr jointElem = joint->Element();
-  checkElementPtr(jointElem, testFile, 11, jointXmlPath);
+  ASSERT_NE(nullptr, jointElem);
+  EXPECT_EQ(testFile, jointElem->FilePath());
+  ASSERT_TRUE(jointElem->LineNumber().has_value());
+  EXPECT_EQ(11, jointElem->LineNumber().value());
+  EXPECT_EQ(jointXmlPath, jointElem->XmlPath());
 
   const std::string nestedModelXmlPath =
     xmlPath + "/model[@name=\"nested_model\"]";
@@ -97,7 +102,11 @@ TEST(ElementTracing, NestedModels)
   const sdf::Model *nestedModel = model->ModelByName("nested_model");
   ASSERT_NE(nullptr, nestedModel);
   sdf::ElementPtr nestedModelElem = nestedModel->Element();
-  checkElementPtr(nestedModelElem, testFile, 5, nestedModelXmlPath);
+  ASSERT_NE(nullptr, nestedModelElem);
+  EXPECT_EQ(testFile, nestedModelElem->FilePath());
+  ASSERT_TRUE(nestedModelElem->LineNumber().has_value());
+  EXPECT_EQ(5, nestedModelElem->LineNumber().value());
+  EXPECT_EQ(nestedModelXmlPath, nestedModelElem->XmlPath());
 
   const std::string nestedLinkXmlPath =
     nestedModelXmlPath + "/link[@name=\"nested_link01\"]";
@@ -105,7 +114,11 @@ TEST(ElementTracing, NestedModels)
   const sdf::Link *nestedLink = nestedModel->LinkByName("nested_link01");
   ASSERT_NE(nullptr, nestedLink);
   sdf::ElementPtr nestedLinkElem = nestedLink->Element();
-  checkElementPtr(nestedLinkElem, testFile, 6, nestedLinkXmlPath);
+  ASSERT_NE(nullptr, nestedLinkElem);
+  EXPECT_EQ(testFile, nestedLinkElem->FilePath());
+  ASSERT_TRUE(nestedLinkElem->LineNumber().has_value());
+  EXPECT_EQ(6, nestedLinkElem->LineNumber().value());
+  EXPECT_EQ(nestedLinkXmlPath, nestedLinkElem->XmlPath());
 
   const std::string nestedNestedModelXmlPath =
     nestedModelXmlPath + "/model[@name=\"nested_nested_model\"]";
@@ -114,8 +127,11 @@ TEST(ElementTracing, NestedModels)
     nestedModel->ModelByName("nested_nested_model");
   ASSERT_NE(nullptr, nestedNestedModel);
   sdf::ElementPtr nestedNestedModelElem = nestedNestedModel->Element();
-  checkElementPtr(nestedNestedModelElem, testFile, 7,
-      nestedNestedModelXmlPath);
+  ASSERT_NE(nullptr, nestedNestedModelElem);
+  EXPECT_EQ(testFile, nestedNestedModelElem->FilePath());
+  ASSERT_TRUE(nestedNestedModelElem->LineNumber().has_value());
+  EXPECT_EQ(7, nestedNestedModelElem->LineNumber().value());
+  EXPECT_EQ(nestedNestedModelXmlPath, nestedNestedModelElem->XmlPath());
 
   const std::string nestedNestedLinkXmlPath =
     nestedNestedModelXmlPath + "/link[@name=\"nested_nested_link01\"]";
@@ -124,7 +140,11 @@ TEST(ElementTracing, NestedModels)
     nestedNestedModel->LinkByName("nested_nested_link01");
   ASSERT_NE(nullptr, nestedNestedLink);
   sdf::ElementPtr nestedNestedLinkElem = nestedNestedLink->Element();
-  checkElementPtr(nestedNestedLinkElem, testFile, 8, nestedNestedLinkXmlPath);
+  ASSERT_NE(nullptr, nestedNestedLinkElem);
+  EXPECT_EQ(testFile, nestedNestedLinkElem->FilePath());
+  ASSERT_TRUE(nestedNestedLinkElem->LineNumber().has_value());
+  EXPECT_EQ(8, nestedNestedLinkElem->LineNumber().value());
+  EXPECT_EQ(nestedNestedLinkXmlPath, nestedNestedLinkElem->XmlPath());
 }
 
 //////////////////////////////////////////////////
@@ -140,83 +160,118 @@ TEST(ElementTracing, includes)
   const std::string xmlPath = "/sdf";
 
   sdf::ElementPtr rootElem = root.Element();
-  checkElementPtr(rootElem, worldFile, 2, xmlPath);
+  ASSERT_NE(nullptr, rootElem);
+  EXPECT_EQ(worldFile, rootElem->FilePath());
+  ASSERT_TRUE(rootElem->LineNumber().has_value());
+  EXPECT_EQ(2, rootElem->LineNumber().value());
+  EXPECT_EQ(xmlPath, rootElem->XmlPath());
 
   const std::string worldXmlPath = xmlPath + "/world[@name=\"default\"]";
   const sdf::World *world = root.WorldByIndex(0);
   ASSERT_NE(nullptr, world);
   sdf::ElementPtr worldElem = world->Element();
-  checkElementPtr(worldElem, worldFile, 3, worldXmlPath);
+  ASSERT_NE(nullptr, worldElem);
+  EXPECT_EQ(worldFile, worldElem->FilePath());
+  ASSERT_TRUE(worldElem->LineNumber().has_value());
+  EXPECT_EQ(3, worldElem->LineNumber().value());
+  EXPECT_EQ(worldXmlPath, worldElem->XmlPath());
 
   // Actors
-  const std::string actorFilePath =
-      sdf::testing::TestFile("integration", "model", "test_actor") +
-      "model.sdf";
+  const std::string actorFilePath = sdf::testing::TestFile(
+      "integration", "model", "test_actor", "model.sdf");
   const std::string actorXmlPath = "/sdf/actor[@name=\"actor\"]";
 
   const sdf::Actor *actor = world->ActorByIndex(0);
   ASSERT_NE(nullptr, actor);
   sdf::ElementPtr actorElem = actor->Element();
-  checkElementPtr(actorElem, actorFilePath, 4, actorXmlPath);
+  ASSERT_NE(nullptr, actorElem);
+  EXPECT_EQ(actorFilePath, actorElem->FilePath());
+  ASSERT_TRUE(actorElem->LineNumber().has_value());
+  EXPECT_EQ(4, actorElem->LineNumber().value());
+  EXPECT_EQ(actorXmlPath, actorElem->XmlPath());
 
   const std::string overrideActorXmlPath =
       "/sdf/actor[@name=\"override_actor_name\"]";
   const sdf::Actor *overrideActor = world->ActorByIndex(1);
   ASSERT_NE(nullptr, overrideActor);
   sdf::ElementPtr overrideActorElem = overrideActor->Element();
-  checkElementPtr(overrideActorElem, actorFilePath, 4, overrideActorXmlPath);
+  ASSERT_NE(nullptr, overrideActorElem);
+  EXPECT_EQ(actorFilePath, overrideActorElem->FilePath());
+  ASSERT_TRUE(overrideActorElem->LineNumber().has_value());
+  EXPECT_EQ(4, overrideActorElem->LineNumber().value());
+  EXPECT_EQ(overrideActorXmlPath, overrideActorElem->XmlPath());
 
   const std::string overrideActorPluginXmlPath =
       worldXmlPath + "/include[6]/plugin[0]";
 
   sdf::ElementPtr overrideActorPluginElem =
       overrideActorElem->GetElement("plugin");
-  checkElementPtr(
-      overrideActorPluginElem, worldFile, 40, overrideActorPluginXmlPath);
+  ASSERT_NE(nullptr, overrideActorPluginElem);
+  EXPECT_EQ(worldFile, overrideActorPluginElem->FilePath());
+  ASSERT_TRUE(overrideActorPluginElem->LineNumber().has_value());
+  EXPECT_EQ(40, overrideActorPluginElem->LineNumber().value());
+  EXPECT_EQ(overrideActorPluginXmlPath, overrideActorPluginElem->XmlPath());
 
   // Lights
-  const std::string lightFilePath =
-      sdf::testing::TestFile("integration", "model", "test_light") +
-      "model.sdf";
+  const std::string lightFilePath = sdf::testing::TestFile(
+      "integration", "model", "test_light", "model.sdf");
   const std::string lightXmlPath = "/sdf/light[@name=\"point_light\"]";
 
   const sdf::Light *light = world->LightByIndex(0);
   ASSERT_NE(nullptr, light);
   sdf::ElementPtr lightElem = light->Element();
-  checkElementPtr(lightElem, lightFilePath, 3, lightXmlPath);
+  ASSERT_NE(nullptr, lightElem);
+  EXPECT_EQ(lightFilePath, lightElem->FilePath());
+  ASSERT_TRUE(lightElem->LineNumber().has_value());
+  EXPECT_EQ(3, lightElem->LineNumber().value());
+  EXPECT_EQ(lightXmlPath, lightElem->XmlPath());
 
   const std::string overrideLightXmlPath =
       "/sdf/light[@name=\"override_light_name\"]";
   const sdf::Light *overrideLight = world->LightByIndex(1);
   ASSERT_NE(nullptr, overrideLight);
   sdf::ElementPtr overrideLightElem = overrideLight->Element();
-  checkElementPtr(overrideLightElem, lightFilePath, 3, overrideLightXmlPath);
+  ASSERT_NE(nullptr, overrideLightElem);
+  EXPECT_EQ(lightFilePath, overrideLightElem->FilePath());
+  ASSERT_TRUE(overrideLightElem->LineNumber().has_value());
+  EXPECT_EQ(3, overrideLightElem->LineNumber().value());
+  EXPECT_EQ(overrideLightXmlPath, overrideLightElem->XmlPath());
 
   // Models
-  const std::string modelFilePath =
-      sdf::testing::TestFile("integration", "model", "test_model") +
-      "model.sdf";
+  const std::string modelFilePath = sdf::testing::TestFile(
+      "integration", "model", "test_model", "model.sdf");
   const std::string modelXmlPath = "/sdf/model[@name=\"test_model\"]";
 
   const sdf::Model *model = world->ModelByIndex(0);
   ASSERT_NE(nullptr, model);
   sdf::ElementPtr modelElem = model->Element();
-  checkElementPtr(modelElem, modelFilePath, 4, modelXmlPath);
+  ASSERT_NE(nullptr, modelElem);
+  EXPECT_EQ(modelFilePath, modelElem->FilePath());
+  ASSERT_TRUE(modelElem->LineNumber().has_value());
+  EXPECT_EQ(4, modelElem->LineNumber().value());
+  EXPECT_EQ(modelXmlPath, modelElem->XmlPath());
 
   const std::string overrideModelXmlPath =
       "/sdf/model[@name=\"override_model_name\"]";
   const sdf::Model *overrideModel = world->ModelByIndex(1);
   ASSERT_NE(nullptr, overrideModel);
   sdf::ElementPtr overrideModelElem = overrideModel->Element();
-  checkElementPtr(overrideModelElem, modelFilePath, 4, overrideModelXmlPath);
+  ASSERT_NE(nullptr, overrideModelElem);
+  EXPECT_EQ(modelFilePath, overrideModelElem->FilePath());
+  ASSERT_TRUE(overrideModelElem->LineNumber().has_value());
+  EXPECT_EQ(4, overrideModelElem->LineNumber().value());
+  EXPECT_EQ(overrideModelXmlPath, overrideModelElem->XmlPath());
 
   const std::string overrideModelPluginXmlPath =
       worldXmlPath + "/include[1]/plugin[0]";
 
   sdf::ElementPtr overrideModelPluginElem =
       overrideModelElem->GetElement("plugin");
-  checkElementPtr(
-      overrideModelPluginElem, worldFile, 14, overrideModelPluginXmlPath);
+  ASSERT_NE(nullptr, overrideModelPluginElem);
+  EXPECT_EQ(worldFile, overrideModelPluginElem->FilePath());
+  ASSERT_TRUE(overrideModelPluginElem->LineNumber().has_value());
+  EXPECT_EQ(14, overrideModelPluginElem->LineNumber().value());
+  EXPECT_EQ(overrideModelPluginXmlPath, overrideModelPluginElem->XmlPath());
 
   const std::string overrideModelWithFileXmlPath =
       "/sdf/model[@name=\"test_model_with_file\"]";
@@ -224,8 +279,11 @@ TEST(ElementTracing, includes)
   const sdf::Model *overrideModelWithFile = world->ModelByIndex(2);
   ASSERT_NE(nullptr, overrideModelWithFile);
   sdf::ElementPtr overrideModelWithFileElem = overrideModelWithFile->Element();
-  checkElementPtr(
-      overrideModelWithFileElem, modelFilePath, 4,
-      overrideModelWithFileXmlPath);
+  ASSERT_NE(nullptr, overrideModelWithFileElem);
+  EXPECT_EQ(modelFilePath, overrideModelWithFileElem->FilePath());
+  ASSERT_TRUE(overrideModelWithFileElem->LineNumber().has_value());
+  EXPECT_EQ(4, overrideModelWithFileElem->LineNumber().value());
+  EXPECT_EQ(overrideModelWithFileXmlPath,
+      overrideModelWithFileElem->XmlPath());
 }
 

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -37,13 +37,13 @@ std::string findFileCb(const std::string &_input)
 {
   const std::string delimiter = "/";
   std::size_t delimiter_pos = 0;
-  
+
   if ((delimiter_pos = _input.find(delimiter)) != std::string::npos)
   {
     return sdf::testing::TestFile("integration", "model",
         _input.substr(0, delimiter_pos),
         _input.substr(delimiter_pos + 1, _input.size()));
-  }  
+  }
   return sdf::testing::TestFile("integration", "model", _input);
 }
 

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -151,7 +151,7 @@ TEST(ElementTracing, includes)
   // Actors
   const std::string actorFilePath =
       sdf::testing::TestFile("integration", "model", "test_actor") +
-      "/model.sdf";
+      "model.sdf";
   const std::string actorXmlPath = "/sdf/actor[@name=\"actor\"]";
 
   const sdf::Actor *actor = world->ActorByIndex(0);
@@ -177,7 +177,7 @@ TEST(ElementTracing, includes)
   // Lights
   const std::string lightFilePath =
       sdf::testing::TestFile("integration", "model", "test_light") +
-      "/model.sdf";
+      "model.sdf";
   const std::string lightXmlPath = "/sdf/light[@name=\"point_light\"]";
 
   const sdf::Light *light = world->LightByIndex(0);
@@ -195,7 +195,7 @@ TEST(ElementTracing, includes)
   // Models
   const std::string modelFilePath =
       sdf::testing::TestFile("integration", "model", "test_model") +
-      "/model.sdf";
+      "model.sdf";
   const std::string modelXmlPath = "/sdf/model[@name=\"test_model\"]";
 
   const sdf::Model *model = world->ModelByIndex(0);

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Open Source Robotics Foundation
+ * Copyright 2021 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,19 +21,13 @@
 
 #include "sdf/SDFImpl.hh"
 #include "sdf/parser.hh"
-#include "sdf/Frame.hh"
 #include "sdf/Model.hh"
 #include "sdf/Joint.hh"
 #include "sdf/Link.hh"
 #include "sdf/Root.hh"
 #include "sdf/World.hh"
 #include "sdf/Actor.hh"
-#include "sdf/Collision.hh"
-#include "sdf/Filesystem.hh"
-#include "sdf/Geometry.hh"
 #include "sdf/Light.hh"
-#include "sdf/Mesh.hh"
-#include "sdf/Visual.hh"
 #include "test_config.h"
 
 //////////////////////////////////////////////////

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -68,7 +68,7 @@ TEST(ElementTracing, NestedModels)
   ASSERT_NE(nullptr, model);
 
   const std::string xmlPath = "/sdf/model[@name=\"top_level_model\"]";
-  
+
   sdf::ElementPtr modelElem = model->Element();
   checkElementPtr(modelElem, testFile, 2, xmlPath);
   EXPECT_EQ(2, static_cast<int>(model->LinkCount()));
@@ -91,17 +91,17 @@ TEST(ElementTracing, NestedModels)
 
   const std::string jointXmlPath =
     xmlPath + "/joint[@name=\"top_level_joint\"]";
-  
+
   const sdf::Joint *joint = model->JointByIndex(0);
   ASSERT_NE(nullptr, joint);
   sdf::ElementPtr jointElem = joint->Element();
   checkElementPtr(jointElem, testFile, 11, jointXmlPath);
-  
+
   const std::string nestedModelXmlPath =
     xmlPath + "/model[@name=\"nested_model\"]";
- 
+
   const sdf::Model *nestedModel = model->ModelByName("nested_model");
-  ASSERT_NE(nullptr, nestedModel); 
+  ASSERT_NE(nullptr, nestedModel);
   sdf::ElementPtr nestedModelElem = nestedModel->Element();
   checkElementPtr(nestedModelElem, testFile, 5, nestedModelXmlPath);
 
@@ -115,7 +115,7 @@ TEST(ElementTracing, NestedModels)
 
   const std::string nestedNestedModelXmlPath =
     nestedModelXmlPath + "/model[@name=\"nested_nested_model\"]";
- 
+
   const sdf::Model *nestedNestedModel =
     nestedModel->ModelByName("nested_nested_model");
   ASSERT_NE(nullptr, nestedNestedModel);
@@ -125,7 +125,7 @@ TEST(ElementTracing, NestedModels)
 
   const std::string nestedNestedLinkXmlPath =
     nestedNestedModelXmlPath + "/link[@name=\"nested_nested_link01\"]";
-  
+
   const sdf::Link *nestedNestedLink =
     nestedNestedModel->LinkByName("nested_nested_link01");
   ASSERT_NE(nullptr, nestedNestedLink);
@@ -174,7 +174,7 @@ TEST(ElementTracing, includes)
 
   const std::string overrideActorPluginXmlPath =
       worldXmlPath + "/include[6]/plugin[0]";
-  
+
   sdf::ElementPtr overrideActorPluginElem =
       overrideActorElem->GetElement("plugin");
   checkElementPtr(
@@ -231,7 +231,7 @@ TEST(ElementTracing, includes)
   ASSERT_NE(nullptr, overrideModelWithFile);
   sdf::ElementPtr overrideModelWithFileElem = overrideModelWithFile->Element();
   checkElementPtr(
-      overrideModelWithFileElem, modelFilePath, 4, 
+      overrideModelWithFileElem, modelFilePath, 4,
       overrideModelWithFileXmlPath);
 }
 

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "sdf/SDFImpl.hh"
+#include "sdf/parser.hh"
+#include "sdf/Frame.hh"
+#include "sdf/Model.hh"
+#include "sdf/Joint.hh"
+#include "sdf/Link.hh"
+#include "sdf/Root.hh"
+#include "sdf/World.hh"
+#include "sdf/Actor.hh"
+#include "sdf/Collision.hh"
+#include "sdf/Filesystem.hh"
+#include "sdf/Geometry.hh"
+#include "sdf/Light.hh"
+#include "sdf/Mesh.hh"
+#include "sdf/Visual.hh"
+#include "test_config.h"
+
+//////////////////////////////////////////////////
+std::string findFileCb(const std::string &_input)
+{
+  return sdf::testing::TestFile("integration", "model", _input);
+}
+
+//////////////////////////////////////////////////
+void checkElementPtr(const sdf::ElementPtr &_elem,
+    const std::string &_filePath, int _lineNumber, const std::string &_xmlPath)
+{
+  ASSERT_NE(nullptr, _elem);
+  EXPECT_EQ(_filePath, _elem->FilePath());
+  ASSERT_TRUE(_elem->LineNumber().has_value());
+  EXPECT_EQ(_lineNumber, _elem->LineNumber().value());
+  EXPECT_EQ(_xmlPath, _elem->XmlPath());
+}
+
+//////////////////////////////////////////////////
+TEST(ElementTracing, NestedModels)
+{
+  const std::string testFile =
+    sdf::testing::TestFile("sdf", "nested_model.sdf");
+
+  sdf::Root root;
+  auto errors = root.Load(testFile);
+  EXPECT_TRUE(errors.empty()) << errors;
+
+  // Get the first model
+  const sdf::Model *model = root.Model();
+  ASSERT_NE(nullptr, model);
+
+  const std::string xmlPath = "/sdf/model[@name=\"top_level_model\"]";
+  
+  sdf::ElementPtr modelElem = model->Element();
+  checkElementPtr(modelElem, testFile, 2, xmlPath);
+  EXPECT_EQ(2, static_cast<int>(model->LinkCount()));
+  EXPECT_EQ(1, static_cast<int>(model->JointCount()));
+  EXPECT_EQ(1, static_cast<int>(model->ModelCount()));
+
+  const std::string parentLinkXmlPath = xmlPath + "/link[@name=\"parent\"]";
+
+  const sdf::Link *parentLink = model->LinkByName("parent");
+  ASSERT_NE(nullptr, parentLink);
+  sdf::ElementPtr parentLinkElem = parentLink->Element();
+  checkElementPtr(parentLinkElem, testFile, 3, parentLinkXmlPath);
+
+  const std::string childLinkXmlPath = xmlPath + "/link[@name=\"child\"]";
+
+  const sdf::Link *childLink = model->LinkByName("child");
+  ASSERT_NE(nullptr, childLink);
+  sdf::ElementPtr childLinkElem = childLink->Element();
+  checkElementPtr(childLinkElem, testFile, 4, childLinkXmlPath);
+
+  const std::string jointXmlPath =
+    xmlPath + "/joint[@name=\"top_level_joint\"]";
+  
+  const sdf::Joint *joint = model->JointByIndex(0);
+  ASSERT_NE(nullptr, joint);
+  sdf::ElementPtr jointElem = joint->Element();
+  checkElementPtr(jointElem, testFile, 11, jointXmlPath);
+  
+  const std::string nestedModelXmlPath =
+    xmlPath + "/model[@name=\"nested_model\"]";
+ 
+  const sdf::Model *nestedModel = model->ModelByName("nested_model");
+  ASSERT_NE(nullptr, nestedModel); 
+  sdf::ElementPtr nestedModelElem = nestedModel->Element();
+  checkElementPtr(nestedModelElem, testFile, 5, nestedModelXmlPath);
+
+  const std::string nestedLinkXmlPath =
+    nestedModelXmlPath + "/link[@name=\"nested_link01\"]";
+
+  const sdf::Link *nestedLink = nestedModel->LinkByName("nested_link01");
+  ASSERT_NE(nullptr, nestedLink);
+  sdf::ElementPtr nestedLinkElem = nestedLink->Element();
+  checkElementPtr(nestedLinkElem, testFile, 6, nestedLinkXmlPath);
+
+  const std::string nestedNestedModelXmlPath =
+    nestedModelXmlPath + "/model[@name=\"nested_nested_model\"]";
+ 
+  const sdf::Model *nestedNestedModel =
+    nestedModel->ModelByName("nested_nested_model");
+  ASSERT_NE(nullptr, nestedNestedModel);
+  sdf::ElementPtr nestedNestedModelElem = nestedNestedModel->Element();
+  checkElementPtr(nestedNestedModelElem, testFile, 7,
+      nestedNestedModelXmlPath);
+
+  const std::string nestedNestedLinkXmlPath =
+    nestedNestedModelXmlPath + "/link[@name=\"nested_nested_link01\"]";
+  
+  const sdf::Link *nestedNestedLink =
+    nestedNestedModel->LinkByName("nested_nested_link01");
+  ASSERT_NE(nullptr, nestedNestedLink);
+  sdf::ElementPtr nestedNestedLinkElem = nestedNestedLink->Element();
+  checkElementPtr(nestedNestedLinkElem, testFile, 8, nestedNestedLinkXmlPath);
+}
+
+//////////////////////////////////////////////////
+TEST(ElementTracing, includes)
+{
+  sdf::setFindCallback(findFileCb);
+
+  const auto worldFile = sdf::testing::TestFile("sdf", "includes.sdf");
+  sdf::Root root;
+  sdf::Errors errors = root.Load(worldFile);
+  EXPECT_TRUE(errors.empty());
+
+  const std::string xmlPath = "/sdf";
+
+  sdf::ElementPtr rootElem = root.Element();
+  checkElementPtr(rootElem, worldFile, 2, xmlPath);
+
+  const std::string worldXmlPath = xmlPath + "/world[@name=\"default\"]";
+  const sdf::World *world = root.WorldByIndex(0);
+  ASSERT_NE(nullptr, world);
+  sdf::ElementPtr worldElem = world->Element();
+  checkElementPtr(worldElem, worldFile, 3, worldXmlPath);
+
+  // Actors
+  const std::string actorFilePath =
+      sdf::testing::TestFile("integration", "model", "test_actor") +
+      "/model.sdf";
+  const std::string actorXmlPath = "/sdf/actor[@name=\"actor\"]";
+
+  const sdf::Actor *actor = world->ActorByIndex(0);
+  ASSERT_NE(nullptr, actor);
+  sdf::ElementPtr actorElem = actor->Element();
+  checkElementPtr(actorElem, actorFilePath, 4, actorXmlPath);
+
+  const std::string overrideActorXmlPath =
+      "/sdf/actor[@name=\"override_actor_name\"]";
+  const sdf::Actor *overrideActor = world->ActorByIndex(1);
+  ASSERT_NE(nullptr, overrideActor);
+  sdf::ElementPtr overrideActorElem = overrideActor->Element();
+  checkElementPtr(overrideActorElem, actorFilePath, 4, overrideActorXmlPath);
+
+  const std::string overrideActorPluginXmlPath =
+      worldXmlPath + "/include[6]/plugin[0]";
+  
+  sdf::ElementPtr overrideActorPluginElem =
+      overrideActorElem->GetElement("plugin");
+  checkElementPtr(
+      overrideActorPluginElem, worldFile, 40, overrideActorPluginXmlPath);
+
+  // Lights
+  const std::string lightFilePath =
+      sdf::testing::TestFile("integration", "model", "test_light") +
+      "/model.sdf";
+  const std::string lightXmlPath = "/sdf/light[@name=\"point_light\"]";
+
+  const sdf::Light *light = world->LightByIndex(0);
+  ASSERT_NE(nullptr, light);
+  sdf::ElementPtr lightElem = light->Element();
+  checkElementPtr(lightElem, lightFilePath, 3, lightXmlPath);
+
+  const std::string overrideLightXmlPath =
+      "/sdf/light[@name=\"override_light_name\"]";
+  const sdf::Light *overrideLight = world->LightByIndex(1);
+  ASSERT_NE(nullptr, overrideLight);
+  sdf::ElementPtr overrideLightElem = overrideLight->Element();
+  checkElementPtr(overrideLightElem, lightFilePath, 3, overrideLightXmlPath);
+
+  // Models
+  const std::string modelFilePath =
+      sdf::testing::TestFile("integration", "model", "test_model") +
+      "/model.sdf";
+  const std::string modelXmlPath = "/sdf/model[@name=\"test_model\"]";
+
+  const sdf::Model *model = world->ModelByIndex(0);
+  ASSERT_NE(nullptr, model);
+  sdf::ElementPtr modelElem = model->Element();
+  checkElementPtr(modelElem, modelFilePath, 4, modelXmlPath);
+
+  const std::string overrideModelXmlPath =
+      "/sdf/model[@name=\"override_model_name\"]";
+  const sdf::Model *overrideModel = world->ModelByIndex(1);
+  ASSERT_NE(nullptr, overrideModel);
+  sdf::ElementPtr overrideModelElem = overrideModel->Element();
+  checkElementPtr(overrideModelElem, modelFilePath, 4, overrideModelXmlPath);
+
+  const std::string overrideModelPluginXmlPath =
+      worldXmlPath + "/include[1]/plugin[0]";
+
+  sdf::ElementPtr overrideModelPluginElem =
+      overrideModelElem->GetElement("plugin");
+  checkElementPtr(
+      overrideModelPluginElem, worldFile, 14, overrideModelPluginXmlPath);
+
+  const std::string overrideModelWithFileXmlPath =
+      "/sdf/model[@name=\"test_model_with_file\"]";
+
+  const sdf::Model *overrideModelWithFile = world->ModelByIndex(2);
+  ASSERT_NE(nullptr, overrideModelWithFile);
+  sdf::ElementPtr overrideModelWithFileElem = overrideModelWithFile->Element();
+  checkElementPtr(
+      overrideModelWithFileElem, modelFilePath, 4, 
+      overrideModelWithFileXmlPath);
+}
+

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 #include <gtest/gtest.h>
 
 #include "sdf/SDFImpl.hh"
@@ -31,8 +32,18 @@
 #include "test_config.h"
 
 //////////////////////////////////////////////////
+// This function handles path sanitization only up to a single '/'.
 std::string findFileCb(const std::string &_input)
 {
+  const std::string delimiter = "/";
+  std::size_t delimiter_pos = 0;
+  
+  if ((delimiter_pos = _input.find(delimiter)) != std::string::npos)
+  {
+    return sdf::testing::TestFile("integration", "model",
+        _input.substr(0, delimiter_pos),
+        _input.substr(delimiter_pos + 1, _input.size()));
+  }  
   return sdf::testing::TestFile("integration", "model", _input);
 }
 
@@ -273,8 +284,6 @@ TEST(ElementTracing, includes)
   EXPECT_EQ(14, overrideModelPluginElem->LineNumber().value());
   EXPECT_EQ(overrideModelPluginXmlPath, overrideModelPluginElem->XmlPath());
 
-  const std::string modelWithFileFilePath = sdf::testing::TestFile(
-      "integration", "model", "test_model/model.sdf");
   const std::string overrideModelWithFileXmlPath =
       "/sdf/model[@name=\"test_model_with_file\"]";
 
@@ -282,7 +291,7 @@ TEST(ElementTracing, includes)
   ASSERT_NE(nullptr, overrideModelWithFile);
   sdf::ElementPtr overrideModelWithFileElem = overrideModelWithFile->Element();
   ASSERT_NE(nullptr, overrideModelWithFileElem);
-  EXPECT_EQ(modelWithFileFilePath, overrideModelWithFileElem->FilePath());
+  EXPECT_EQ(modelFilePath, overrideModelWithFileElem->FilePath());
   ASSERT_TRUE(overrideModelWithFileElem->LineNumber().has_value());
   EXPECT_EQ(4, overrideModelWithFileElem->LineNumber().value());
   EXPECT_EQ(overrideModelWithFileXmlPath,

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -273,6 +273,8 @@ TEST(ElementTracing, includes)
   EXPECT_EQ(14, overrideModelPluginElem->LineNumber().value());
   EXPECT_EQ(overrideModelPluginXmlPath, overrideModelPluginElem->XmlPath());
 
+  const std::string modelWithFileFilePath = sdf::testing::TestFile(
+      "integration", "model", "test_model/model.sdf");
   const std::string overrideModelWithFileXmlPath =
       "/sdf/model[@name=\"test_model_with_file\"]";
 
@@ -280,7 +282,7 @@ TEST(ElementTracing, includes)
   ASSERT_NE(nullptr, overrideModelWithFile);
   sdf::ElementPtr overrideModelWithFileElem = overrideModelWithFile->Element();
   ASSERT_NE(nullptr, overrideModelWithFileElem);
-  EXPECT_EQ(modelFilePath, overrideModelWithFileElem->FilePath());
+  EXPECT_EQ(modelWithFileFilePath, overrideModelWithFileElem->FilePath());
   ASSERT_TRUE(overrideModelWithFileElem->LineNumber().has_value());
   EXPECT_EQ(4, overrideModelWithFileElem->LineNumber().value());
   EXPECT_EQ(overrideModelWithFileXmlPath,


### PR DESCRIPTION
# 🎉 New feature

Closes #226 and #510

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This encodes the XML path and line number information into each `Element` during parsing, and further adds the XML path information into the errors that occur, specifically when `readXml` is called.

Changes to `sdf::Error`:
* Added `XmlPath` setter and getter to the API
* Operator `<<` now handles printouts depending on availability of `XmlPath`, `FilePath` and `LineNumber`
  * `Error Code #: [XML_PATH]: Msg: ...`
  * `Error Code #: [XML_PATH:FILE_PATH]: Msg: ...`
  * `Error Code #: [XML_PATH:FILE_PATH:L#]: Msg: ...`
* Added tests

Changes to `sdf::Element`:
* Added API for `XmlPath` and `LineNumber`
* Added unit tests
* Added integration tests, see `test/integration/element_tracing.cc`

Changes to `Utils`:
* Added XML path support to `sdfwarn` and `sdfdbg`
* Added tests

Changes to `parser`:
* Keeps track XML path as it parses the SDF
* Attributes the XML path to each corresponding SDF Element

## Test it
<!--Explain how reviewers can test this new feature manually.-->

```bash
source ws/install/setup.bash
./ws/build/sdformat11/src/UNIT_Error_TEST
./ws/build/sdformat11/src/UNIT_Element_TEST
./ws/build/sdformat11/src/UNIT_Utils_TEST
./ws/build/sdformat11/src/UNIT_parser_TEST
./ws/build/sdformat11/test/integration/INTEGRATION_element_tracing
```

Testing with `ign sdf -k`
```bash
source ws/install/setup.bash
cd ws/src/sdformat/test/sdf
ign sdf -k bad_syntax_double.sdf
```

We would expect the top of the error message stack to be,
```bash
Error Code 9: [/sdf/world[@name="default"]/model[@name="robot1"]/link[@name="link"]/velocity_decay/linear:/ws/src/sdformat/test/sdf/bad_syntax_double.sdf:L7]: Msg: Error reading element <linear>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
