### PR TITLE
Add particle_scatter_ratio to SDF 1.6 spec

### DIFF
--- a/sdf/1.6/particle_emitter.sdf
+++ b/sdf/1.6/particle_emitter.sdf
@@ -104,6 +104,17 @@
     </description>
   </element>
 
+  <element name="particle_scatter_ratio" type="float" default="0.65" required="0">
+    <description>
+    This is used to determine the ratio of particles that will be detected
+    by sensors. Increasing the ratio means there is a higher chance of
+    particles reflecting and interfering with depth sensing, making the
+    emitter appear more dense. Decreasing the ratio decreases the chance
+    of particles reflecting and interfering with depth sensing, making it
+    appear less dense.
+    </description>
+  </element>
+
   <include filename="pose.sdf" required="0"/>
   <include filename="material.sdf" required="0"/>
 </element>


### PR DESCRIPTION
# 🎉 New feature

## Summary

The `<particle_emitter>` SDF element was added to SDF spec 1.6 and 1.7 in pull request #528. However, `particle_scatter_ratio` was later only added to SDF spec 1.7 in pull request #547. This PR adds the SDF element to 1.6.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Code check passed (In source directory, run `sh tools/code_check.sh`)
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
