### PR TITLE
Adding comment and modifications to element_tracing test regarding path sanitization

### DIFF
--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -31,18 +31,8 @@
 #include "test_config.h"
 
 //////////////////////////////////////////////////
-// This function handles path sanitization only up to a single '/'.
 std::string findFileCb(const std::string &_input)
 {
-  const std::string delimiter = "/";
-  std::size_t delimiter_pos = 0;
-
-  if ((delimiter_pos = _input.find(delimiter)) != std::string::npos)
-  {
-    return sdf::testing::TestFile("integration", "model",
-        _input.substr(0, delimiter_pos),
-        _input.substr(delimiter_pos + 1, _input.size()));
-  }
   return sdf::testing::TestFile("integration", "model", _input);
 }
 
@@ -248,7 +238,7 @@ TEST(ElementTracing, includes)
   EXPECT_EQ(overrideLightXmlPath, overrideLightElem->XmlPath());
 
   // Models
-  const std::string modelFilePath = sdf::testing::TestFile(
+  std::string modelFilePath = sdf::testing::TestFile(
       "integration", "model", "test_model", "model.sdf");
   const std::string modelXmlPath = "/sdf/model[@name=\"test_model\"]";
 
@@ -283,6 +273,15 @@ TEST(ElementTracing, includes)
   EXPECT_EQ(14, overrideModelPluginElem->LineNumber().value());
   EXPECT_EQ(overrideModelPluginXmlPath, overrideModelPluginElem->XmlPath());
 
+#ifdef _WIN32
+  // There is a / in the last argument of TestFile here, as sdf::findFile does
+  // not sanitize the file paths provided, which in this case is
+  // 'test_model/model.sdf', therefore Windows machines will assign the path
+  // '\\path\\to\\integration\\model\\test_model/model.sdf', instead of
+  // '\\path\\to\\integration\\model\\test_model\\model.sdf'.
+  modelFilePath = sdf::testing::TestFile(
+      "integration", "model", "test_model/model.sdf");
+#endif
   const std::string overrideModelWithFileXmlPath =
       "/sdf/model[@name=\"test_model_with_file\"]";
 

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -279,6 +279,7 @@ TEST(ElementTracing, includes)
   // 'test_model/model.sdf', therefore Windows machines will assign the path
   // '\\path\\to\\integration\\model\\test_model/model.sdf', instead of
   // '\\path\\to\\integration\\model\\test_model\\model.sdf'.
+  // Reference issue #572.
   modelFilePath = sdf::testing::TestFile(
       "integration", "model", "test_model/model.sdf");
 #endif


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Related to https://github.com/osrf/sdformat/issues/572

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This modifies an integration test for `element_tracing`, highlighting the issue https://github.com/osrf/sdformat/issues/572, for Windows machines, and adding a comment that explains the change in the test.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
