### PR TITLE
Revert behavior of FilePath() for elements loaded from strings

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1005,6 +1005,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     _sdf->RemoveFromParent();
     _sdf->Copy(refSDF);
 
+    _sdf->SetFilePath(filePath);
     _sdf->SetXmlPath(xmlPath);
     if (lineNumber.has_value())
       _sdf->SetLineNumber(lineNumber.value());

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -685,11 +685,6 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, SDFPtr _sdf,
       _sdf->Root()->SetOriginalVersion(sdfNode->Attribute("version"));
     }
 
-    if (_sdf->Root()->FilePath().empty())
-    {
-      _sdf->Root()->SetFilePath(_source);
-    }
-
     if (!_sdf->Root()->LineNumber().has_value())
     {
       _sdf->Root()->SetLineNumber(sdfNode->GetLineNum());
@@ -773,11 +768,6 @@ bool readDoc(tinyxml2::XMLDocument *_xmlDoc, ElementPtr _sdf,
     if (_sdf->OriginalVersion().empty())
     {
       _sdf->SetOriginalVersion(sdfNode->Attribute("version"));
-    }
-
-    if (_sdf->FilePath().empty())
-    {
-      _sdf->SetFilePath(_source);
     }
 
     if (!_sdf->LineNumber().has_value())
@@ -962,9 +952,9 @@ std::string getModelFilePath(const std::string &_modelDirPath)
 bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     const ParserConfig &_config, const std::string &_source, Errors &_errors)
 {
-  std::string sourcePath = _source;
+  std::string errorSourcePath = _source;
   if (_source == kSdfStringSource || _source == kUrdfStringSource)
-    sourcePath = "<" + _source + ">";
+    errorSourcePath = "<" + _source + ">";
 
   // Check if the element pointer is deprecated.
   if (_sdf->GetRequired() == "-1")
@@ -983,7 +973,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     {
       Error err(
           ErrorCode::ELEMENT_MISSING,
-          "SDF Element<" + _sdf->GetName() + "> is missing", sourcePath);
+          "SDF Element<" + _sdf->GetName() + "> is missing", errorSourcePath);
       err.SetXmlPath(_sdf->XmlPath());
       _errors.push_back(err);
       return false;
@@ -1015,7 +1005,6 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
     _sdf->RemoveFromParent();
     _sdf->Copy(refSDF);
 
-    _sdf->SetFilePath(filePath);
     _sdf->SetXmlPath(xmlPath);
     if (lineNumber.has_value())
       _sdf->SetLineNumber(lineNumber.value());
@@ -1072,7 +1061,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 "'" + std::string(attribute->Value()) +
                 "' is reserved; it cannot be used as a value of "
                 "attribute [" + p->GetKey() + "]",
-                sourcePath, attribute->GetLineNum());
+                errorSourcePath, attribute->GetLineNum());
             err.SetXmlPath(attributeXmlPath);
             _errors.push_back(err);
           }
@@ -1083,7 +1072,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           Error err(
               ErrorCode::ATTRIBUTE_INVALID,
               "Unable to read attribute[" + p->GetKey() + "]",
-              sourcePath, attribute->GetLineNum());
+              errorSourcePath, attribute->GetLineNum());
           err.SetXmlPath(attributeXmlPath);
           _errors.push_back(err);
           return false;
@@ -1100,7 +1089,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
               << "] not defined in SDF.\n";
       Error err(
           ErrorCode::ATTRIBUTE_INCORRECT_TYPE,
-          ss.str(), sourcePath, _xml->GetLineNum());
+          ss.str(), errorSourcePath, _xml->GetLineNum());
       err.SetXmlPath(attributeXmlPath);
       enforceConfigurablePolicyCondition(
           _config.WarningsPolicy(), err, _errors);
@@ -1119,7 +1108,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           ErrorCode::ATTRIBUTE_MISSING,
           "Required attribute[" + p->GetKey() + "] in element[" + _xml->Value()
           + "] is not specified in SDF.",
-          sourcePath, _xml->GetLineNum());
+          errorSourcePath, _xml->GetLineNum());
       err.SetXmlPath(_sdf->XmlPath());
       _errors.push_back(err);
       return false;
@@ -1163,7 +1152,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error err(
                 ErrorCode::URI_LOOKUP,
                 "Unable to find uri[" + uri + "]",
-                sourcePath, uriElement->GetLineNum());
+                errorSourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             continue;
@@ -1182,7 +1171,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                     "Unable to resolve uri[" + uri + "] to model path [" +
                     modelPath + "] since it does not contain a model.config " +
                     "file.",
-                    sourcePath, uriElement->GetLineNum());
+                    errorSourcePath, uriElement->GetLineNum());
                 err.SetXmlPath(uriXmlPath);
                 _errors.push_back(err);
                 continue;
@@ -1202,7 +1191,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
           Error err(
               ErrorCode::ATTRIBUTE_MISSING,
               "<include> element missing 'uri' attribute",
-              sourcePath, elemXml->GetLineNum());
+              errorSourcePath, elemXml->GetLineNum());
           err.SetXmlPath(includeXmlPath);
           _errors.push_back(err);
           continue;
@@ -1232,7 +1221,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
             Error err(
                 ErrorCode::FILE_READ,
                 "Unable to read file[" + filename + "]",
-                sourcePath, uriElement->GetLineNum());
+                errorSourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             return false;
@@ -1273,7 +1262,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "Failed to find top level <model> / <actor> / <light> for "
                 "<include>\n",
-                sourcePath, uriElement->GetLineNum());
+                errorSourcePath, uriElement->GetLineNum());
             err.SetXmlPath(uriXmlPath);
             _errors.push_back(err);
             continue;
@@ -1352,7 +1341,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   ErrorCode::MODEL_PLACEMENT_FRAME_INVALID,
                   "<pose> is required when specifying the placement_frame "
                   "element",
-                  sourcePath, elemXml->GetLineNum());
+                  errorSourcePath, elemXml->GetLineNum());
               err.SetXmlPath(placementFrameXmlPath);
               _errors.push_back(err);
               return false;
@@ -1367,7 +1356,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   "'" + placementFrameVal +
                   "' is reserved; it cannot be used as a value of "
                   "element [placement_frame]",
-                  sourcePath, placementFrameElem->GetLineNum());
+                  errorSourcePath, placementFrameElem->GetLineNum());
               err.SetXmlPath(placementFrameXmlPath);
               _errors.push_back(err);
             }
@@ -1391,7 +1380,6 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
                 sdf::ElementPtr pluginElem;
                 pluginElem = topLevelElem->AddElement("plugin");
-                pluginElem->SetFilePath(sourcePath);
                 pluginElem->SetLineNumber(childElemXml->GetLineNum());
                 pluginElem->SetXmlPath(pluginXmlPath);
 
@@ -1401,7 +1389,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                   Error err(
                       ErrorCode::ELEMENT_INVALID,
                       "Error reading plugin element",
-                      sourcePath, childElemXml->GetLineNum());
+                      errorSourcePath, childElemXml->GetLineNum());
                   err.SetXmlPath(pluginXmlPath);
                   _errors.push_back(err);
                   return false;
@@ -1442,7 +1430,6 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
           ElementPtr element = elemDesc->Clone();
           element->SetParent(_sdf);
-          element->SetFilePath(sourcePath);
           element->SetLineNumber(elemXml->GetLineNum());
           element->SetXmlPath(elemXmlPath);
           if (readXml(elemXml, element, _config, _source, _errors))
@@ -1455,7 +1442,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_INVALID,
                 std::string("Error reading element <") +
                 elemXml->Value() + ">",
-                sourcePath, elemXml->GetLineNum());
+                errorSourcePath, elemXml->GetLineNum());
             err.SetXmlPath(elemXmlPath);
             _errors.push_back(err);
             return false;
@@ -1480,7 +1467,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
 
         Error err(
             ErrorCode::ELEMENT_INCORRECT_TYPE,
-            ss.str(), sourcePath, elemXml->GetLineNum());
+            ss.str(), errorSourcePath, elemXml->GetLineNum());
         err.SetXmlPath(elemXmlPath);
         enforceConfigurablePolicyCondition(
             _config.UnrecognizedElementsPolicy(), err, _errors);
@@ -1511,7 +1498,7 @@ bool readXml(tinyxml2::XMLElement *_xml, ElementPtr _sdf,
                 ErrorCode::ELEMENT_MISSING,
                 "XML Missing required element[" + elemDesc->GetName() +
                 "], child of element[" + _sdf->GetName() + "]",
-                sourcePath, elemXml->GetLineNum());
+                errorSourcePath, elemXml->GetLineNum());
             err.SetXmlPath(elemXmlPath);
             _errors.push_back(err);
             return false;

--- a/src/parser_TEST.cc
+++ b/src/parser_TEST.cc
@@ -719,6 +719,55 @@ TEST(Parser, ReadMultiLineStringError)
 }
 
 /////////////////////////////////////////////////
+/// Check that FilePath() for elements loaded from a file returns the file path
+/// whereas it returns "" for elements loaded from a string.
+TEST(Parser, ElementFilePath)
+{
+  auto findFileCb = [](const std::string &_uri)
+  {
+    return sdf::testing::TestFile("integration", "model", _uri);
+  };
+
+  const std::string testString = R"(
+    <?xml version="1.0" ?>
+    <sdf version="1.8">
+      <world name="default">
+        <include>
+          <uri>test_model</uri>
+          <name>included_model</name>
+        </include>
+        <model name="direct_model">
+          <link name="link"/>
+        </model>
+      </world>
+    </sdf>)";
+
+  sdf::ParserConfig config;
+  config.SetFindCallback(findFileCb);
+  sdf::Errors errors;
+  sdf::SDFPtr sdf = InitSDF();
+  ASSERT_TRUE(sdf::readString(testString, config, sdf, errors));
+  ASSERT_TRUE(errors.empty());
+  ASSERT_NE(nullptr, sdf);
+  auto root = sdf->Root();
+  ASSERT_NE(nullptr, root);
+  EXPECT_EQ("", root->FilePath());
+
+  // included_model is loaded from a file, so FilePath should return a file
+  // path.
+  auto includedModel = root->GetElement("world")->GetElement("model");
+  EXPECT_EQ("included_model", includedModel->Get<std::string>("name"));
+  EXPECT_EQ(findFileCb(sdf::filesystem::append("test_model", "model.sdf")),
+      includedModel->FilePath());
+
+  // direct_model is loaded from a string along with the containing world, so
+  // FilePath should return "".
+  auto directModel = includedModel->GetNextElement("model");
+  EXPECT_EQ("direct_model", directModel->Get<std::string>("name"));
+  EXPECT_EQ("", directModel->FilePath());
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {

--- a/test/integration/element_tracing.cc
+++ b/test/integration/element_tracing.cc
@@ -207,7 +207,7 @@ TEST(ElementTracing, includes)
   sdf::ElementPtr overrideActorPluginElem =
       overrideActorElem->GetElement("plugin");
   ASSERT_NE(nullptr, overrideActorPluginElem);
-  EXPECT_EQ(worldFile, overrideActorPluginElem->FilePath());
+  EXPECT_EQ(actorFilePath, overrideActorPluginElem->FilePath());
   ASSERT_TRUE(overrideActorPluginElem->LineNumber().has_value());
   EXPECT_EQ(40, overrideActorPluginElem->LineNumber().value());
   EXPECT_EQ(overrideActorPluginXmlPath, overrideActorPluginElem->XmlPath());
@@ -268,7 +268,7 @@ TEST(ElementTracing, includes)
   sdf::ElementPtr overrideModelPluginElem =
       overrideModelElem->GetElement("plugin");
   ASSERT_NE(nullptr, overrideModelPluginElem);
-  EXPECT_EQ(worldFile, overrideModelPluginElem->FilePath());
+  EXPECT_EQ(modelFilePath, overrideModelPluginElem->FilePath());
   ASSERT_TRUE(overrideModelPluginElem->LineNumber().has_value());
   EXPECT_EQ(14, overrideModelPluginElem->LineNumber().value());
   EXPECT_EQ(overrideModelPluginXmlPath, overrideModelPluginElem->XmlPath());


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

#548 introduced a behavior change on `sdf::Element::FilePath()` for elements loaded from strings. Before that PR, `FilePath()` returned `""` for such elements, but presently, it returns either `data-string` or `<data-string>`. This behavior change could cause failures in downstream applications once released (I know the test `INTEGRATION_save_world` in ign-gazebo will have test failures). 

https://github.com/osrf/sdformat/commit/4876f92fb0962616957f2c4772467efceb040ba3 adds failing test showing the behavior change.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

