### PR TITLE
Methods for removing attributes from an element

### DIFF
--- a/include/sdf/Element.hh
+++ b/include/sdf/Element.hh
@@ -226,6 +226,13 @@ namespace sdf
     /// \return True if the attribute is set, false otherwise.
     public: bool GetAttributeSet(const std::string &_key) const;
 
+    /// \brief Remove an attribute.
+    /// \param[in] _key the key of the attribute.
+    public: void RemoveAttribute(const std::string &_key);
+
+    /// \brief Removes all attributes.
+    public: void RemoveAllAttributes();
+
     /// \brief Get the param of the elements value
     /// return A Param pointer to the value of this element.
     public: ParamPtr GetValue() const;

--- a/src/Element.cc
+++ b/src/Element.cc
@@ -516,6 +516,27 @@ bool Element::GetAttributeSet(const std::string &_key) const
 }
 
 /////////////////////////////////////////////////
+void Element::RemoveAttribute(const std::string &_key)
+{
+  Param_V::const_iterator iter;
+  for (iter = this->dataPtr->attributes.begin();
+      iter != this->dataPtr->attributes.end(); ++iter)
+  {
+    if ((*iter)->GetKey() == _key)
+    {
+      this->dataPtr->attributes.erase(iter);
+      break;
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+void Element::RemoveAllAttributes()
+{
+  this->dataPtr->attributes.clear();
+}
+
+/////////////////////////////////////////////////
 ParamPtr Element::GetAttribute(const std::string &_key) const
 {
   Param_V::const_iterator iter;

--- a/src/Element_TEST.cc
+++ b/src/Element_TEST.cc
@@ -154,6 +154,40 @@ TEST(Element, GetAttributeSet)
 }
 
 /////////////////////////////////////////////////
+TEST(Element, RemoveAttribute)
+{
+  sdf::Element elem;
+  ASSERT_EQ(elem.GetAttributeCount(), 0UL);
+
+  elem.AddAttribute("test", "string", "foo", false, "foo description");
+  elem.AddAttribute("attr", "float", "0.0", false, "float description");
+  ASSERT_EQ(elem.GetAttributeCount(), 2UL);
+
+  elem.RemoveAttribute("test");
+  EXPECT_EQ(elem.GetAttributeCount(), 1UL);
+  EXPECT_EQ(elem.GetAttribute("test"), nullptr);
+  EXPECT_NE(elem.GetAttribute("attr"), nullptr);
+}
+
+/////////////////////////////////////////////////
+TEST(Element, RemoveAllAttributes)
+{
+  sdf::Element elem;
+  ASSERT_EQ(elem.GetAttributeCount(), 0UL);
+
+  elem.AddAttribute("test", "string", "foo", false, "foo description");
+  elem.AddAttribute("test2", "string", "foo", false, "foo description");
+  elem.AddAttribute("attr", "float", "0.0", false, "float description");
+  ASSERT_EQ(elem.GetAttributeCount(), 3UL);
+
+  elem.RemoveAllAttributes();
+  EXPECT_EQ(elem.GetAttributeCount(), 0UL);
+  EXPECT_EQ(elem.GetAttribute("test"), nullptr);
+  EXPECT_EQ(elem.GetAttribute("test2"), nullptr);
+  EXPECT_EQ(elem.GetAttribute("attr"), nullptr);
+}
+
+/////////////////////////////////////////////////
 TEST(Element, Include)
 {
   sdf::Element elem;


### PR DESCRIPTION
Signed-off-by: Jenn Nguyen <jenn@openrobotics.org>

# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Added methods:

- `sdf::Element::RemoveAttribute(string key)`: Removes a specified attribute from the Element
- `sdf::Element::RemoveAllAttributes()`: Removes all attributes from the Element

This should be forward ported to `sdf10` and `sdf11`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
```bash
./build/sdformat9/src/UNIT_Element_TEST --gtest_filter=Element.RemoveAttribute
./build/sdformat9/src/UNIT_Element_TEST --gtest_filter=Element.RemoveAllAttributes
```

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**