### PR TITLE
parser: Use encapsulated string constants for non-file sources

### DIFF
--- a/include/sdf/Types.hh
+++ b/include/sdf/Types.hh
@@ -65,11 +65,11 @@ namespace sdf
 
   /// \brief The source path replacement if it was parsed from a string,
   /// instead of a file.
-  constexpr char kSdfStringSource[] = "data-string";
+  constexpr char kSdfStringSource[] = "<data-string>";
 
   /// \brief The source path replacement if the urdf was parsed from a string,
   /// instead of a file.
-  constexpr char kUrdfStringSource[] = "urdf string";
+  constexpr char kUrdfStringSource[] = "<urdf-string>";
 
   /// \brief Split a string using the delimiter in splitter.
   /// \param[in] str       The string to split.

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -932,10 +932,6 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     const ParserConfig &_config, const std::string &_source, Errors &_errors)
 {
-  std::string sourcePath = _source;
-  if (_source == kSdfStringSource || _source == kUrdfStringSource)
-    sourcePath = "<" + _source + ">";
-
   // Check if the element pointer is deprecated.
   if (_sdf->GetRequired() == "-1")
   {
@@ -954,7 +950,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
       _errors.push_back({
           ErrorCode::ELEMENT_MISSING,
           "SDF Element<" + _sdf->GetName() + "> is missing",
-          sourcePath});
+          _source});
       return false;
     }
     else
@@ -1028,7 +1024,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 "'" + std::string(attribute->Value()) +
                 "' is reserved; it cannot be used as a value of "
                 "attribute [" + p->GetKey() + "]",
-                sourcePath,
+                _source,
                 attribute->GetLineNum()});
             }
         }
@@ -1038,7 +1034,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           _errors.push_back({
               ErrorCode::ATTRIBUTE_INVALID,
               "Unable to read attribute[" + p->GetKey() + "]",
-              sourcePath,
+              _source,
               attribute->GetLineNum()});
           return false;
         }
@@ -1057,7 +1053,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           Error(
               ErrorCode::ATTRIBUTE_INCORRECT_TYPE,
               ss.str(),
-              sourcePath,
+              _source,
               _xml->GetLineNum()),
           _errors);
     }
@@ -1075,7 +1071,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           ErrorCode::ATTRIBUTE_MISSING,
           "Required attribute[" + p->GetKey() + "] in element[" + _xml->Value()
           + "] is not specified in SDF.",
-          sourcePath,
+          _source,
           _xml->GetLineNum()});
       return false;
     }
@@ -1111,7 +1107,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             _errors.push_back({
                 ErrorCode::URI_LOOKUP,
                 "Unable to find uri[" + uri + "]",
-                sourcePath,
+                _source,
                 uriElement->GetLineNum()});
             continue;
           }
@@ -1129,7 +1125,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                     "Unable to resolve uri[" + uri + "] to model path [" +
                     modelPath + "] since it does not contain a model.config " +
                     "file.",
-                    sourcePath,
+                    _source,
                     uriElement->GetLineNum()});
                 continue;
               }
@@ -1148,7 +1144,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           _errors.push_back({
               ErrorCode::ATTRIBUTE_MISSING,
               "<include> element missing 'uri' attribute",
-              sourcePath,
+              _source,
               elemXml->GetLineNum()});
           continue;
         }
@@ -1177,7 +1173,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             _errors.push_back({
                 ErrorCode::FILE_READ,
                 "Unable to read file[" + filename + "]",
-                sourcePath,
+                _source,
                 uriElement->GetLineNum()});
             return false;
           }
@@ -1219,7 +1215,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "Failed to find top level <model> / <actor> / <light> for "
                 "<include>\n",
-                sourcePath,
+                _source,
                 uriElement->GetLineNum()});
             continue;
           }
@@ -1294,7 +1290,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   ErrorCode::MODEL_PLACEMENT_FRAME_INVALID,
                   "<pose> is required when specifying the placement_frame "
                   "element",
-                  sourcePath,
+                  _source,
                   elemXml->GetLineNum()});
               return false;
             }
@@ -1308,7 +1304,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   "'" + placementFrameVal +
                   "' is reserved; it cannot be used as a value of "
                   "element [placement_frame]",
-                  sourcePath,
+                  _source,
                   placementFrameElem->GetLineNum()});
             }
             topLevelElem->GetAttribute("placement_frame")
@@ -1327,12 +1323,12 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 pluginElem = topLevelElem->AddElement("plugin");
 
                 if (!readXml(
-                    childElemXml, pluginElem, _config, sourcePath, _errors))
+                    childElemXml, pluginElem, _config, _source, _errors))
                 {
                   _errors.push_back({
                       ErrorCode::ELEMENT_INVALID,
                       "Error reading plugin element",
-                      sourcePath,
+                      _source,
                       childElemXml->GetLineNum()});
                   return false;
                 }
@@ -1367,7 +1363,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         {
           ElementPtr element = elemDesc->Clone();
           element->SetParent(_sdf);
-          if (readXml(elemXml, element, _config, sourcePath, _errors))
+          if (readXml(elemXml, element, _config, _source, _errors))
           {
             _sdf->InsertElement(element);
           }
@@ -1377,7 +1373,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_INVALID,
                 std::string("Error reading element <") +
                 elemXml->Value() + ">",
-                sourcePath,
+                _source,
                 elemXml->GetLineNum()});
             return false;
           }
@@ -1399,7 +1395,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error(
                 ErrorCode::ELEMENT_INCORRECT_TYPE,
                 ss.str(),
-                sourcePath,
+                _source,
                 elemXml->GetLineNum()),
             _errors);
 
@@ -1427,7 +1423,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "XML Missing required element[" + elemDesc->GetName() +
                 "], child of element[" + _sdf->GetName() + "]",
-                sourcePath,
+                _source,
                 elemXml->GetLineNum()});
             return false;
           }

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -656,8 +656,7 @@ TEST(Parser, ReadSingleLineStringError)
 
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   ASSERT_TRUE(errors[0].FilePath().has_value());
-  EXPECT_EQ(errors[0].FilePath().value(),
-      "<" + std::string(sdf::kSdfStringSource) + ">");
+  EXPECT_EQ(errors[0].FilePath().value(), sdf::kSdfStringSource);
   ASSERT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 1);
 }
@@ -695,8 +694,7 @@ TEST(Parser, ReadMultiLineStringError)
 
   EXPECT_EQ(errors[0].Code(), sdf::ErrorCode::ATTRIBUTE_MISSING);
   ASSERT_TRUE(errors[0].FilePath().has_value());
-  EXPECT_EQ(errors[0].FilePath().value(),
-      "<" + std::string(sdf::kSdfStringSource) + ">");
+  EXPECT_EQ(errors[0].FilePath().value(), sdf::kSdfStringSource);
   ASSERT_TRUE(errors[0].LineNumber().has_value());
   EXPECT_EQ(errors[0].LineNumber().value(), 10);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #536, follow-up to #537
Downstream: https://github.com/ignitionrobotics/ign-gazebo/pull/794

## Summary
Takes prior revision of #537.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed) - N/A
- [x] Updated migration guide (as needed) - N/A
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**