### PR TITLE
Fix bug where included URDFs are not parsed when there are no custom parsers

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1156,7 +1156,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
         // If the file is not an SDFormat file, it is assumed that it will
         // handled by a custom parser, so fall through and add the include
         // element into _sdf.
-        if (sdf::isSdfFile(filename))
+        if (sdf::isSdfFile(filename) || _config.CustomModelParsers().empty())
         {
           // NOTE: sdf::init is an expensive call. For performance reason,
           // a new sdf pointer is created here by cloning a fresh sdf template

--- a/test/integration/includes.cc
+++ b/test/integration/includes.cc
@@ -361,3 +361,30 @@ TEST(IncludesTest, IncludeModelMissingConfig)
 
   EXPECT_EQ(nullptr, root.Model());
 }
+
+//////////////////////////////////////////////////
+/// Check that sdformat natively parses URDF files when there are no custom
+/// parsers
+TEST(IncludesTest, IncludeUrdf)
+{
+  sdf::setFindCallback(findFileCb);
+
+  std::ostringstream stream;
+  stream
+    << "<sdf version='" << SDF_VERSION << "'>"
+    << "<include>"
+    << "  <uri>test_include_urdf</uri>"
+    << "</include>"
+    << "</sdf>";
+
+  sdf::Root root;
+  sdf::Errors errors = root.LoadSdfString(stream.str());
+  ASSERT_TRUE(errors.empty()) << errors;
+
+  auto model = root.Model();
+  ASSERT_NE(nullptr, model);
+  EXPECT_EQ("test_include_urdf", model->Name());
+  EXPECT_EQ(2u, model->LinkCount());
+  EXPECT_EQ(1u, model->JointCount());
+}
+

--- a/test/integration/model/test_include_urdf/model.config
+++ b/test/integration/model/test_include_urdf/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>test_include_urdf</name>
+  <sdf version="1.6">model.urdf</sdf>
+</model>

--- a/test/integration/model/test_include_urdf/model.urdf
+++ b/test/integration/model/test_include_urdf/model.urdf
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<robot name="test_include_urdf">
+
+  <link name="base_link">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+  </link>
+
+  <joint name="joint_1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link_1"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="1" lower="-1" upper="1" velocity="1"/>
+  </joint>
+
+  <link name="link_1">
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+    </inertial>
+  </link>
+
+</robot>
+
+


### PR DESCRIPTION

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
#475 introduced a regression where included URDFs were being silently ignored when there are no custom parsers available. This returns the behavior back to URDFs being parsed natively by SDFormat if there are no custom parsers.

Note, however, that if there are custom parsers, but none of them are able to parse the URDF, the URDF file will be ignored. This might not be desirable, but changing the logic so that URDFs get parsed by SDFormat after trying all available custom parsers will require more significant changes, so I did not attempt to do that in this PR.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
