### PR TITLE
Merge sdf 1.7 changes forward to 1.8

### DIFF
--- a/sdf/1.8/camera.sdf
+++ b/sdf/1.8/camera.sdf
@@ -29,7 +29,7 @@
       <description>Near clipping plane</description>
     </element>
 
-    <element name="far" type="double" default="100" min="10.0" required="1">
+    <element name="far" type="double" default="100" min="0.1" required="1">
       <description>Far clipping plane</description>
     </element>
   </element> <!-- End Clip -->

--- a/sdf/1.8/camera.sdf
+++ b/sdf/1.8/camera.sdf
@@ -18,7 +18,7 @@
       <description>Height in pixels </description>
     </element>
     <element name="format" type="string" default="R8G8B8" required="0">
-      <description>(L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
+      <description>(L8|L16|R_FLOAT16|R_FLOAT32|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)</description>
     </element>
   </element> <!-- End Image -->
 

--- a/sdf/1.8/frame.sdf
+++ b/sdf/1.8/frame.sdf
@@ -10,7 +10,7 @@
     <description>
       Name of the link or frame to which this frame is attached.
       If a frame is specified, recursively following the attached_to attributes
-      of the specified frames must lead to the name of a link or the world frame.
+      of the specified frames must lead to the name of a link, a model, or the world frame.
     </description>
   </attribute>
 

--- a/sdf/1.8/material.sdf
+++ b/sdf/1.8/material.sdf
@@ -45,6 +45,11 @@
     <description>The emissive color of a material specified by set of four numbers representing red/green/blue, each in the range of [0,1].</description>
   </element>
 
+  <element name="double_sided" type="bool" default="false" required="0">
+    <description>If true, the mesh that this material is applied to will be rendered as double sided</description>
+  </element>
+
+
   <element name="pbr" required="0">
     <description>Physically Based Rendering (PBR) material. There are two PBR workflows: metal and specular. While both workflows and their parameters can be specified at the same time, typically only one of them will be used (depending on the underlying renderer capability). It is also recommended to use the same workflow for all materials in the world.</description>
 

--- a/sdf/1.8/material.sdf
+++ b/sdf/1.8/material.sdf
@@ -25,6 +25,10 @@
     </element>
   </element>
 
+  <element name="render_order" type="float" default="0.0" required="0">
+    <description>Set render order for coplanar polygons. The higher value will be rendered on top of the other coplanar polygons</description>
+  </element>
+
   <element name="lighting" type="bool" default="true" required="0">
     <description>If false, dynamic lighting will be disabled</description>
   </element>

--- a/sdf/1.8/material.sdf
+++ b/sdf/1.8/material.sdf
@@ -95,6 +95,14 @@
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
       </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
+      </element>
+
     </element>
 
     <element name="specular" required="0">
@@ -130,6 +138,13 @@
 
       <element name="emissive_map" type="string" default="" required="0">
         <description>Filename of the emissive map.</description>
+      </element>
+
+      <element name="light_map" type="string" default="" required="0">
+        <attribute name="uv_set" type="unsigned int" default="0" required="0">
+          <description>Index of the texture coordinate set to use.</description>
+        </attribute>
+        <description>Filename of the light map. The light map is a prebaked light texture that is applied over the albedo map</description>
       </element>
     </element>
 

--- a/sdf/1.8/sensor.sdf
+++ b/sdf/1.8/sensor.sdf
@@ -12,7 +12,7 @@
                   altimeter,
                   camera,
                   contact,
-                  depth_camera,
+                  depth_camera, depth,
                   force_torque,
                   gps,
                   gpu_lidar,
@@ -25,9 +25,9 @@
                   ray,
                   rfid,
                   rfidtag,
-                  rgbd_camera,
+                  rgbd_camera, rgbd,
                   sonar,
-                  thermal_camera,
+                  thermal_camera, thermal,
                   wireless_receiver, and
                   wireless_transmitter.
       The "ray" and "gpu_ray" types are equivalent to "lidar" and "gpu_lidar", respectively. It is preferred to use "lidar" and "gpu_lidar" since "ray" and "gpu_ray" will be deprecated. The "ray" and "gpu_ray" types are maintained for legacy support.

--- a/sdf/1.8/surface.sdf
+++ b/sdf/1.8/surface.sdf
@@ -141,11 +141,11 @@
     </element>
 
     <element name="collide_bitmask" type="unsigned int" default="65535" required="0">
-      <description>Bitmask for collision filtering. This will override collide_without_contact</description>
+      <description>Bitmask for collision filtering. This will override collide_without_contact. Parsed as 16-bit unsigned integer.</description>
     </element>
 
     <element name="category_bitmask" type="unsigned int" default="65535" required="0">
-      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask.]]></description>
+      <description><![CDATA[Bitmask for category of collision filtering. Collision happens if ((category1 & collision2) | (category2 & collision1)) is not zero. If not specified, the category_bitmask should be interpreted as being the same as collide_bitmask. Parsed as 16-bit unsigned integer.]]></description>
     </element>
 
     <element name="poissons_ratio" type="double" default="0.3" required="0">


### PR DESCRIPTION
# 🦟 Bug fix

I noticed that several changes to the `sdf/1.7` folder on the `sdf10` branch were merged forward to `sdf11`'s `sdf/1.7` folder but not also copied to the `sdf/1.8` folder. This manually ports SDFormat 1.7 changes in already in `sdf11` forward to SDFormat 1.8

## Summary

Changes to the `sdf/1.7` folder were introduced to the `sdf9` and `sdf10` branches in the following pull requests:

* #410 
* #435 
* #429 
* #446 
* #487 
* #514 
* #521 

They haven't yet been propagated forward to the `sdf/1.8` folder, so that's what I've done here. I used `meld sdf/1.7  sdf/1.8` to manually identify the changes that should be propagated forward.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
