### PR TITLE
Clean up use of PROJECT_SOURCE_PATH in tests

### DIFF
--- a/src/FrameSemantics_TEST.cc
+++ b/src/FrameSemantics_TEST.cc
@@ -301,8 +301,7 @@ TEST(FrameSemantics, buildPoseRelativeToGraph)
 TEST(NestedFrameSemantics, buildFrameAttachedToGraph_Model)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_nested_frame_attached_to.sdf");
+    sdf::testing::TestFile("sdf", "model_nested_frame_attached_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -394,8 +393,7 @@ TEST(NestedFrameSemantics, buildFrameAttachedToGraph_Model)
 TEST(NestedFrameSemantics, buildFrameAttachedToGraph_World)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_nested_frame_attached_to.sdf");
+    sdf::testing::TestFile("sdf", "world_nested_frame_attached_to.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -581,8 +579,7 @@ TEST(NestedFrameSemantics, buildFrameAttachedToGraph_World)
 TEST(NestedFrameSemantics, ModelWithoutLinksWithNestedStaticModel)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_nested_static_model.sdf");
+    sdf::testing::TestFile("sdf", "model_nested_static_model.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -611,8 +608,7 @@ TEST(NestedFrameSemantics, ModelWithoutLinksWithNestedStaticModel)
 TEST(NestedFrameSemantics, InvalidAttachedToScope)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "world_frame_invalid_attached_to_scope.sdf");
+    sdf::testing::TestFile("sdf", "world_frame_invalid_attached_to_scope.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/src/ParserConfig_TEST.cc
+++ b/src/ParserConfig_TEST.cc
@@ -31,7 +31,7 @@ TEST(ParserConfig, Construction)
   EXPECT_TRUE(config.URIPathMap().empty());
 
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir = sdf::testing::SourceFile();
 
   config.AddURIPath("file://", testDir);
@@ -57,7 +57,7 @@ TEST(ParserConfig, Construction)
 TEST(ParserConfig, CopyConstructor)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir1 = sdf::testing::SourceFile();
   const std::string testDir2 = sdf::testing::TestFile();
 
@@ -100,7 +100,7 @@ TEST(ParserConfig, CopyConstructor)
 TEST(ParserConfig, CopyAssignmentOperator)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir1 = sdf::testing::SourceFile();
   const std::string testDir2 = sdf::testing::TestFile();
 
@@ -143,9 +143,8 @@ TEST(ParserConfig, CopyAssignmentOperator)
 TEST(ParserConfig, MoveConstructor)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir1 = sdf::testing::SourceFile();
-  const std::string testDir2 = sdf::testing::TestFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);
@@ -170,7 +169,7 @@ TEST(ParserConfig, MoveConstructor)
 TEST(ParserConfig, MoveAssignmentOperator)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir1 = sdf::testing::SourceFile();
 
   sdf::ParserConfig config1;
@@ -197,7 +196,7 @@ TEST(ParserConfig, MoveAssignmentOperator)
 TEST(ParserConfig, CopyAssignmentAfterMove)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source path 
+  // the source path
   const std::string testDir1 = sdf::testing::SourceFile();
   const std::string testDir2 = sdf::testing::TestFile();
 

--- a/src/ParserConfig_TEST.cc
+++ b/src/ParserConfig_TEST.cc
@@ -31,8 +31,8 @@ TEST(ParserConfig, Construction)
   EXPECT_TRUE(config.URIPathMap().empty());
 
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir = PROJECT_SOURCE_PATH;
+  // the source path 
+  const std::string testDir = sdf::testing::SourceFile();
 
   config.AddURIPath("file://", testDir);
   ASSERT_FALSE(config.URIPathMap().empty());
@@ -57,10 +57,9 @@ TEST(ParserConfig, Construction)
 TEST(ParserConfig, CopyConstructor)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir1 = PROJECT_SOURCE_PATH;
-  const std::string testDir2 =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
+  // the source path 
+  const std::string testDir1 = sdf::testing::SourceFile();
+  const std::string testDir2 = sdf::testing::TestFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);
@@ -101,10 +100,9 @@ TEST(ParserConfig, CopyConstructor)
 TEST(ParserConfig, CopyAssignmentOperator)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir1 = PROJECT_SOURCE_PATH;
-  const std::string testDir2 =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
+  // the source path 
+  const std::string testDir1 = sdf::testing::SourceFile();
+  const std::string testDir2 = sdf::testing::TestFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);
@@ -145,8 +143,9 @@ TEST(ParserConfig, CopyAssignmentOperator)
 TEST(ParserConfig, MoveConstructor)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir1 = PROJECT_SOURCE_PATH;
+  // the source path 
+  const std::string testDir1 = sdf::testing::SourceFile();
+  const std::string testDir2 = sdf::testing::TestFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);
@@ -171,8 +170,8 @@ TEST(ParserConfig, MoveConstructor)
 TEST(ParserConfig, MoveAssignmentOperator)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir1 = PROJECT_SOURCE_PATH;
+  // the source path 
+  const std::string testDir1 = sdf::testing::SourceFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);
@@ -198,10 +197,9 @@ TEST(ParserConfig, MoveAssignmentOperator)
 TEST(ParserConfig, CopyAssignmentAfterMove)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir1 = PROJECT_SOURCE_PATH;
-  const std::string testDir2 =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
+  // the source path 
+  const std::string testDir1 = sdf::testing::SourceFile();
+  const std::string testDir2 = sdf::testing::TestFile();
 
   sdf::ParserConfig config1;
   config1.AddURIPath("file://", testDir1);

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -422,13 +422,11 @@ TEST(Parser, IncludesErrors)
     // clear the contents of the buffer
     buffer.str("");
 
-    const std::string modelRootPath = sdf::filesystem::append(
-        PROJECT_SOURCE_PATH, "test", "integration", "model");
     const auto path =
         sdf::testing::TestFile("sdf", "includes_model_without_sdf.sdf");
     sdf::setFindCallback([&](const std::string &_file)
         {
-          return sdf::filesystem::append(modelRootPath, _file);
+          return sdf::testing::TestFile("integration", "model", _file);
         });
 
     sdf::SDFPtr sdf(new sdf::SDF());
@@ -448,13 +446,11 @@ TEST(Parser, IncludesErrors)
     // clear the contents of the buffer
     buffer.str("");
 
-    const std::string modelRootPath = sdf::filesystem::append(
-        PROJECT_SOURCE_PATH, "test", "integration", "model");
     const auto path =
         sdf::testing::TestFile("sdf", "includes_without_top_level.sdf");
     sdf::setFindCallback([&](const std::string &_file)
         {
-          return sdf::filesystem::append(modelRootPath, _file);
+          return sdf::testing::TestFile("integration", "model", _file);
         });
 
     sdf::SDFPtr sdf(new sdf::SDF());
@@ -480,15 +476,12 @@ TEST(Parser, IncludesErrors)
 
 TEST(Parser, PlacementFrameMissingPose)
 {
-  const std::string modelRootPath = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "model");
-
-  const std::string testModelPath = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "sdf", "placement_frame_missing_pose.sdf");
+  const std::string testModelPath =
+      sdf::testing::TestFile("sdf", "placement_frame_missing_pose.sdf");
 
   sdf::setFindCallback([&](const std::string &_file)
       {
-        return sdf::filesystem::append(modelRootPath, _file);
+        return sdf::testing::TestFile("integration", "model", _file);
       });
   sdf::SDFPtr sdf = InitSDF();
   sdf::Errors errors;

--- a/test/integration/deprecated_specs.cc
+++ b/test/integration/deprecated_specs.cc
@@ -23,8 +23,7 @@
 TEST(DeprecatedSpecs, Spec1_0)
 {
   const std::string filename =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "deprecated_sdf_1-0.sdf");
+    sdf::testing::TestFile("integration", "deprecated_sdf_1-0.sdf");
   sdf::SDFPtr sdf(new sdf::SDF());
   EXPECT_FALSE(sdf::initFile(filename, sdf));
 }
@@ -33,8 +32,7 @@ TEST(DeprecatedSpecs, Spec1_0)
 TEST(DeprecatedSpecs, Spec1_2)
 {
   const std::string filename =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                            "deprecated_sdf_1-2.sdf");
+    sdf::testing::TestFile("integration", "deprecated_sdf_1-2.sdf");
   sdf::SDFPtr sdf(new sdf::SDF());
   EXPECT_FALSE(sdf::initFile(filename, sdf));
 }

--- a/test/integration/interface_api.cc
+++ b/test/integration/interface_api.cc
@@ -123,8 +123,7 @@ class InterfaceAPI : public ::testing::Test
 {
   protected: void SetUp() override
   {
-    this->modelDir = sdf::filesystem::append(
-        PROJECT_SOURCE_PATH, "test", "integration", "model");
+    this->modelDir = sdf::testing::TestFile("integration", "model");
 
     this->config.SetFindCallback(
         [=](const std::string &_file)
@@ -341,8 +340,8 @@ void TomlParserTest(const sdf::InterfaceModelConstPtr &_interfaceModel)
 TEST_F(InterfaceAPI, TomlParserWorldInclude)
 {
   using ignition::math::Pose3d;
-  const std::string testFile = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-      "test", "sdf", "world_include_with_interface_api.sdf");
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "world_include_with_interface_api.sdf");
 
   this->config.RegisterCustomModelParser(customTomlParser);
   sdf::Root root;
@@ -360,8 +359,8 @@ TEST_F(InterfaceAPI, TomlParserWorldInclude)
 TEST_F(InterfaceAPI, TomlParserModelInclude)
 {
   using ignition::math::Pose3d;
-  const std::string testFile = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-      "test", "sdf", "model_include_with_interface_api.sdf");
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "model_include_with_interface_api.sdf");
 
   this->config.RegisterCustomModelParser(customTomlParser);
   sdf::Root root;
@@ -380,8 +379,8 @@ TEST_F(InterfaceAPI, TomlParserModelInclude)
 TEST_F(InterfaceAPI, FrameSemantics)
 {
   using ignition::math::Pose3d;
-  const std::string testFile = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-      "test", "sdf", "include_with_interface_api_frame_semantics.sdf");
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "include_with_interface_api_frame_semantics.sdf");
 
   this->config.RegisterCustomModelParser(customTomlParser);
   sdf::Root root;
@@ -548,8 +547,8 @@ TEST_F(InterfaceAPI, FrameSemantics)
 TEST_F(InterfaceAPI, Reposturing)
 {
   using ignition::math::Pose3d;
-  const std::string testFile = sdf::filesystem::append(PROJECT_SOURCE_PATH,
-      "test", "sdf", "include_with_interface_api_reposture.sdf");
+  const std::string testFile = sdf::testing::TestFile(
+      "sdf", "include_with_interface_api_reposture.sdf");
 
   std::unordered_map<std::string, sdf::InterfaceModelPtr> models;
   std::unordered_map<std::string, Pose3d> posesAfterReposture;

--- a/test/integration/joint_dom.cc
+++ b/test/integration/joint_dom.cc
@@ -234,8 +234,7 @@ TEST(DOMJoint, LoadInvalidJointChildWorld)
 TEST(DOMJoint, LoadJointParentFrame)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_parent_frame.sdf");
+    sdf::testing::TestFile("sdf", "joint_parent_frame.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -327,8 +326,7 @@ TEST(DOMJoint, LoadJointParentFrame)
 TEST(DOMJoint, LoadJointChildFrame)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_child_frame.sdf");
+    sdf::testing::TestFile("sdf", "joint_child_frame.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -764,8 +762,7 @@ TEST(DOMJoint, LoadURDFJointPoseRelativeTo)
 TEST(DOMJoint, LoadJointNestedParentChild)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "joint_nested_parent_child.sdf");
+    sdf::testing::TestFile("sdf", "joint_nested_parent_child.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/locale_fix.cc
+++ b/test/integration/locale_fix.cc
@@ -25,8 +25,7 @@
 #include "test_config.h"
 
 const std::string SDF_TEST_FILE =
-  sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
-                          "numeric.sdf");
+  sdf::testing::TestFile("integration", "numeric.sdf");
 
 // Windows supports the setlocale call but we can not extract the
 // available locales using the Linux call

--- a/test/integration/model_dom.cc
+++ b/test/integration/model_dom.cc
@@ -214,8 +214,7 @@ TEST(DOMRoot, NestedModel)
 TEST(DOMRoot, MultiNestedModel)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_multi_nested_model.sdf");
+    sdf::testing::TestFile("sdf", "model_multi_nested_model.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -488,8 +487,7 @@ TEST(DOMRoot, LoadNestedCanonicalLink)
 TEST(DOMRoot, LoadNestedExplicitCanonicalLink)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "nested_explicit_canonical_link.sdf");
+    sdf::testing::TestFile("sdf", "nested_explicit_canonical_link.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -536,8 +534,7 @@ TEST(DOMRoot, LoadNestedExplicitCanonicalLink)
 TEST(DOMRoot, ModelPlacementFrameAttribute)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "model_with_placement_frame_attribute.sdf");
+    sdf::testing::TestFile("sdf", "model_with_placement_frame_attribute.sdf");
 
   // Load the SDF file
   sdf::Root root;
@@ -557,8 +554,7 @@ TEST(DOMRoot, ModelPlacementFrameAttribute)
 TEST(DOMRoot, LoadInvalidNestedModelWithoutLinks)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "nested_without_links_invalid.sdf");
+    sdf::testing::TestFile("sdf", "nested_without_links_invalid.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -249,7 +249,7 @@ TEST(NestedModel, State)
 TEST(NestedModel, NestedInclude)
 {
   const std::string name = "double_pendulum_kinematics";
-  const std::string MODEL_PATH = 
+  const std::string MODEL_PATH =
     sdf::testing::TestFile("integration", "model", name);
 
   // this uses two models from the test/integration/model folder that are
@@ -406,7 +406,7 @@ TEST(NestedModel, NestedInclude)
 TEST(NestedModel, NestedModelWithFrames)
 {
   const std::string name = "test_model_with_frames";
-  const std::string modelPath = 
+  const std::string modelPath =
     sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
@@ -579,7 +579,7 @@ void prepareForDirectComparison(sdf::ElementPtr _worldElem)
 TEST(NestedModel, NestedModelWithFramesDirectComparison)
 {
   const std::string name = "test_model_with_frames";
-  const std::string modelPath = 
+  const std::string modelPath =
     sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
@@ -609,7 +609,7 @@ TEST(NestedModel, NestedModelWithFramesDirectComparison)
   prepareForDirectComparison(worldElem);
 
   // Compare with expected output
-  const std::string expectedSdfPath = 
+  const std::string expectedSdfPath =
     sdf::testing::TestFile(
         "integration", "nested_model_with_frames_expected.sdf");
   std::fstream fs;
@@ -625,7 +625,7 @@ TEST(NestedModel, NestedModelWithFramesDirectComparison)
 TEST(NestedModel, PartiallyFlattened)
 {
   const std::string testFile =
-    sdf::testing::TestFile("integration", 
+    sdf::testing::TestFile("integration",
       "partially_flattened.sdf");
 
   // Load the SDF file
@@ -782,7 +782,7 @@ TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
 TEST(NestedModel, NestedModelWithSiblingFrames)
 {
   const std::string name = "test_model_with_frames";
-  const std::string MODEL_PATH = 
+  const std::string MODEL_PATH =
       sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d testFramePose(0, 5, 0, 0, 0, -IGN_PI/2);
@@ -885,7 +885,7 @@ TEST(NestedModel, NestedModelWithSiblingFrames)
 TEST(NestedModel, NestedFrameOnlyModel)
 {
   const std::string name = "frame_only_model";
-  const std::string MODEL_PATH = 
+  const std::string MODEL_PATH =
       sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
@@ -943,10 +943,10 @@ class PlacementFrame: public ::testing::Test
 
   protected: void SetUp() override
   {
-    const std::string modelRootPath = 
+    const std::string modelRootPath =
         sdf::testing::TestFile("integration", "model");
 
-    const std::string testModelPath = 
+    const std::string testModelPath =
         sdf::testing::TestFile("sdf", "placement_frame.sdf");
 
     sdf::setFindCallback(
@@ -1265,7 +1265,7 @@ TEST(NestedReference, PlacementFrameAttribute)
 /////////////////////////////////////////////////
 TEST(NestedReference, PlacementFrameElement)
 {
-  const std::string modelRootPath = 
+  const std::string modelRootPath =
     sdf::testing::TestFile("integration", "model");
 
   sdf::setFindCallback([&](const std::string &_file)
@@ -1399,7 +1399,7 @@ TEST(NestedReference, PlacementFrameElement)
 /////////////////////////////////////////////////
 TEST(NestedModel, IncludeElements)
 {
-  const std::string modelRootPath = 
+  const std::string modelRootPath =
     sdf::testing::TestFile("integration", "model");
 
   sdf::ParserConfig config;

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -249,8 +249,8 @@ TEST(NestedModel, State)
 TEST(NestedModel, NestedInclude)
 {
   const std::string name = "double_pendulum_kinematics";
-  const std::string MODEL_PATH = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/" + name;
+  const std::string MODEL_PATH = 
+    sdf::testing::TestFile("integration", "model", name);
 
   // this uses two models from the test/integration/model folder that are
   // identical except for the //sdf/@version attribute
@@ -406,8 +406,8 @@ TEST(NestedModel, NestedInclude)
 TEST(NestedModel, NestedModelWithFrames)
 {
   const std::string name = "test_model_with_frames";
-  const std::string modelPath = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/" + name;
+  const std::string modelPath = 
+    sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
 
@@ -579,8 +579,8 @@ void prepareForDirectComparison(sdf::ElementPtr _worldElem)
 TEST(NestedModel, NestedModelWithFramesDirectComparison)
 {
   const std::string name = "test_model_with_frames";
-  const std::string modelPath = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/" + name;
+  const std::string modelPath = 
+    sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
 
@@ -609,9 +609,9 @@ TEST(NestedModel, NestedModelWithFramesDirectComparison)
   prepareForDirectComparison(worldElem);
 
   // Compare with expected output
-  const std::string expectedSdfPath =
-      std::string(PROJECT_SOURCE_PATH) +
-      "/test/integration/nested_model_with_frames_expected.sdf";
+  const std::string expectedSdfPath = 
+    sdf::testing::TestFile(
+        "integration", "nested_model_with_frames_expected.sdf");
   std::fstream fs;
   fs.open(expectedSdfPath);
   EXPECT_TRUE(fs.is_open());
@@ -625,7 +625,7 @@ TEST(NestedModel, NestedModelWithFramesDirectComparison)
 TEST(NestedModel, PartiallyFlattened)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+    sdf::testing::TestFile("integration", 
       "partially_flattened.sdf");
 
   // Load the SDF file
@@ -727,10 +727,9 @@ TEST(NestedModel, PartiallyFlattened)
 // Compare parsed SDF with expected string
 TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
 {
-  const std::string modelRootPath = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/";
   const std::string name = "test_nested_model_with_frames";
-  const std::string modelPath = modelRootPath + name;
+  const std::string modelPath = sdf::testing::TestFile(
+      "integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
 
@@ -755,7 +754,7 @@ TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
   sdf::setFindCallback(
       [&](const std::string &_file)
       {
-        return modelRootPath + _file;
+        return sdf::testing::TestFile("integration", "model", _file);
       });
 
   sdf::Errors errors;
@@ -767,8 +766,8 @@ TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
 
   // Compare with expected output
   const std::string expectedSdfPath =
-      std::string(PROJECT_SOURCE_PATH) +
-      "/test/integration/two_level_nested_model_with_frames_expected.sdf";
+      sdf::testing::TestFile(
+          "integration", "two_level_nested_model_with_frames_expected.sdf");
   std::fstream fs;
   fs.open(expectedSdfPath);
   EXPECT_TRUE(fs.is_open());
@@ -783,8 +782,8 @@ TEST(NestedModel, TwoLevelNestedModelWithFramesDirectComparison)
 TEST(NestedModel, NestedModelWithSiblingFrames)
 {
   const std::string name = "test_model_with_frames";
-  const std::string MODEL_PATH = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/" + name;
+  const std::string MODEL_PATH = 
+      sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d testFramePose(0, 5, 0, 0, 0, -IGN_PI/2);
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
@@ -886,8 +885,8 @@ TEST(NestedModel, NestedModelWithSiblingFrames)
 TEST(NestedModel, NestedFrameOnlyModel)
 {
   const std::string name = "frame_only_model";
-  const std::string MODEL_PATH = std::string(PROJECT_SOURCE_PATH)
-      + "/test/integration/model/" + name;
+  const std::string MODEL_PATH = 
+      sdf::testing::TestFile("integration", "model", name);
 
   const ignition::math::Pose3d model1Pose(10, 0, 0, 0, 0, IGN_PI/2);
 
@@ -944,11 +943,11 @@ class PlacementFrame: public ::testing::Test
 
   protected: void SetUp() override
   {
-    const std::string modelRootPath = sdf::filesystem::append(
-        PROJECT_SOURCE_PATH, "test", "integration", "model");
+    const std::string modelRootPath = 
+        sdf::testing::TestFile("integration", "model");
 
-    const std::string testModelPath = sdf::filesystem::append(
-        PROJECT_SOURCE_PATH, "test", "sdf", "placement_frame.sdf");
+    const std::string testModelPath = 
+        sdf::testing::TestFile("sdf", "placement_frame.sdf");
 
     sdf::setFindCallback(
         [&](const std::string &_file)
@@ -1122,7 +1121,7 @@ TEST_F(PlacementFrame, ModelPlacementFrameAttribute)
 TEST(NestedReference, PoseRelativeTo)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf", 
         "model_relative_to_nested_reference.sdf");
 
   // Load the SDF file
@@ -1185,7 +1184,7 @@ TEST(NestedReference, PoseRelativeTo)
 TEST(NestedReference, PoseRelativeToInWorld)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
+    sdf::testing::TestFile("sdf", 
         "world_relative_to_nested_reference.sdf");
 
   // Load the SDF file
@@ -1246,7 +1245,7 @@ TEST(NestedReference, PoseRelativeToInWorld)
 TEST(NestedReference, PlacementFrameAttribute)
 {
   const std::string testFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration",
+      sdf::testing::TestFile("integration", 
           "model", "model_with_nested_placement_frame_attribute", "model.sdf");
 
   // Load the SDF file
@@ -1266,8 +1265,8 @@ TEST(NestedReference, PlacementFrameAttribute)
 /////////////////////////////////////////////////
 TEST(NestedReference, PlacementFrameElement)
 {
-  const std::string modelRootPath = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "model");
+  const std::string modelRootPath = 
+    sdf::testing::TestFile("integration", "model");
 
   sdf::setFindCallback([&](const std::string &_file)
   {
@@ -1400,8 +1399,8 @@ TEST(NestedReference, PlacementFrameElement)
 /////////////////////////////////////////////////
 TEST(NestedModel, IncludeElements)
 {
-  const std::string modelRootPath = sdf::filesystem::append(
-      PROJECT_SOURCE_PATH, "test", "integration", "model");
+  const std::string modelRootPath = 
+    sdf::testing::TestFile("integration", "model");
 
   sdf::ParserConfig config;
   config.SetFindCallback(

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -1184,7 +1184,7 @@ TEST(NestedReference, PoseRelativeTo)
 TEST(NestedReference, PoseRelativeToInWorld)
 {
   const std::string testFile =
-    sdf::testing::TestFile("sdf", 
+    sdf::testing::TestFile("sdf",
         "world_relative_to_nested_reference.sdf");
 
   // Load the SDF file
@@ -1245,7 +1245,7 @@ TEST(NestedReference, PoseRelativeToInWorld)
 TEST(NestedReference, PlacementFrameAttribute)
 {
   const std::string testFile =
-      sdf::testing::TestFile("integration", 
+      sdf::testing::TestFile("integration",
           "model", "model_with_nested_placement_frame_attribute", "model.sdf");
 
   // Load the SDF file

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -1121,7 +1121,7 @@ TEST_F(PlacementFrame, ModelPlacementFrameAttribute)
 TEST(NestedReference, PoseRelativeTo)
 {
   const std::string testFile =
-    sdf::testing::TestFile("sdf", 
+    sdf::testing::TestFile("sdf",
         "model_relative_to_nested_reference.sdf");
 
   // Load the SDF file

--- a/test/integration/nested_multiple_elements_error.cc
+++ b/test/integration/nested_multiple_elements_error.cc
@@ -28,7 +28,7 @@
 #include "sdf/World.hh"
 #include "test_config.h"
 
-const auto g_testPath = sdf::filesystem::append(PROJECT_SOURCE_PATH, "test");
+const auto g_testPath = sdf::testing::TestFile();
 const auto g_modelsPath =
     sdf::filesystem::append(g_testPath, "integration", "model");
 const auto g_sdfPath = sdf::filesystem::append(g_testPath, "sdf");

--- a/test/integration/parser_config.cc
+++ b/test/integration/parser_config.cc
@@ -66,7 +66,7 @@ TEST(ParserConfig, NonGlobalConfig)
 
   sdf::ParserConfig config;
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // the source directory 
+  // the source directory
   const std::string testDir = sdf::testing::SourceFile();
   config.AddURIPath("file://", testDir);
   config.SetFindCallback(

--- a/test/integration/parser_config.cc
+++ b/test/integration/parser_config.cc
@@ -32,8 +32,8 @@
 TEST(ParserConfig, GlobalConfig)
 {
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir = PROJECT_SOURCE_PATH;
+  // the source directory
+  const std::string testDir = sdf::testing::SourceFile();
 
   sdf::addURIPath("file://", testDir);
   sdf::setFindCallback(
@@ -66,8 +66,8 @@ TEST(ParserConfig, NonGlobalConfig)
 
   sdf::ParserConfig config;
   // The directory used in AddURIPath must exist in the filesystem, so we'll use
-  // PROJECT_SOURCE_PATH
-  const std::string testDir = PROJECT_SOURCE_PATH;
+  // the source directory 
+  const std::string testDir = sdf::testing::SourceFile();
   config.AddURIPath("file://", testDir);
   config.SetFindCallback(
       [](const std::string &)
@@ -97,14 +97,11 @@ TEST(ParserConfig, ParseWithNonGlobalConfig)
 
   // Case 1: Use of sdf::setFindCallback
   {
-    const std::string testFile =
-      sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-          "includes.sdf");
+    const std::string testFile = sdf::testing::TestFile("sdf", "includes.sdf");
 
     auto findFileCb = [](const std::string &_uri)
     {
-      return sdf::filesystem::append(
-          PROJECT_SOURCE_PATH, "test", "integration", "model", _uri);
+      return sdf::testing::TestFile("integration", "model", _uri);
     };
 
     sdf::ParserConfig config;
@@ -181,8 +178,7 @@ TEST(ParserConfig, ParseWithNonGlobalConfig)
 
     sdf::ParserConfig config;
     config.AddURIPath("testScheme://",
-        sdf::filesystem::append(
-            PROJECT_SOURCE_PATH, "test", "integration", "model"));
+        sdf::testing::TestFile("integration", "model"));
 
     // Parsing testSdfString without setting addURIPath on the global
     // ParserConfig should fail

--- a/test/integration/schema_test.cc
+++ b/test/integration/schema_test.cc
@@ -30,16 +30,13 @@ const std::string SDF_ROOT_SCHEMA =
                           "root.xsd");
 
 const std::string SDF_TEST_PR2 =
-  sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration", "model",
-                          "pr2.sdf");
+  sdf::testing::TestFile("integration", "model", "pr2.sdf");
 
 const std::string SDF_TEST_TURTLEBOT =
-  sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration", "model",
-                          "turtlebot.sdf");
+  sdf::testing::TestFile("integration", "model", "turtlebot.sdf");
 
 const std::string SDF_TEST_PENDULUM =
-  sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "integration", "model",
-                          "double_pendulum.sdf");
+  sdf::testing::TestFile("integration", "model", "double_pendulum.sdf");
 
 
 class SDFSchemaGenerator : public testing::Test

--- a/test/integration/unknown.cc
+++ b/test/integration/unknown.cc
@@ -90,8 +90,7 @@ TEST(Unknown, CopyUnknownElement)
 TEST(UnrecognizedElements, UnrecognizedElementsWithWarningsPolicies)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "unrecognized_elements.sdf");
+    sdf::testing::TestFile("sdf", "unrecognized_elements.sdf");
 
   sdf::ParserConfig config;
 
@@ -125,8 +124,7 @@ TEST(UnrecognizedElements, UnrecognizedElementsWithWarningsPolicies)
 TEST(UnrecognizedElements, UnrecognizedElementsWithNamespaces)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "unrecognized_elements_with_namespace.sdf");
+    sdf::testing::TestFile("sdf", "unrecognized_elements_with_namespace.sdf");
 
   sdf::ParserConfig config;
   config.SetUnrecognizedElementsPolicy(sdf::EnforcementPolicy::ERR);

--- a/test/integration/visual_dom.cc
+++ b/test/integration/visual_dom.cc
@@ -203,8 +203,7 @@ TEST(DOMVisual, Transparency)
 TEST(DOMVisual, LaserRetro)
 {
   const std::string testFile =
-    sdf::filesystem::append(PROJECT_SOURCE_PATH, "test", "sdf",
-        "shapes.sdf");
+    sdf::testing::TestFile("sdf", "shapes.sdf");
 
   // Load the SDF file
   sdf::Root root;

--- a/tools/code_check.sh
+++ b/tools/code_check.sh
@@ -11,7 +11,7 @@ if test "$1" = "-xmldir" -a -n "$2"; then
   builddir=../build
 else
   # This is a heuristic guess; not every developer puts the `build` dir in the src dir
-  builddir=/home/mjcarroll/workspaces/ign_edifice/build/sdformat11/
+  builddir=./build
 fi
 
 # Use a suppression file for spurious errors

--- a/tools/code_check.sh
+++ b/tools/code_check.sh
@@ -11,7 +11,7 @@ if test "$1" = "-xmldir" -a -n "$2"; then
   builddir=../build
 else
   # This is a heuristic guess; not every developer puts the `build` dir in the src dir
-  builddir=./build
+  builddir=/home/mjcarroll/workspaces/ign_edifice/build/sdformat11/
 fi
 
 # Use a suppression file for spurious errors


### PR DESCRIPTION
# 🧹 Clean some uses of PROJECT_SOURCE_PATH

This is partially to address compatibility with Bazel builds, but also generally better practice going forward as it handles paths more consistently across operating systems.

Signed-off-by: Michael Carroll <michael@openrobotics.org>